### PR TITLE
Updating light mode bg color of code

### DIFF
--- a/fastn-core/ftd/design.ftd
+++ b/fastn-core/ftd/design.ftd
@@ -342,7 +342,7 @@ light: rgba(0, 0, 0, 0.8)
 dark: rgba(0, 0, 0, 0.8)
 
 -- ftd.color code-:
-light: #2B303B
+light: #eff1f5
 dark: #2B303B
 
 -- ftd.background-colors background-:


### PR DESCRIPTION
@amitu @Arpita-Jaiswal Please, review. Added background color  of light mode to default `$inherited.colors.background.code`.

This color `#eff1f5` is taken from https://fastn.io/install/
