### PR TITLE
Reset `found_eq` once a param is found and added to `args`

### DIFF
--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -49,6 +49,8 @@ fn extract_arguments(query: &str) -> ftd::interpreter::Result<(String, Vec<Strin
                     output_query += &format!("${}{}", args.len(), gap);
                 }
             }
+
+            found_eq = false;
         } else {
             if escaped {
                 output_query += "\\";


### PR DESCRIPTION
Reset `found_eq` once a param is found and added to `args`.