### PR TITLE
Inherited: Option<String> -> &str and Build check edition in fastn 0.4

### DIFF
--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -196,7 +196,10 @@ pub async fn build(
     Ok(())
 }
 
-pub async fn default_build_files(base_path: camino::Utf8PathBuf) -> fastn_core::Result<()> {
+pub async fn default_build_files(
+    base_path: camino::Utf8PathBuf,
+    ftd_edition: &fastn_core::FTDEdition,
+) -> fastn_core::Result<()> {
     let default_css_content = ftd::css();
     let hashed_css_name = fastn_core::utils::hashed_default_css_name();
     let save_default_css = base_path.join(hashed_css_name.as_str());
@@ -211,12 +214,14 @@ pub async fn default_build_files(base_path: camino::Utf8PathBuf) -> fastn_core::
         .await
         .ok();
 
-    let default_ftd_js_content = fastn_js::all_js_without_test();
-    let hashed_ftd_js_name = fastn_core::utils::hashed_default_ftd_js();
-    let save_default_ftd_js = base_path.join(hashed_ftd_js_name.as_str());
-    fastn_core::utils::update(save_default_ftd_js, default_ftd_js_content.as_bytes())
-        .await
-        .ok();
+    if ftd_edition.is_2023() {
+        let default_ftd_js_content = fastn_js::all_js_without_test();
+        let hashed_ftd_js_name = fastn_core::utils::hashed_default_ftd_js();
+        let save_default_ftd_js = base_path.join(hashed_ftd_js_name.as_str());
+        fastn_core::utils::update(save_default_ftd_js, default_ftd_js_content.as_bytes())
+            .await
+            .ok();
+    }
 
     Ok(())
 }

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -21,6 +21,9 @@ impl FTDEdition {
             }
         }
     }
+    pub(crate) fn is_2023(&self) -> bool {
+        matches!(self, fastn_core::FTDEdition::FTD2023)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -36,7 +36,7 @@ impl Element {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -180,7 +180,7 @@ impl Container {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> Vec<fastn_js::ComponentStatement> {
         let mut component_statements = vec![];
@@ -250,7 +250,7 @@ impl InheritedProperties {
                     doc,
                     component_definition_name,
                     loop_alias,
-                    &None,
+                    fastn_js::INHERITED_VARIABLE,
                     device,
                 ),
             ));
@@ -263,7 +263,7 @@ impl InheritedProperties {
                     doc,
                     component_definition_name,
                     loop_alias,
-                    &None,
+                    fastn_js::INHERITED_VARIABLE,
                     device,
                 ),
             ));
