### PR TITLE
`request-data` into basic types

### DIFF
--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -674,7 +674,7 @@ impl Config {
                 let mut s = fastn_core::sitemap::Sitemap::parse(
                     sitemap_temp.body.as_str(),
                     &package,
-                    &self,
+                    self,
                     false,
                 )
                 .await?;

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -31,8 +31,6 @@ pub struct Config {
     pub all_packages: std::cell::RefCell<std::collections::BTreeMap<String, fastn_core::Package>>,
     pub downloaded_assets: std::collections::BTreeMap<String, String>,
     pub global_ids: std::collections::HashMap<String, String>,
-    // Related to current request, or per request
-    pub extra_data: serde_json::Map<String, serde_json::Value>,
     pub named_parameters: Vec<(String, ftd::Value)>,
     pub current_document: Option<String>,
     pub request: Option<fastn_core::http::Request>, // TODO: It should only contain reference
@@ -326,27 +324,6 @@ impl Config {
             }
         }
 
-        Ok(())
-    }
-
-    /// `attach_data_string()` sets the value of extra data in fastn_core::Config,
-    /// provided as `data` paramater of type `&str`
-    pub fn attach_data_string(&mut self, data: &str) -> fastn_core::Result<()> {
-        self.attach_data(serde_json::from_str(data)?)
-    }
-
-    /// `attach_data()` sets the value of extra data in fastn_core::Config,
-    /// provided as `data` paramater of type `serde_json::Value`
-    pub fn attach_data(&mut self, data: serde_json::Value) -> fastn_core::Result<()> {
-        let data = match data {
-            serde_json::Value::Object(o) => o,
-            t => {
-                return Err(fastn_core::Error::UsageError {
-                    message: format!("Expected object type, found: `{:?}`", t),
-                })
-            }
-        };
-        self.extra_data = data;
         Ok(())
     }
 
