### PR TITLE
fix: release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-ubuntu, release-macos, release-windows]
     steps:
+      - uses: actions/checkout@main
       - uses: actions/download-artifact@v2
         with:
           name: macos_x64_latest


### PR DESCRIPTION
Release is broken because I changed release action to create note from a template. The template is checked in, but the repo is not checked out when release action runs, which lead to failure. To fix it adding the checkout step in the release action. 

Why template? 

1. we want make it easier to modify the release note template. It being part of release.yml means multiline templates was tricky. 
2. We are embedding GITHUB_SHA in the binaries we are creating, but they are pointing to wrong version, a few commits before the actual release. By putting the SHA in release note we can easily check which release belongs to which version.

Ideally 2 is should only help if we create a release without updating the version number in `fastn/Cargo.toml`, which is what we have been doing all this while. The version in `fastn/Cargo.toml` is printed when we run `fastn --version`, but since we did not update it regularly, it was not useful, so we relied on SHA, but there was no direct relation between SHA to release as noted in 2. 

If we modify our action to not ask for version number and create a release based on the version number in `fastn/Cargo.toml` then we do not need all this. 