### PR TITLE
Implemented `extract_arguments` in sql.rs

### DIFF
--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -1,5 +1,50 @@
-fn extract_arguments(_query: &str) -> ftd::interpreter::Result<(String, Vec<String>)> {
-    todo!()
+fn extract_arguments(query: &str) -> ftd::interpreter::Result<(String, Vec<String>)> {
+    let chars: Vec<char> = query.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut found_eq = false;
+    let mut args: Vec<String> = Vec::new();
+    let mut output_query = String::new();
+
+    while i < len {
+        let current_char = chars[i];
+
+        if current_char == '=' {
+            found_eq = true;
+        }
+
+        if found_eq && current_char == '$' && chars[i - 1] != '\\' {
+            let mut arg = String::new();
+            i += 1;
+
+            while i < len && chars[i] != ' ' {
+                arg.push(chars[i]);
+                i += 1;
+            }
+
+            let gap = if i < len { " " } else { "" };
+
+            if !arg.is_empty() {
+                let index = args.iter().position(|x| *x == arg);
+
+                match index {
+                    Some(idx) => {
+                        output_query.push_str(&format!("${}{}", idx + 1, gap));
+                    }
+                    None => {
+                        args.push(arg.clone());
+                        output_query.push_str(&format!("${}{}", args.len(), gap));
+                    }
+                }
+            }
+        } else {
+            output_query.push(current_char);
+        }
+
+        i += 1;
+    }
+
+    Ok((output_query, args))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hey Team,

I've implemented the `extract_arguments` function, which extracts named arguments from a SQL query and replaces them with indexed arguments.

I've tested the function on my machine, and it has passed all the test cases. Of course, there's always room for improvement in the implementation.

Let me know if you have any feedback or suggestions to make it even better.

Thanks!