@@ -1295,7 +1272,6 @@ impl Config {
             packages_root: root.clone().join(".packages"),
             root,
             original_directory,
-            extra_data: Default::default(),
             current_document: None,
             all_packages: Default::default(),
             downloaded_assets: Default::default(),

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -697,7 +697,7 @@ impl Config {
                 let mut s = fastn_core::sitemap::Sitemap::parse(
                     sitemap_temp.body.as_str(),
                     &package,
-                    &mut self.clone(), //TODO: totally wrong
+                    &self,
                     false,
                 )
                 .await?;
@@ -1326,7 +1326,7 @@ impl Config {
                     let mut s = fastn_core::sitemap::Sitemap::parse(
                         sitemap_temp.body.as_str(),
                         &package,
-                        &mut config,
+                        &config,
                         resolve_sitemap,
                     )
                     .await?;

--- a/fastn-core/src/library2022/processor/apps.rs
+++ b/fastn-core/src/library2022/processor/apps.rs
@@ -27,5 +27,5 @@ pub fn process(
         .collect_vec();
 
     let installed_apps = fastn_core::ds::LengthList::from_owned(apps);
-    doc.from_json(&installed_apps, &kind, value.line_number())
+    doc.from_json(&installed_apps, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/document.rs
+++ b/fastn-core/src/library2022/processor/document.rs
@@ -29,7 +29,7 @@ pub fn process_readers(
         None => vec![],
     };
 
-    doc.from_json(dbg!(&readers), &kind, value.line_number())
+    doc.from_json(dbg!(&readers), &kind, &value)
 }
 
 pub fn process_writers(
@@ -62,7 +62,7 @@ pub fn process_writers(
         None => vec![],
     };
 
-    doc.from_json(&writers, &kind, value.line_number())
+    doc.from_json(&writers, &kind, &value)
 }
 
 pub fn document_id(

--- a/fastn-core/src/library2022/processor/figma_tokens.rs
+++ b/fastn-core/src/library2022/processor/figma_tokens.rs
@@ -13,7 +13,7 @@ pub fn process_figma_tokens(
     let mut dark_colors: ftd::Map<ftd::Map<VT>> = ftd::Map::new();
 
     extract_light_dark_colors(
-        value,
+        &value,
         doc,
         &mut variable_name,
         &mut light_colors,
@@ -40,7 +40,7 @@ pub fn process_figma_tokens(
     );
 
     let response_json: serde_json::Value = serde_json::Value::String(full_cs);
-    doc.from_json(&response_json, &kind, line_number)
+    doc.from_json(&response_json, &kind, &value)
 }
 
 pub fn process_figma_tokens_old(
@@ -56,7 +56,7 @@ pub fn process_figma_tokens_old(
     let mut dark_colors: ftd::Map<ftd::Map<VT>> = ftd::Map::new();
 
     extract_light_dark_colors(
-        value,
+        &value,
         doc,
         &mut variable_name,
         &mut light_colors,
@@ -246,7 +246,7 @@ pub fn process_figma_tokens_old(
     );
 
     let response_json: serde_json::Value = serde_json::Value::String(full_cs);
-    doc.from_json(&response_json, &kind, line_number)
+    doc.from_json(&response_json, &kind, &value)
 }
 
 pub fn capitalize_word(s: &str) -> String {
@@ -258,7 +258,7 @@ pub fn capitalize_word(s: &str) -> String {
 }
 
 fn extract_light_dark_colors(
-    value: ftd::ast::VariableValue,
+    value: &ftd::ast::VariableValue,
     doc: &mut ftd::interpreter::TDoc,
     variable_name: &mut Option<String>,
     light_colors: &mut ftd::Map<ftd::Map<VT>>,

--- a/fastn-core/src/library2022/processor/figma_typography_tokens.rs
+++ b/fastn-core/src/library2022/processor/figma_typography_tokens.rs
@@ -12,7 +12,7 @@ pub fn process_typography_tokens(
     let mut mobile_types: ftd::Map<TypeData> = ftd::Map::new();
 
     extract_types(
-        value,
+        &value,
         doc,
         &mut variable_name,
         &mut desktop_types,
@@ -39,11 +39,11 @@ pub fn process_typography_tokens(
     );
 
     let response_json: serde_json::Value = serde_json::Value::String(full_typography);
-    doc.from_json(&response_json, &kind, line_number)
+    doc.from_json(&response_json, &kind, &value)
 }
 
 fn extract_types(
-    value: ftd::ast::VariableValue,
+    value: &ftd::ast::VariableValue,
     doc: &mut ftd::interpreter::TDoc,
     variable_name: &mut Option<String>,
     desktop_types: &mut ftd::Map<TypeData>,

--- a/fastn-core/src/library2022/processor/get_data.rs
+++ b/fastn-core/src/library2022/processor/get_data.rs
@@ -30,20 +30,12 @@ pub fn process(
         });
     }
 
-    if let Some(data) = config.extra_data.get(key.as_str()) {
-        return doc.from_json(data, &kind, &value);
-    }
-
     if let Some(ref sitemap) = config.package.sitemap {
         let doc_id = config
             .current_document
-            .clone()
-            .map(|v| fastn_core::utils::id_to_path(v.as_str()))
-            .unwrap_or_else(|| {
-                doc.name
-                    .to_string()
-                    .replace(config.package.name.as_str(), "")
-            })
+            .as_ref()
+            .map(|v| fastn_core::utils::id_to_path(v))
+            .unwrap_or_else(|| doc.name.replace(config.package.name.as_str(), ""))
             .trim()
             .replace(std::path::MAIN_SEPARATOR, "/");
 

--- a/fastn-core/src/library2022/processor/get_data.rs
+++ b/fastn-core/src/library2022/processor/get_data.rs
@@ -31,7 +31,7 @@ pub fn process(
     }
 
     if let Some(data) = config.extra_data.get(key.as_str()) {
-        return doc.from_json(data, &kind, line_number);
+        return doc.from_json(data, &kind, &value);
     }
 
     if let Some(ref sitemap) = config.package.sitemap {
@@ -51,36 +51,36 @@ pub fn process(
             if let Some(data) = extra_data.get(key.as_str()) {
                 return match kind {
                     ftd::interpreter::Kind::Integer => {
-                        let value = data.parse::<i64>().map_err(|e| {
+                        let value2 = data.parse::<i64>().map_err(|e| {
                             ftd::interpreter::Error::ParseError {
                                 message: e.to_string(),
                                 doc_id: doc.name.to_string(),
                                 line_number,
                             }
                         })?;
-                        doc.from_json(&value, &kind, line_number)
+                        doc.from_json(&value2, &kind, &value)
                     }
                     ftd::interpreter::Kind::Decimal { .. } => {
-                        let value = data.parse::<f64>().map_err(|e| {
+                        let value2 = data.parse::<f64>().map_err(|e| {
                             ftd::interpreter::Error::ParseError {
                                 message: e.to_string(),
                                 doc_id: doc.name.to_string(),
                                 line_number,
                             }
                         })?;
-                        doc.from_json(&value, &kind, line_number)
+                        doc.from_json(&value2, &kind, &value)
                     }
                     ftd::interpreter::Kind::Boolean { .. } => {
-                        let value = data.parse::<bool>().map_err(|e| {
+                        let value2 = data.parse::<bool>().map_err(|e| {
                             ftd::interpreter::Error::ParseError {
                                 message: e.to_string(),
                                 doc_id: doc.name.to_string(),
                                 line_number,
                             }
                         })?;
-                        doc.from_json(&value, &kind, line_number)
+                        doc.from_json(&value2, &kind, &value)
                     }
-                    _ => doc.from_json(data, &kind, line_number),
+                    _ => doc.from_json(data, &kind, &value),
                 };
             }
         }
@@ -118,7 +118,7 @@ pub fn process(
         return doc.from_json(
             &serde_json::from_str::<serde_json::Value>(&file)?,
             &kind,
-            line_number,
+            &value,
         );
     }
 
@@ -126,7 +126,7 @@ pub fn process(
         return doc.from_json(
             &serde_json::from_str::<serde_json::Value>(b.value.as_str())?,
             &kind,
-            line_number,
+            &value,
         );
     }
 
@@ -142,16 +142,16 @@ pub fn process(
     };
 
     if let Ok(val) = caption.parse::<bool>() {
-        return doc.from_json(&serde_json::json!(val), &kind, line_number);
+        return doc.from_json(&serde_json::json!(val), &kind, &value);
     }
 
     if let Ok(val) = caption.parse::<i64>() {
-        return doc.from_json(&serde_json::json!(val), &kind, line_number);
+        return doc.from_json(&serde_json::json!(val), &kind, &value);
     }
 
     if let Ok(val) = caption.parse::<f64>() {
-        return doc.from_json(&serde_json::json!(val), &kind, line_number);
+        return doc.from_json(&serde_json::json!(val), &kind, &value);
     }
 
-    doc.from_json(&serde_json::json!(caption), &kind, line_number)
+    doc.from_json(&serde_json::json!(caption), &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/http.rs
+++ b/fastn-core/src/library2022/processor/http.rs
@@ -118,5 +118,5 @@ pub async fn process(
     let response_json: serde_json::Value = serde_json::from_str(&response_string)
         .map_err(|e| ftd::interpreter::Error::Serde { source: e })?;
 
-    doc.from_json(&response_json, &kind, line_number)
+    doc.from_json(&response_json, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/package_tree.rs
+++ b/fastn-core/src/library2022/processor/package_tree.rs
@@ -64,5 +64,5 @@ pub async fn process(
     )
     .await
     .unwrap();
-    doc.from_json(&tree, &kind, value.line_number())
+    doc.from_json(&tree, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -42,7 +42,7 @@ pub async fn process(
         execute_query(query.as_str(), doc, value.line_number(), headers).await?,
         kind,
         doc,
-        value.line_number(),
+        &value,
     )
 }
 

--- a/fastn-core/src/library2022/processor/query.rs
+++ b/fastn-core/src/library2022/processor/query.rs
@@ -37,6 +37,6 @@ pub async fn process(
             }
         })?,
         &kind,
-        value.line_number(),
+        &value,
     )
 }

--- a/fastn-core/src/library2022/processor/request_data.rs
+++ b/fastn-core/src/library2022/processor/request_data.rs
@@ -45,6 +45,5 @@ pub fn process(
         }
     }
 
-    data.extend(config.extra_data.clone());
     doc.from_json(&data, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/request_data.rs
+++ b/fastn-core/src/library2022/processor/request_data.rs
@@ -45,5 +45,5 @@ pub fn process(
         }
     }
 
-    doc.from_json(&data, &kind, value.line_number())
+    doc.from_json(&data, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/request_data.rs
+++ b/fastn-core/src/library2022/processor/request_data.rs
@@ -45,5 +45,26 @@ pub fn process(
         }
     }
 
+    let doc_id = config
+        .current_document
+        .as_ref()
+        .map(|v| fastn_core::utils::id_to_path(v))
+        .unwrap_or_else(|| doc.name.replace(config.package.name.as_str(), ""))
+        .trim()
+        .replace(std::path::MAIN_SEPARATOR, "/");
+
+    if let Some(extra_data) = config
+        .package
+        .sitemap
+        .as_ref()
+        .and_then(|v| v.get_extra_data_by_id(doc_id.as_str()))
+    {
+        data.extend(
+            extra_data
+                .iter()
+                .map(|(k, v)| (k.to_string(), serde_json::Value::String(v.to_string()))),
+        );
+    }
+
     doc.from_json(&data, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/request_data.rs
+++ b/fastn-core/src/library2022/processor/request_data.rs
@@ -22,7 +22,7 @@ pub fn process(
             param_value
                 .to_serde_value()
                 .ok_or(ftd::ftd2021::p1::Error::ParseError {
-                    message: format!("ftd value cannot be parsed to json: name: {}", name),
+                    message: format!("ftd value cannot be parsed to json: name: {name}"),
                     doc_id: doc.name.to_string(),
                     line_number: value.line_number(),
                 })?;
@@ -38,7 +38,7 @@ pub fn process(
         Ok(None) => {}
         Err(e) => {
             return ftd::interpreter::utils::e2(
-                format!("Error while parsing request body: {:?}", e),
+                format!("Error while parsing request body: {e:?}"),
                 doc.name,
                 value.line_number(),
             )

--- a/fastn-core/src/library2022/processor/request_data.rs
+++ b/fastn-core/src/library2022/processor/request_data.rs
@@ -45,5 +45,6 @@ pub fn process(
         }
     }
 
+    data.extend(config.extra_data.clone());
     doc.from_json(&data, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/sitemap.rs
+++ b/fastn-core/src/library2022/processor/sitemap.rs
@@ -18,13 +18,13 @@ pub fn process(
             .replace(std::path::MAIN_SEPARATOR, "/");
 
         if let Some(sitemap) = sitemap.get_sitemap_by_id(doc_id.as_str()) {
-            return doc.from_json(&sitemap, &kind, value.line_number());
+            return doc.from_json(&sitemap, &kind, &value);
         }
     }
     doc.from_json(
         &fastn_core::sitemap::SiteMapCompat::default(),
         &kind,
-        value.line_number(),
+        &value,
     )
 }
 
@@ -48,12 +48,12 @@ pub fn full_sitemap_process(
             .replace(std::path::MAIN_SEPARATOR, "/");
 
         let sitemap_compat = to_sitemap_compat(sitemap, doc_id.as_str());
-        return doc.from_json(&sitemap_compat, &kind, value.line_number());
+        return doc.from_json(&sitemap_compat, &kind, &value);
     }
     doc.from_json(
         &fastn_core::sitemap::SiteMapCompat::default(),
         &kind,
-        value.line_number(),
+        &value,
     )
 }
 

--- a/fastn-core/src/library2022/processor/sitemap.rs
+++ b/fastn-core/src/library2022/processor/sitemap.rs
@@ -253,10 +253,10 @@ pub fn to_sitemap_compat(
             .filter(|s| !s.skip)
             .map(|s| to_section_compat(s, current_document))
             .collect_vec(),
-        subsections: vec![],
+        sub_sections: vec![],
         toc: vec![],
         current_section: None,
-        current_subsection: None,
+        current_sub_section: None,
         current_page: None,
         readers: sitemap.readers.clone(),
         writers: sitemap.writers.clone(),

--- a/fastn-core/src/library2022/processor/sitemap.rs
+++ b/fastn-core/src/library2022/processor/sitemap.rs
@@ -22,7 +22,7 @@ pub fn process(
         }
     }
     doc.from_json(
-        &fastn_core::sitemap::SiteMapCompat::default(),
+        &fastn_core::sitemap::SitemapCompat::default(),
         &kind,
         &value,
     )
@@ -51,7 +51,7 @@ pub fn full_sitemap_process(
         return doc.from_json(&sitemap_compat, &kind, &value);
     }
     doc.from_json(
-        &fastn_core::sitemap::SiteMapCompat::default(),
+        &fastn_core::sitemap::SitemapCompat::default(),
         &kind,
         &value,
     )
@@ -118,7 +118,7 @@ pub struct SiteMapCompat {
 pub fn to_sitemap_compat(
     sitemap: &fastn_core::sitemap::Sitemap,
     current_document: &str,
-) -> fastn_core::sitemap::SiteMapCompat {
+) -> fastn_core::sitemap::SitemapCompat {
     use itertools::Itertools;
     fn to_toc_compat(
         toc_item: &fastn_core::sitemap::toc::TocItem,
@@ -246,7 +246,7 @@ pub fn to_sitemap_compat(
         }
     }
 
-    fastn_core::sitemap::SiteMapCompat {
+    fastn_core::sitemap::SitemapCompat {
         sections: sitemap
             .sections
             .iter()

--- a/fastn-core/src/library2022/processor/sqlite.rs
+++ b/fastn-core/src/library2022/processor/sqlite.rs
@@ -84,10 +84,10 @@ pub(crate) fn result_to_value(
     value: &ftd::ast::VariableValue,
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
     if kind.is_list() {
-        doc.from_json_rows(result.as_slice(), &kind, value)
+        doc.rows_to_value(result.as_slice(), &kind, value)
     } else {
         match result.len() {
-            1 => doc.from_json_row(&result[0], &kind, value),
+            1 => doc.row_to_value(&result[0], &kind, value),
             0 => ftd::interpreter::utils::e2(
                 "Query returned no result, expected one row".to_string(),
                 doc.name,

--- a/fastn-core/src/library2022/processor/sqlite.rs
+++ b/fastn-core/src/library2022/processor/sqlite.rs
@@ -73,7 +73,7 @@ pub async fn process(
         .await?,
         kind,
         doc,
-        value.line_number(),
+        &value,
     )
 }
 
@@ -81,22 +81,22 @@ pub(crate) fn result_to_value(
     result: Vec<Vec<serde_json::Value>>,
     kind: ftd::interpreter::Kind,
     doc: &ftd::interpreter::TDoc<'_>,
-    line_number: usize,
+    value: &ftd::ast::VariableValue,
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
     if kind.is_list() {
-        doc.from_json_rows(result.as_slice(), &kind, line_number)
+        doc.from_json_rows(result.as_slice(), &kind, value)
     } else {
         match result.len() {
-            1 => doc.from_json_row(&result[0], &kind, line_number),
+            1 => doc.from_json_row(&result[0], &kind, value),
             0 => ftd::interpreter::utils::e2(
                 "Query returned no result, expected one row".to_string(),
                 doc.name,
-                line_number,
+                value.line_number(),
             ),
             len => ftd::interpreter::utils::e2(
                 format!("Query returned {} rows, expected one row", len),
                 doc.name,
-                line_number,
+                value.line_number(),
             ),
         }
     }

--- a/fastn-core/src/library2022/processor/toc.rs
+++ b/fastn-core/src/library2022/processor/toc.rs
@@ -23,5 +23,5 @@ pub fn process(
     .iter()
     .map(|item| item.to_toc_item_compat())
     .collect::<Vec<fastn_core::library::toc::TocItemCompat>>();
-    doc.from_json(&toc_items, &kind, line_number)
+    doc.from_json(&toc_items, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -23,5 +23,5 @@ pub fn process(
         is_login: bool,
     }
     let ud = UserDetails { is_login };
-    doc.from_json(&ud, &kind, value.line_number())
+    doc.from_json(&ud, &kind, &value)
 }

--- a/fastn-core/src/library2022/processor/user_group.rs
+++ b/fastn-core/src/library2022/processor/user_group.rs
@@ -11,7 +11,7 @@ pub fn process(
         .values()
         .map(|g| g.to_group_compat())
         .collect_vec();
-    doc.from_json(&g, &kind, value.line_number())
+    doc.from_json(&g, &kind, &value)
 }
 
 /// processor: user-group-by-id
@@ -47,7 +47,7 @@ pub fn process_by_id(
             doc_id: doc.name.to_string(),
             line_number: value.line_number(),
         })?;
-    doc.from_json(&g, &kind, value.line_number())
+    doc.from_json(&g, &kind, &value)
 }
 
 /// processor: get-identities

--- a/fastn-core/src/package/mod.rs
+++ b/fastn-core/src/package/mod.rs
@@ -35,7 +35,7 @@ pub struct Package {
 
     pub groups: std::collections::BTreeMap<String, crate::user_group::UserGroup>,
 
-    /// sitemap stores the structure of the package. The structure includes sections, subsections
+    /// sitemap stores the structure of the package. The structure includes sections, sub_sections
     /// and table of content (`toc`). This automatically converts the documents in package into the
     /// corresponding to structure.
     pub sitemap: Option<fastn_core::sitemap::Sitemap>,

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -30,12 +30,12 @@ pub struct Sitemap {
 #[derive(Debug, Default, serde::Serialize)]
 pub struct SitemapCompat {
     pub sections: Vec<toc::TocItemCompat>,
-    pub subsections: Vec<toc::TocItemCompat>,
+    pub sub_sections: Vec<toc::TocItemCompat>,
     pub toc: Vec<toc::TocItemCompat>,
     #[serde(rename = "current-section")]
     pub current_section: Option<toc::TocItemCompat>,
     #[serde(rename = "current-subsection")]
-    pub current_subsection: Option<toc::TocItemCompat>,
+    pub current_sub_section: Option<toc::TocItemCompat>,
     #[serde(rename = "current-page")]
     pub current_page: Option<toc::TocItemCompat>,
     pub readers: Vec<String>,
@@ -45,7 +45,7 @@ pub struct SitemapCompat {
 #[derive(Debug, Clone)]
 pub enum SitemapElement {
     Section(section::Section),
-    Subsection(section::Subsection),
+    SubSection(section::Subsection),
     TocItem(toc::TocItem),
 }
 
@@ -84,7 +84,7 @@ impl SitemapElement {
     pub(crate) fn insert_key_value(&mut self, key: &str, value: &str) {
         let element_title = match self {
             SitemapElement::Section(s) => &mut s.extra_data,
-            SitemapElement::Subsection(s) => &mut s.extra_data,
+            SitemapElement::SubSection(s) => &mut s.extra_data,
             SitemapElement::TocItem(s) => &mut s.extra_data,
         };
         element_title.insert(key.to_string(), value.trim().to_string());
@@ -93,7 +93,7 @@ impl SitemapElement {
     pub(crate) fn set_title(&mut self, title: Option<String>) {
         let element_title = match self {
             SitemapElement::Section(s) => &mut s.title,
-            SitemapElement::Subsection(s) => &mut s.title,
+            SitemapElement::SubSection(s) => &mut s.title,
             SitemapElement::TocItem(s) => &mut s.title,
         };
         *element_title = title;
@@ -102,7 +102,7 @@ impl SitemapElement {
     pub(crate) fn set_icon(&mut self, path: Option<String>) {
         let element_icon = match self {
             SitemapElement::Section(s) => &mut s.icon,
-            SitemapElement::Subsection(s) => &mut s.icon,
+            SitemapElement::SubSection(s) => &mut s.icon,
             SitemapElement::TocItem(s) => &mut s.icon,
         };
         *element_icon = path;
@@ -111,7 +111,7 @@ impl SitemapElement {
     pub(crate) fn set_bury(&mut self, value: bool) {
         let element_bury = match self {
             SitemapElement::Section(s) => &mut s.bury,
-            SitemapElement::Subsection(s) => &mut s.bury,
+            SitemapElement::SubSection(s) => &mut s.bury,
             SitemapElement::TocItem(s) => &mut s.bury,
         };
         *element_bury = value;
@@ -127,7 +127,7 @@ impl SitemapElement {
             SitemapElement::Section(s) => {
                 s.id = id;
             }
-            SitemapElement::Subsection(s) => {
+            SitemapElement::SubSection(s) => {
                 s.id = Some(id);
             }
             SitemapElement::TocItem(s) => {
@@ -139,7 +139,7 @@ impl SitemapElement {
     pub(crate) fn set_nav_title(&mut self, nav_title: Option<String>) {
         let nav = match self {
             SitemapElement::Section(s) => &mut s.nav_title,
-            SitemapElement::Subsection(s) => &mut s.nav_title,
+            SitemapElement::SubSection(s) => &mut s.nav_title,
             SitemapElement::TocItem(s) => &mut s.nav_title,
         };
         *nav = nav_title;
@@ -148,7 +148,7 @@ impl SitemapElement {
     pub(crate) fn set_skip(&mut self, flag: bool) {
         let skip = match self {
             SitemapElement::Section(s) => &mut s.skip,
-            SitemapElement::Subsection(s) => &mut s.skip,
+            SitemapElement::SubSection(s) => &mut s.skip,
             SitemapElement::TocItem(s) => &mut s.skip,
         };
         *skip = flag;
@@ -157,7 +157,7 @@ impl SitemapElement {
     pub(crate) fn set_confidential(&mut self, flag: bool) {
         let skip = match self {
             SitemapElement::Section(s) => &mut s.confidential,
-            SitemapElement::Subsection(s) => &mut s.confidential,
+            SitemapElement::SubSection(s) => &mut s.confidential,
             SitemapElement::TocItem(s) => &mut s.confidential,
         };
         *skip = flag;
@@ -166,7 +166,7 @@ impl SitemapElement {
     pub(crate) fn set_readers(&mut self, group: &str) {
         let readers = match self {
             SitemapElement::Section(s) => &mut s.readers,
-            SitemapElement::Subsection(s) => &mut s.readers,
+            SitemapElement::SubSection(s) => &mut s.readers,
             SitemapElement::TocItem(s) => &mut s.readers,
         };
         readers.push(group.to_string());
@@ -175,7 +175,7 @@ impl SitemapElement {
     pub(crate) fn set_writers(&mut self, group: &str) {
         let writers = match self {
             SitemapElement::Section(s) => &mut s.writers,
-            SitemapElement::Subsection(s) => &mut s.writers,
+            SitemapElement::SubSection(s) => &mut s.writers,
             SitemapElement::TocItem(s) => &mut s.writers,
         };
         writers.push(group.to_string());
@@ -184,7 +184,7 @@ impl SitemapElement {
     pub(crate) fn set_document(&mut self, doc: &str) {
         let document = match self {
             SitemapElement::Section(s) => &mut s.document,
-            SitemapElement::Subsection(s) => &mut s.document,
+            SitemapElement::SubSection(s) => &mut s.document,
             SitemapElement::TocItem(s) => &mut s.document,
         };
         *document = Some(doc.to_string());
@@ -193,7 +193,7 @@ impl SitemapElement {
     pub(crate) fn get_title(&self) -> Option<String> {
         match self {
             SitemapElement::Section(s) => &s.title,
-            SitemapElement::Subsection(s) => &s.title,
+            SitemapElement::SubSection(s) => &s.title,
             SitemapElement::TocItem(s) => &s.title,
         }
         .clone()
@@ -202,7 +202,7 @@ impl SitemapElement {
     pub(crate) fn get_id(&self) -> Option<String> {
         match self {
             SitemapElement::Section(s) => Some(s.id.clone()),
-            SitemapElement::Subsection(s) => s.id.clone(),
+            SitemapElement::SubSection(s) => s.id.clone(),
             SitemapElement::TocItem(s) => Some(s.id.clone()),
         }
     }
@@ -221,7 +221,7 @@ impl SitemapElement {
             SitemapElement::Section(s) => {
                 s.path_parameters = params;
             }
-            SitemapElement::Subsection(s) => {
+            SitemapElement::SubSection(s) => {
                 s.path_parameters = params;
             }
             SitemapElement::TocItem(t) => {
@@ -329,7 +329,7 @@ impl SitemapParser {
                         if !ParsingState::ParsingSection.eq(&self.state) {
                             return Err(ParseError::InvalidTOCItem {
                                 doc_id: self.doc_name.clone(),
-                                message: "Ambiguous <title>: <URL> evaluation. Subsection is called before subsection".to_string(),
+                                message: "Ambiguous <title>: <URL> evaluation. SubSection is called before subsection".to_string(),
                                 row_content: rest.as_str().to_string(),
                             });
                         }
@@ -362,7 +362,7 @@ impl SitemapParser {
                 id: rest.as_str().trim().to_string(),
                 ..Default::default()
             }),
-            ParsingState::ParsingSubsection => SitemapElement::Subsection(section::Subsection {
+            ParsingState::ParsingSubsection => SitemapElement::SubSection(section::Subsection {
                 id: Some(rest.as_str().trim().to_string()),
                 ..Default::default()
             }),
@@ -1036,10 +1036,10 @@ impl Sitemap {
         );
         return Some(SitemapCompat {
             sections,
-            subsections,
+            sub_sections: subsections,
             toc,
             current_section,
-            current_subsection,
+            current_sub_section: current_subsection,
             current_page,
             readers: self.readers.clone(),
             writers: self.writers.clone(),
@@ -1606,7 +1606,7 @@ fn construct_tree_util(mut elements: Vec<(SitemapElement, usize)>) -> Vec<sectio
             // todo: return an error
             return;
         };
-        while let Some((SitemapElement::Subsection(subsection), _)) = elements.last() {
+        while let Some((SitemapElement::SubSection(subsection), _)) = elements.last() {
             last_section.subsections.push(subsection.to_owned());
             elements.pop();
         }

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -28,7 +28,7 @@ pub struct Sitemap {
 }
 
 #[derive(Debug, Default, serde::Serialize)]
-pub struct SiteMapCompat {
+pub struct SitemapCompat {
     pub sections: Vec<toc::TocItemCompat>,
     pub subsections: Vec<toc::TocItemCompat>,
     pub toc: Vec<toc::TocItemCompat>,
@@ -892,7 +892,7 @@ impl Sitemap {
         }
     }
 
-    pub(crate) fn get_sitemap_by_id(&self, id: &str) -> Option<SiteMapCompat> {
+    pub(crate) fn get_sitemap_by_id(&self, id: &str) -> Option<SitemapCompat> {
         use itertools::Itertools;
 
         let mut sections = vec![];
@@ -1034,7 +1034,7 @@ impl Sitemap {
                     )
                 }),
         );
-        return Some(SiteMapCompat {
+        return Some(SitemapCompat {
             sections,
             subsections,
             toc,

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -550,7 +550,7 @@ impl Sitemap {
     pub async fn parse(
         s: &str,
         package: &fastn_core::Package,
-        config: &mut fastn_core::Config,
+        config: &fastn_core::Config,
         resolve_sitemap: bool,
     ) -> Result<Self, ParseError> {
         let mut parser = SitemapParser {
@@ -595,7 +595,7 @@ impl Sitemap {
     async fn resolve(
         &mut self,
         package: &fastn_core::Package,
-        config: &mut fastn_core::Config,
+        config: &fastn_core::Config,
     ) -> fastn_core::Result<()> {
         let package_root = config.get_root_for_package(package);
         let current_package_root = config.root.to_owned();
@@ -608,7 +608,7 @@ impl Sitemap {
             section: &mut section::Section,
             package_root: &camino::Utf8PathBuf,
             current_package_root: &camino::Utf8PathBuf,
-            config: &mut fastn_core::Config,
+            config: &fastn_core::Config,
         ) -> fastn_core::Result<()> {
             let (file_location, translation_file_location) = if let Ok(file_name) = config
                 .get_file_path_and_resolve(
@@ -677,7 +677,7 @@ impl Sitemap {
             subsection: &mut section::Subsection,
             package_root: &camino::Utf8PathBuf,
             current_package_root: &camino::Utf8PathBuf,
-            config: &mut fastn_core::Config,
+            config: &fastn_core::Config,
         ) -> fastn_core::Result<()> {
             if let Some(ref id) = subsection.get_file_id() {
                 let (file_location, translation_file_location) = if let Ok(file_name) = config
@@ -737,7 +737,7 @@ impl Sitemap {
             toc: &mut toc::TocItem,
             package_root: &camino::Utf8PathBuf,
             current_package_root: &camino::Utf8PathBuf,
-            config: &mut fastn_core::Config,
+            config: &fastn_core::Config,
         ) -> fastn_core::Result<()> {
             let (file_location, translation_file_location) = if let Ok(file_name) = config
                 .get_file_path_and_resolve(

--- a/fastn-core/src/sitemap/section.rs
+++ b/fastn-core/src/sitemap/section.rs
@@ -86,7 +86,6 @@ pub struct Section {
     /// The above example injects the value `true` and `Hello World`
     /// to the variables `show` and `message` respectively in inheritance.ftd
     /// and then renders it.
-    //    pub extra_data: Vec<(String, String)>,
     pub extra_data: std::collections::BTreeMap<String, String>,
     pub is_active: bool,
     pub nav_title: Option<String>,

--- a/ftd/src/ast/import.rs
+++ b/ftd/src/ast/import.rs
@@ -53,7 +53,7 @@ impl Import {
         if !section.sub_sections.is_empty() {
             return ftd::ast::parse_error(
                 format!(
-                    "Subsection not expected for import statement `{:?}`",
+                    "SubSection not expected for import statement `{:?}`",
                     section
                 ),
                 doc_id,

--- a/ftd/src/ast/main.rs
+++ b/ftd/src/ast/main.rs
@@ -252,8 +252,8 @@ impl AST {
 /// Only '/' comments are ignored here.
 /// ';' comments are ignored inside the [`parser`] itself.
 ///
-/// uses [`Section::remove_comments()`] and [`Subsection::remove_comments()`] to remove comments
-/// in sections and subsections accordingly.
+/// uses [`Section::remove_comments()`] and [`SubSection::remove_comments()`] to remove comments
+/// in sections and sub_sections accordingly.
 ///
 /// [`parser`]: ftd::p1::parser::parse
 /// [`Section::remove_comments()`]: ftd::p1::section::Section::remove_comments

--- a/ftd/src/ftd2021/di/import.rs
+++ b/ftd/src/ftd2021/di/import.rs
@@ -26,7 +26,7 @@ impl Import {
         if !section.sub_sections.is_empty() {
             return ftd::ftd2021::di::parse_error(
                 format!(
-                    "Subsection not expected for import statement `{:?}`",
+                    "SubSection not expected for import statement `{:?}`",
                     section
                 ),
                 doc_id,

--- a/ftd/src/ftd2021/di/test.rs
+++ b/ftd/src/ftd2021/di/test.rs
@@ -140,7 +140,7 @@ fn di_import() {
             -- end: import
             "
         ),
-        "ASTParseError: foo:1 -> Subsection not expected for import statement \
+        "ASTParseError: foo:1 -> SubSection not expected for import statement \
         `Section { name: \"import\", kind: None, caption: Some(KV(KV { \
         line_number: 1, key: \"$caption$\", kind: None, value: Some(\"foo\"), \
         condition: None, access_modifier: Public, source: Caption })), \

--- a/ftd/src/ftd2021/interpreter/main.rs
+++ b/ftd/src/ftd2021/interpreter/main.rs
@@ -198,8 +198,8 @@ impl ParsedDocument {
     /// Only '/' comments are ignored here.
     /// ';' comments are ignored inside the [`parser`] itself.
     ///
-    /// uses [`Section::remove_comments()`] and [`Subsection::remove_comments()`] to remove comments
-    /// in sections and subsections accordingly.
+    /// uses [`Section::remove_comments()`] and [`SubSection::remove_comments()`] to remove comments
+    /// in sections and sub_sections accordingly.
     ///
     /// [`parser`]: ftd::p1::parser::parse
     /// [`Section::remove_comments()`]: ftd::p1::section::Section::remove_comments

--- a/ftd/src/ftd2021/p1/parser.rs
+++ b/ftd/src/ftd2021/p1/parser.rs
@@ -344,13 +344,13 @@ pub fn parse_file_for_global_ids(data: &str) -> Vec<(String, usize)> {
 
         // section could be component definition
         // in that case ignore relevant id's defined under its definition
-        // including the ids defined on its subsections
+        // including the ids defined on its sub_sections
         if ftd::identifier::is_section(line) {
             ignore_id = ignore_next_id(line);
             register_id_for_last_section = !ignore_id;
         }
 
-        // In cases, when there are uncommented subsections
+        // In cases, when there are uncommented sub_sections
         // under commented section then ignore their id's
         if ftd::identifier::is_subsection(line) && register_id_for_last_section {
             ignore_id = ignore_next_id(line);

--- a/ftd/src/ftd2021/p2/interpreter.rs
+++ b/ftd/src/ftd2021/p2/interpreter.rs
@@ -1015,7 +1015,7 @@ impl InterpreterState {
         var_types: &[String],
     ) -> ftd::ftd2021::p1::Result<Vec<ftd::ReplaceLinkBlock<std::collections::HashSet<String>>>>
     {
-        // will contain all replace blocks for section and its subsections
+        // will contain all replace blocks for section and its sub_sections
         // where link replacement or escape links need to be resolved
         let mut replace_blocks: Vec<ftd::ReplaceLinkBlock<std::collections::HashSet<String>>> =
             vec![];
@@ -1353,7 +1353,7 @@ impl InterpreterState {
                                 .get_mut(target_subsection_index)
                                 .ok_or_else(|| ftd::ftd2021::p1::Error::UnknownData {
                                     message: format!(
-                                        "No subsection present at index {} in subsections",
+                                        "No subsection present at index {} in sub_sections",
                                         target_subsection_index
                                     ),
                                     doc_id: self.id.clone(),
@@ -1397,7 +1397,7 @@ impl InterpreterState {
 
         return self.continue_();
 
-        /// replaces all links present in any textsource from a single section and its subsections,
+        /// replaces all links present in any textsource from a single section and its sub_sections,
         /// also resolves any escaped links if present.
         /// returns true if any replacement took place else false
         fn replace_all_links(
@@ -1773,8 +1773,8 @@ impl ParsedDocument {
     /// Only '/' comments are ignored here.
     /// ';' comments are ignored inside the [`parser`] itself.
     ///
-    /// uses [`Section::remove_comments()`] and [`Subsection::remove_comments()`] to remove comments
-    /// in sections and subsections accordingly.
+    /// uses [`Section::remove_comments()`] and [`SubSection::remove_comments()`] to remove comments
+    /// in sections and sub_sections accordingly.
     ///
     /// [`parser`]: ftd::p1::parser::parse
     /// [`Section::remove_comments()`]: ftd::p1::section::Section::remove_comments

--- a/ftd/src/interpreter/things/component.rs
+++ b/ftd/src/interpreter/things/component.rs
@@ -671,7 +671,7 @@ impl Property {
 
         let _argument = Property::get_argument_for_children(&component_arguments).ok_or(
             ftd::interpreter::Error::ParseError {
-                message: "Subsection is unexpected".to_string(),
+                message: "SubSection is unexpected".to_string(),
                 doc_id: doc.name.to_string(),
                 line_number,
             },


### PR DESCRIPTION
Right now this code does not work:

```
-- import: fastn/processors as pr

-- integer id:
$processor$: pr.request-data

-- ftd.integer: $id
```

`request-data` can only extract data into a record with the right field.

- [x] merge logic of `TDoc::from_json_row()` into `TDoc::from_json()`
- [x] We should allow extracting data into basic types. 
- [x] We should also allow default values of field to be honoured if a data is not passed. 
- [x] We should also honour key-value data in sitemap.
- [ ] honour key-value in dynamic-urls as well