### PR TITLE
disc based ast caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1555,7 @@ dependencies = [
  "colored",
  "deadpool-postgres",
  "diffy",
+ "dirs",
  "edit",
  "env_logger",
  "fastn-js",
@@ -2853,6 +2875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3450,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ strip = true
 # using the latest dependency, and what is the plan to moving to the latest version.
 actix-web = "4"
 antidote = "1"
+dirs = "5"
 native-tls = "0.2"
 deadpool-postgres = { git = "https://github.com/amitu/deadpool", rev = "dbf5a46" }
 postgres-native-tls = "0.5"

--- a/fastn-core/Cargo.toml
+++ b/fastn-core/Cargo.toml
@@ -33,6 +33,7 @@ github-auth = ["dep:oauth2"]
 actix-web.workspace = true
 antidote.workspace = true
 async-lock.workspace = true
+dirs.workspace = true
 async-recursion.workspace = true
 camino.workspace = true
 clap.workspace = true

--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -5,8 +5,6 @@ pub async fn build(
     ignore_failed: bool,
     test: bool,
 ) -> fastn_core::Result<()> {
-    fastn_core::utils::enable_parse_caching(true);
-
     tokio::fs::create_dir_all(config.build_dir()).await?;
     let documents = get_documents_for_current_package(config).await?;
 

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -3,8 +3,75 @@ fn cached_parse(
     source: &str,
     line_number: usize,
 ) -> ftd::interpreter::Result<ftd::interpreter::ParsedDocument> {
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct C {
+        hash: String,
+        doc: ftd::interpreter::ParsedDocument,
+    }
+
+    let hash = fastn_core::utils::generate_hash(source);
+
+    if let Some(c) = get_cached::<C>(id) {
+        if c.hash == hash {
+            tracing::debug!("cache hit");
+            return Ok(c.doc);
+        }
+        tracing::debug!("cached hash mismatch");
+    } else {
+        tracing::debug!("cached miss");
+    }
+
     let doc = ftd::interpreter::ParsedDocument::parse_with_line_number(id, source, line_number)?;
-    Ok(doc)
+    cache_it(id, C { doc, hash }).map(|v| v.doc)
+}
+
+fn id_to_cache_key(id: &str) -> String {
+    id.replace("/", "_")
+}
+
+fn get_cached<T>(id: &str) -> Option<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let cache_file = dirs::cache_dir()?
+        .join("fastn.com/ast-cache/")
+        .join(id_to_cache_key(id));
+    serde_json::from_str(
+        &std::fs::read_to_string(cache_file)
+            .map_err(|e| {
+                tracing::debug!("file read error: {}", e.to_string());
+                e
+            })
+            .ok()?,
+    )
+    .map_err(|e| {
+        tracing::debug!("not valid json: {}", e.to_string());
+        e
+    })
+    .ok()
+}
+
+fn cache_it<T>(id: &str, d: T) -> ftd::interpreter::Result<T>
+where
+    T: serde::ser::Serialize,
+{
+    let cache_file = dirs::cache_dir()
+        .ok_or_else(|| ftd::interpreter::Error::OtherError("cache dir not found".to_string()))?
+        .join("fastn.com/ast-cache/")
+        .join(id_to_cache_key(id));
+    std::fs::create_dir_all(cache_file.parent().unwrap()).map_err(|e| {
+        ftd::interpreter::Error::OtherError(format!(
+            "failed to create cache dir: {}",
+            e.to_string()
+        ))
+    })?;
+    std::fs::write(cache_file, serde_json::to_string(&d)?).map_err(|e| {
+        ftd::interpreter::Error::OtherError(format!(
+            "failed to write cache file: {}",
+            e.to_string()
+        ))
+    })?;
+    Ok(d)
 }
 
 #[tracing::instrument(skip_all)]

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -1,23 +1,9 @@
-type ParsedDocC =
-    antidote::RwLock<std::collections::HashMap<String, ftd::interpreter::ParsedDocument>>;
-static PARSED_DOC_CACHE: once_cell::sync::Lazy<ParsedDocC> =
-    once_cell::sync::Lazy::new(|| antidote::RwLock::new(std::collections::HashMap::new()));
-
 fn cached_parse(
     id: &str,
     source: &str,
     line_number: usize,
 ) -> ftd::interpreter::Result<ftd::interpreter::ParsedDocument> {
-    if let Some(doc) = PARSED_DOC_CACHE.read().get(id).cloned() {
-        return Ok(doc);
-    }
-
     let doc = ftd::interpreter::ParsedDocument::parse_with_line_number(id, source, line_number)?;
-
-    if fastn_core::utils::parse_caching_enabled() {
-        PARSED_DOC_CACHE.write().insert(id.to_string(), doc.clone());
-    }
-
     Ok(doc)
 }
 

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -1,7 +1,7 @@
 type ParsedDocC =
-    std::sync::RwLock<std::collections::HashMap<String, ftd::interpreter::ParsedDocument>>;
+    antidote::RwLock<std::collections::HashMap<String, ftd::interpreter::ParsedDocument>>;
 static PARSED_DOC_CACHE: once_cell::sync::Lazy<ParsedDocC> =
-    once_cell::sync::Lazy::new(|| std::sync::RwLock::new(std::collections::HashMap::new()));
+    once_cell::sync::Lazy::new(|| antidote::RwLock::new(std::collections::HashMap::new()));
 
 fn cached_parse(
     id: &str,
@@ -15,17 +15,12 @@ fn cached_parse(
     let doc = ftd::interpreter::ParsedDocument::parse_with_line_number(id, source, line_number)?;
 
     if fastn_core::utils::parse_caching_enabled() {
-        if let Ok(mut l) = PARSED_DOC_CACHE.write() {
-            l.insert(id.to_string(), doc.clone());
-        }
+        PARSED_DOC_CACHE.write().insert(id.to_string(), doc.clone());
     }
     return Ok(doc);
 
     fn cached_doc(id: &str) -> Option<ftd::interpreter::ParsedDocument> {
-        if let Ok(l) = PARSED_DOC_CACHE.read() {
-            return l.get(id).cloned();
-        }
-        None
+        PARSED_DOC_CACHE.read().get(id).cloned()
     }
 }
 

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -26,7 +26,7 @@ fn cached_parse(
 }
 
 fn id_to_cache_key(id: &str) -> String {
-    id.replace("/", "_")
+    id.replace('/', "_")
 }
 
 fn get_cached<T>(id: &str) -> Option<T>
@@ -60,16 +60,10 @@ where
         .join("fastn.com/ast-cache/")
         .join(id_to_cache_key(id));
     std::fs::create_dir_all(cache_file.parent().unwrap()).map_err(|e| {
-        ftd::interpreter::Error::OtherError(format!(
-            "failed to create cache dir: {}",
-            e.to_string()
-        ))
+        ftd::interpreter::Error::OtherError(format!("failed to create cache dir: {}", e))
     })?;
     std::fs::write(cache_file, serde_json::to_string(&d)?).map_err(|e| {
-        ftd::interpreter::Error::OtherError(format!(
-            "failed to write cache file: {}",
-            e.to_string()
-        ))
+        ftd::interpreter::Error::OtherError(format!("failed to write cache file: {}", e))
     })?;
     Ok(d)
 }

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -8,7 +8,7 @@ fn cached_parse(
     source: &str,
     line_number: usize,
 ) -> ftd::interpreter::Result<ftd::interpreter::ParsedDocument> {
-    if let Some(doc) = cached_doc(id) {
+    if let Some(doc) = PARSED_DOC_CACHE.read().get(id).cloned() {
         return Ok(doc);
     }
 
@@ -17,11 +17,8 @@ fn cached_parse(
     if fastn_core::utils::parse_caching_enabled() {
         PARSED_DOC_CACHE.write().insert(id.to_string(), doc.clone());
     }
-    return Ok(doc);
 
-    fn cached_doc(id: &str) -> Option<ftd::interpreter::ParsedDocument> {
-        PARSED_DOC_CACHE.read().get(id).cloned()
-    }
+    Ok(doc)
 }
 
 #[tracing::instrument(skip_all)]

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -14,17 +14,6 @@ impl ValueOf for clap::ArgMatches {
     }
 }
 
-static CACHE_ENABLED: once_cell::sync::Lazy<antidote::RwLock<bool>> =
-    once_cell::sync::Lazy::new(|| antidote::RwLock::new(false));
-
-pub(crate) fn parse_caching_enabled() -> bool {
-    *CACHE_ENABLED.read()
-}
-
-pub fn enable_parse_caching(enabled: bool) {
-    *CACHE_ENABLED.write() = enabled
-}
-
 // https://stackoverflow.com/questions/71985357/whats-the-best-way-to-write-a-custom-format-macro
 #[macro_export]
 macro_rules! warning {

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -80,11 +80,6 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
         let external_css = serve.values_of_("external-css");
         let inline_css = serve.values_of_("css");
 
-        if serve.get_flag("cached-parse") {
-            fastn_core::warning!("using cached parser, files modifications may be ignored");
-            fastn_core::utils::enable_parse_caching(true);
-        }
-
         return fastn_core::listen(
             bind.as_str(),
             port,
@@ -423,7 +418,6 @@ mod sub_command {
             Read more about it on https://fastn.io/serve/")
             .arg(clap::arg!(--port <PORT> "The port to listen on [default: first available port starting 8000]"))
             .arg(clap::arg!(--bind <ADDRESS> "The address to bind to").default_value("127.0.0.1"))
-            .arg(clap::arg!(--"cached-parse" "Use cached parser"))
             .arg(clap::arg!(--edition <EDITION> "The FTD edition"))
             .arg(clap::arg!(--"external-js" <URL> "Script added in ftd files")
                 .action(clap::ArgAction::Append))

--- a/ftd/src/interpreter/mod.rs
+++ b/ftd/src/interpreter/mod.rs
@@ -44,6 +44,9 @@ pub use things::expression;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("OtherError: {}", _0)]
+    OtherError(String),
+
     #[error("P1Error: {}", _0)]
     P1Error(#[from] ftd::p1::Error),
 


### PR DESCRIPTION
Enabling parse caching for all ftd documents, we are going to watch the file system for changes, to purge the caches. Part of our [performance improvement effort](https://github.com/orgs/fastn-stack/discussions/1057).