@@ -317,7 +317,7 @@ impl Text {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -335,9 +335,7 @@ impl Text {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             },
         ));
         component_statements.extend(self.common.to_set_properties(
@@ -400,7 +398,7 @@ impl Integer {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -419,9 +417,7 @@ impl Integer {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             },
         ));
         component_statements.extend(self.common.to_set_properties(
@@ -483,7 +479,7 @@ impl Decimal {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -502,9 +498,7 @@ impl Decimal {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             },
         ));
         component_statements.extend(self.common.to_set_properties(
@@ -566,7 +560,7 @@ impl Boolean {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -585,9 +579,7 @@ impl Boolean {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             },
         ));
         component_statements.extend(self.common.to_set_properties(
@@ -649,7 +641,7 @@ impl Column {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -685,7 +677,7 @@ impl Column {
         let inherited_variable_name = inherited_variables
             .as_ref()
             .map(|v| v.name.clone())
-            .or(inherited_variable_name.clone());
+            .unwrap_or_else(|| inherited_variable_name.to_string());
 
         if let Some(inherited_variables) = inherited_variables {
             component_statements.push(fastn_js::ComponentStatement::StaticVariable(
@@ -704,9 +696,7 @@ impl Column {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             })
         }));
         if should_return {
@@ -751,7 +741,7 @@ impl Row {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -788,7 +778,7 @@ impl Row {
         let inherited_variable_name = inherited_variables
             .as_ref()
             .map(|v| v.name.clone())
-            .or(inherited_variable_name.clone());
+            .unwrap_or_else(|| inherited_variable_name.to_string());
 
         if let Some(inherited_variables) = inherited_variables {
             component_statements.push(fastn_js::ComponentStatement::StaticVariable(
@@ -807,9 +797,7 @@ impl Row {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             })
         }));
         if should_return {
@@ -853,7 +841,7 @@ impl Device {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -878,7 +866,7 @@ impl Device {
         let inherited_variable_name = inherited_variables
             .as_ref()
             .map(|v| v.name.clone())
-            .or(inherited_variable_name.clone());
+            .unwrap_or_else(|| inherited_variable_name.to_string());
 
         if let Some(inherited_variables) = inherited_variables {
             component_statements.push(fastn_js::ComponentStatement::StaticVariable(
@@ -897,9 +885,7 @@ impl Device {
                     device,
                 ),
                 element_name: kernel.name.to_string(),
-                inherited: inherited_variable_name
-                    .clone()
-                    .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+                inherited: inherited_variable_name.to_string(),
             })
         }));
         component_statements.push(fastn_js::ComponentStatement::Return {
@@ -943,7 +929,7 @@ impl TextCommon {
         element_name: &str,
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         loop_alias: &Option<String>,
         device: &Option<fastn_js::DeviceType>,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -1237,7 +1223,7 @@ impl Common {
         element_name: &str,
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         loop_alias: &Option<String>,
         device: &Option<fastn_js::DeviceType>,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -2071,7 +2057,7 @@ impl ftd::interpreter::Event {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::EventHandler {
         fastn_js::EventHandler {
@@ -2094,7 +2080,7 @@ impl ftd::interpreter::FunctionCall {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::Function {
         let mut parameters = vec![];

--- a/ftd/src/js/mod.rs
+++ b/ftd/src/js/mod.rs
@@ -142,7 +142,7 @@ impl ftd::interpreter::ComponentDefinition {
             0,
             doc,
             &Some(self.name.to_string()),
-            &Some(fastn_js::INHERITED_VARIABLE.to_string()),
+            fastn_js::INHERITED_VARIABLE,
             &None,
             true,
         ));
@@ -159,7 +159,7 @@ impl ftd::interpreter::ComponentDefinition {
                                 doc,
                                 &Some(self.name.to_string()),
                                 &None,
-                                &Some("inherited".to_string()),
+                                fastn_js::INHERITED_VARIABLE,
                                 &None,
                             ),
                         )
@@ -176,9 +176,15 @@ pub fn from_tree(
 ) -> fastn_js::Ast {
     let mut statements = vec![];
     for (index, component) in tree.iter().enumerate() {
-        statements.extend(
-            component.to_component_statements("parent", index, doc, &None, &None, &None, false),
-        )
+        statements.extend(component.to_component_statements(
+            "parent",
+            index,
+            doc,
+            &None,
+            fastn_js::INHERITED_VARIABLE,
+            &None,
+            false,
+        ))
     }
     fastn_js::component0(fastn_js::MAIN_FUNCTION, statements)
 }
@@ -191,7 +197,7 @@ impl ftd::interpreter::Component {
         index: usize,
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -274,7 +280,7 @@ impl ftd::interpreter::Component {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
         should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
@@ -322,9 +328,7 @@ impl ftd::interpreter::Component {
                     name: self.name.to_string(),
                     arguments,
                     parent: parent.to_string(),
-                    inherited: inherited_variable_name
-                        .clone()
-                        .unwrap_or_else(|| "inherited".to_string()),
+                    inherited: inherited_variable_name.to_string(),
                     should_return,
                 },
             )]

--- a/ftd/src/js/utils.rs
+++ b/ftd/src/js/utils.rs
@@ -6,14 +6,14 @@ pub fn trim_all_lines(s: &str) -> String {
 }
 
 pub(crate) fn update_reference_with_none(reference: &str) -> String {
-    update_reference(reference, &None, &None, &None)
+    update_reference(reference, &None, &None, fastn_js::INHERITED_VARIABLE)
 }
 
 pub(crate) fn update_reference(
     reference: &str,
     component_definition_name: &Option<String>,
     loop_alias: &Option<String>,
-    inherited_variable_name: &Option<String>,
+    inherited_variable_name: &str,
 ) -> String {
     let name = reference.to_string();
 
@@ -31,14 +31,8 @@ pub(crate) fn update_reference(
         }
     }
 
-    if let Some(inherited_variable_name) = inherited_variable_name {
-        if let Some(remaining) = name.strip_prefix("inherited.") {
-            return format!("{inherited_variable_name}.{remaining}");
-        }
-    }
-
-    if name.starts_with("inherited.") {
-        return name;
+    if let Some(remaining) = name.strip_prefix("inherited.") {
+        return format!("{inherited_variable_name}.{remaining}");
     }
 
     if name.contains(ftd::interpreter::FTD_LOOP_COUNTER) {

--- a/ftd/src/js/value.rs
+++ b/ftd/src/js/value.rs
@@ -10,7 +10,7 @@ impl Value {
         &self,
         doc: &ftd::interpreter::TDoc,
     ) -> fastn_js::SetPropertyValue {
-        self.to_set_property_value(doc, &None, &None, &None, &None)
+        self.to_set_property_value(doc, &None, &None, fastn_js::INHERITED_VARIABLE, &None)
     }
 
     pub(crate) fn to_set_property_value(
@@ -18,7 +18,7 @@ impl Value {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::SetPropertyValue {
         match self {
@@ -58,7 +58,7 @@ impl Value {
         element_name: &str,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::SetProperty {
         fastn_js::SetProperty {
@@ -71,9 +71,7 @@ impl Value {
                 device,
             ),
             element_name: element_name.to_string(),
-            inherited: inherited_variable_name
-                .clone()
-                .unwrap_or_else(|| fastn_js::INHERITED_VARIABLE.to_string()),
+            inherited: inherited_variable_name.to_string(),
         }
     }
 }
@@ -83,7 +81,7 @@ fn formulas_to_fastn_js_value(
     properties: &[ftd::interpreter::Property],
     component_definition_name: &Option<String>,
     loop_alias: &Option<String>,
-    inherited_variable_name: &Option<String>,
+    inherited_variable_name: &str,
     device: &Option<fastn_js::DeviceType>,
 ) -> fastn_js::Formula {
     let mut deps = vec![];
@@ -131,7 +129,7 @@ impl ftd::interpreter::Expression {
         &self,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
     ) -> Vec<String> {
         let mut deps = vec![];
         for property_value in self.references.values() {
@@ -148,7 +146,7 @@ impl ftd::interpreter::Expression {
         &self,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
     ) -> fastn_grammar::evalexpr::ExprNode {
         return update_node_with_variable_reference_js_(
             &self.expression,
@@ -163,7 +161,7 @@ impl ftd::interpreter::Expression {
             references: &ftd::Map<ftd::interpreter::PropertyValue>,
             component_definition_name: &Option<String>,
             loop_alias: &Option<String>,
-            inherited_variable_name: &Option<String>,
+            inherited_variable_name: &str,
         ) -> fastn_grammar::evalexpr::ExprNode {
             let mut operator = expr.operator().clone();
             if let fastn_grammar::evalexpr::Operator::VariableIdentifierRead { ref identifier } =
@@ -207,7 +205,7 @@ impl ftd::interpreter::PropertyValue {
         &self,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
     ) -> Vec<String> {
         let mut deps = vec![];
         if let Some(reference) = self.get_reference_or_clone() {
@@ -306,7 +304,7 @@ impl ftd::interpreter::PropertyValue {
         &self,
         doc: &ftd::interpreter::TDoc,
     ) -> fastn_js::SetPropertyValue {
-        self.to_fastn_js_value(doc, &None, &None, &None, &None)
+        self.to_fastn_js_value(doc, &None, &None, fastn_js::INHERITED_VARIABLE, &None)
     }
 
     pub(crate) fn to_fastn_js_value(
@@ -314,7 +312,7 @@ impl ftd::interpreter::PropertyValue {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::SetPropertyValue {
         match self {
@@ -356,7 +354,7 @@ impl ftd::interpreter::Value {
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,
         loop_alias: &Option<String>,
-        inherited_variable_name: &Option<String>,
+        inherited_variable_name: &str,
         device: &Option<fastn_js::DeviceType>,
     ) -> fastn_js::SetPropertyValue {
         use itertools::Itertools;
@@ -441,7 +439,7 @@ impl ftd::interpreter::Value {
                         doc,
                         component_definition_name,
                         loop_alias,
-                        &Some(fastn_js::INHERITED_VARIABLE.to_string()),
+                        fastn_js::INHERITED_VARIABLE,
                         device,
                         false,
                     ),


### PR DESCRIPTION
- Inherited variable type changes from &Option<String> to &str. Since inherited is always resolved.
- `fastn build` check edition if it's 2023, then only add `default_fastn_js.js` file