### PR TITLE
Fixed Semicolon Bug and Added String Support in `extract_arguments` function

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-export FASTN_PG_URL="postgres://postgres:[YOUR-PASSWORD]@db.impmoeegmmnnewsdwdwk.supabase.co:6543/postgres"
+export FASTN_PG_URL="postgres://postgres:12deep45@localhost/harsh"

--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -31,7 +31,7 @@ pub(crate) fn extract_arguments(query: &str) -> ftd::interpreter::Result<(String
             }
         }
 
-        if chars[i] == '"' || chars[i] == '"' && !escaped {
+        if (chars[i] == '"' || chars[i] == '"') && !escaped {
             if quote_open {
                 if Some(chars[i]) == quote {
                     quote_open = false;
@@ -136,6 +136,11 @@ mod test {
         e(
             "SELECT * FROM test where name = \"'$name'\" and full_name = $name",
             "SELECT * FROM test where name = \"'$name'\" and full_name = $1",
+            vec!["name"],
+        );
+        e(
+            r#"SELECT * FROM test where name = \"$name\" and full_name = $name"#,
+            r#"SELECT * FROM test where name = \"$1\" and full_name = $1"#,
             vec!["name"],
         );
     }

--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -1,66 +1,85 @@
+const BACKSLASH: char = '\\';
+
+const SPECIAL_CHARS: [char; 9] = [BACKSLASH, '$', '/', ':', '"', ',', '\'', ';', ' '];
+
+// TODO: Can improve the performance
+// Maybe I should use RegEx?
+
 pub(crate) fn extract_arguments(query: &str) -> ftd::interpreter::Result<(String, Vec<String>)> {
     let chars: Vec<char> = query.chars().collect();
     let len = chars.len();
     let mut i = 0;
-    let mut found_eq = false;
+    let mut quote: Option<char> = None;
+    let mut quote_open = false;
     let mut escaped = false;
     let mut args: Vec<String> = Vec::new();
     let mut output_query = String::new();
 
     while i < len {
-        if chars[i] == '=' {
-            found_eq = true;
-        }
-
-        if chars[i] == '\\' {
+        if chars[i] == BACKSLASH {
             escaped = true;
-
             let mut escape_count = 0;
 
-            while i < len && chars[i] == '\\' {
+            while i < len && chars[i] == BACKSLASH {
                 escape_count += 1;
                 i += 1;
             }
 
             if escape_count % 2 == 0 {
-                output_query += &"\\".repeat(escape_count);
+                output_query += &BACKSLASH.to_string().repeat(escape_count);
                 escaped = false;
             }
         }
 
-        if found_eq && chars[i] == '$' && !escaped {
+        if let Some(quote_char) = quote {
+            if chars[i] == quote_char && !escaped {
+                if quote_open {
+                    quote_open = false;
+                    quote = None;
+                }
+            } else {
+                quote_open = true;
+                quote = Some(chars[i]);
+            }
+        }
+
+        if chars[i] == '$' && !escaped && !quote_open {
             let mut arg = String::new();
             i += 1;
 
-            while i < len && chars[i] != ' ' {
-                arg.push(chars[i]);
-                i += 1;
-            }
-
-            if !arg.is_empty() {
-                let index = args.iter().position(|x| x == &arg);
-
-                let gap = if i < len { " " } else { "" };
-
-                if let Some(idx) = index {
-                    output_query += &format!("${}{}", idx + 1, gap);
+            while i < len {
+                if SPECIAL_CHARS.contains(&chars[i]) {
+                    i -= 1;
+                    break;
                 } else {
-                    args.push(arg.clone());
-                    output_query += &format!("${}{}", args.len(), gap);
+                    arg.push(chars[i]);
+                    i += 1;
                 }
             }
 
-            found_eq = false;
+            if !arg.is_empty() {
+                if let Some(index) = args.iter().position(|x| x == &arg) {
+                    output_query += &format!("${}", index + 1);
+                } else {
+                    args.push(arg.clone());
+                    let index = args.len();
+                    output_query += &format!("${}", index);
+                }
+            }
         } else {
             if escaped {
-                output_query += "\\";
+                output_query += &BACKSLASH.to_string();
                 escaped = false;
             }
-
             output_query.push(chars[i]);
         }
 
         i += 1;
+    }
+
+    if quote_open {
+        // TODO: THROW SOME ERROR, A QUOTE WAS LEFT OPEN
+        println!("Quote Open");
     }
 
     Ok((output_query, args))

--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -31,9 +31,9 @@ pub(crate) fn extract_arguments(query: &str) -> ftd::interpreter::Result<(String
             }
         }
 
-        if let Some(quote_char) = quote {
-            if chars[i] == quote_char && !escaped {
-                if quote_open {
+        if chars[i] == '"' || chars[i] == '"' && !escaped {
+            if quote_open {
+                if Some(chars[i]) == quote {
                     quote_open = false;
                     quote = None;
                 }
@@ -126,6 +126,16 @@ mod test {
         e(
             "SELECT * FROM test where name = $name and full_name = $name",
             "SELECT * FROM test where name = $1 and full_name = $1",
+            vec!["name"],
+        );
+        e(
+            "SELECT * FROM test where name = \"$name\" and full_name = $name",
+            "SELECT * FROM test where name = \"$name\" and full_name = $1",
+            vec!["name"],
+        );
+        e(
+            "SELECT * FROM test where name = \"'$name'\" and full_name = $name",
+            "SELECT * FROM test where name = \"'$name'\" and full_name = $1",
             vec!["name"],
         );
     }


### PR DESCRIPTION
Hey Team

In the update code I have fixed the semicolon bug where `SELECT * FROM users WHERE user = $name;` won't be parsed correctly because there was no whitespace after it. In this update, insted of checking for next whitespace, we are checking for next special characters like `':', ";", '"',` etc.

Next thing I added is support for strings. It supports both single and double quote strings, checks if it is closed or not, and won't count anything inside a string as a param eg. `SELECT * FROM users WHERE user = "$name";` -- this will not be counted as a param, but will be treated as a regular string, it also supports escape sequence. One thing it lacks is throwing an error if the string is left open, although we are keeping track of it and I have implemented the code for it, I was not sure which error we should throw.

Lastly, the code performance can be improved a lot. Maybe we should use RegEx? Please give your suggestions.