### PR TITLE
Named parameter in function in fastn 0.4

### DIFF
--- a/fastn-js/src/event.rs
+++ b/fastn-js/src/event.rs
@@ -13,5 +13,5 @@ pub enum Event {
 #[derive(Debug)]
 pub struct Function {
     pub name: String,
-    pub parameters: Vec<fastn_js::SetPropertyValue>,
+    pub parameters: Vec<(String, fastn_js::SetPropertyValue)>,
 }

--- a/fastn-js/src/lib.rs
+++ b/fastn-js/src/lib.rs
@@ -34,7 +34,7 @@ pub use record::RecordInstance;
 pub use ssr::{ssr, ssr_str, ssr_with_js_string};
 pub use static_variable::{static_integer, static_string, StaticVariable};
 pub use to_js::to_js;
-pub use udf::{udf0, udf1, udf2, udf_with_params, UDF};
+pub use udf::{udf0, udf1, udf2, udf_with_arguments, UDF};
 pub use udf_statement::UDFStatement;
 
 pub fn all_js_without_test() -> String {

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -9,21 +9,25 @@ pub struct SetProperty {
 #[derive(Debug)]
 pub enum SetPropertyValue {
     Reference(String),
-    Value(Value),
-    Formula(Formula),
+    Value(fastn_js::Value),
+    Formula(fastn_js::Formula),
 }
 
-impl SetPropertyValue {
+impl fastn_js::SetPropertyValue {
     pub fn to_js(&self) -> String {
         match self {
-            SetPropertyValue::Reference(name) => fastn_js::utils::reference_to_js(name),
-            SetPropertyValue::Value(v) => v.to_js(),
-            SetPropertyValue::Formula(f) => f.to_js(),
+            fastn_js::SetPropertyValue::Reference(name) => fastn_js::utils::reference_to_js(name),
+            fastn_js::SetPropertyValue::Value(v) => v.to_js(),
+            fastn_js::SetPropertyValue::Formula(f) => f.to_js(),
         }
     }
 
     pub fn is_formula(&self) -> bool {
-        matches!(&self, SetPropertyValue::Formula(_))
+        matches!(&self, fastn_js::SetPropertyValue::Formula(_))
+    }
+
+    pub fn null() -> fastn_js::SetPropertyValue {
+        fastn_js::SetPropertyValue::Value(fastn_js::Value::Null)
     }
 }
 
@@ -123,6 +127,7 @@ pub enum Value {
     UI {
         value: Vec<fastn_js::ComponentStatement>,
     },
+    Null,
 }
 
 impl Value {
@@ -168,6 +173,7 @@ impl Value {
                     })
                     .join("")
             ),
+            Value::Null => "null".to_string(),
         }
     }
 }

--- a/fastn-js/src/udf.rs
+++ b/fastn-js/src/udf.rs
@@ -2,29 +2,32 @@
 pub struct UDF {
     pub name: String,
     pub params: Vec<String>,
+    pub args: Vec<(String, fastn_js::SetPropertyValue)>,
     pub body: Vec<fastn_grammar::evalexpr::ExprNode>,
 }
 
 pub fn udf0(name: &str, body: Vec<fastn_grammar::evalexpr::ExprNode>) -> fastn_js::Ast {
     fastn_js::Ast::UDF(UDF {
         name: name.to_string(),
-        params: vec![],
+        params: vec!["args".to_string()],
+        args: vec![],
         body,
     })
 }
 
-pub fn udf_with_params(
+pub fn udf_with_arguments(
     name: &str,
     body: Vec<fastn_grammar::evalexpr::ExprNode>,
-    params: Vec<String>,
+    args: Vec<(String, fastn_js::SetPropertyValue)>,
 ) -> fastn_js::Ast {
     use itertools::Itertools;
 
     fastn_js::Ast::UDF(UDF {
         name: name.to_string(),
-        params: params
+        params: vec!["args".to_string()],
+        args: args
             .into_iter()
-            .map(|v| fastn_js::utils::name_to_js(v.as_str()))
+            .map(|(key, val)| (fastn_js::utils::name_to_js(key.as_str()), val))
             .collect_vec(),
         body,
     })
@@ -34,6 +37,7 @@ pub fn udf1(name: &str, arg1: &str, body: Vec<fastn_grammar::evalexpr::ExprNode>
     fastn_js::Ast::UDF(UDF {
         name: name.to_string(),
         params: vec![arg1.to_string()],
+        args: vec![],
         body,
     })
 }
@@ -47,6 +51,7 @@ pub fn udf2(
     fastn_js::Ast::UDF(UDF {
         name: name.to_string(),
         params: vec![arg1.to_string(), arg2.to_string()],
+        args: vec![],
         body,
     })
 }

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -2739,20 +2739,20 @@ impl ftd::interpreter::FunctionCall {
             .get_function(self.name.as_str(), self.line_number)
             .unwrap();
         for argument in function.arguments {
-            let value = if let Some(value) = self.values.get(argument.name.as_str()) {
-                value.to_value()
-            } else if let Some(value) = argument.get_default_value() {
-                value
-            } else {
+            if let Some(value) = self.values.get(argument.name.as_str()) {
+                parameters.push((
+                    argument.name.to_string(),
+                    value.to_value().to_set_property_value(
+                        doc,
+                        component_definition_name,
+                        loop_alias,
+                        inherited_variable_name,
+                        device,
+                    ),
+                ));
+            } else if argument.get_default_value().is_none() {
                 panic!("Argument value not found {:?}", argument)
-            };
-            parameters.push(value.to_set_property_value(
-                doc,
-                component_definition_name,
-                loop_alias,
-                inherited_variable_name,
-                device,
-            ));
+            }
         }
         fastn_js::Function {
             name: self.name.to_string(),

--- a/ftd/src/js/ftd_test_helpers.rs
+++ b/ftd/src/js/ftd_test_helpers.rs
@@ -75,7 +75,6 @@ fn p(s: &str, t: &str, fix: bool, manual: bool, file_location: &std::path::PathB
     let i = interpret_helper("foo", s).unwrap_or_else(|e| panic!("{:?}", e));
     let js_ast = ftd::js::document_into_js_ast(i);
     let js_document_script = fastn_js::to_js(js_ast.as_slice(), true);
-    dbg!(&js_document_script);
     let js_ftd_script = fastn_js::to_js(ftd::js::default_bag_into_js_ast().as_slice(), false);
     let ssr_body =
         fastn_js::ssr_with_js_string(format!("{js_ftd_script}\n{js_document_script}").as_str());

--- a/ftd/src/js/ftd_test_helpers.rs
+++ b/ftd/src/js/ftd_test_helpers.rs
@@ -75,6 +75,7 @@ fn p(s: &str, t: &str, fix: bool, manual: bool, file_location: &std::path::PathB
     let i = interpret_helper("foo", s).unwrap_or_else(|e| panic!("{:?}", e));
     let js_ast = ftd::js::document_into_js_ast(i);
     let js_document_script = fastn_js::to_js(js_ast.as_slice(), true);
+    dbg!(&js_document_script);
     let js_ftd_script = fastn_js::to_js(ftd::js::default_bag_into_js_ast().as_slice(), false);
     let ssr_body =
         fastn_js::ssr_with_js_string(format!("{js_ftd_script}\n{js_document_script}").as_str());

--- a/ftd/t/js/03-common-properties.html
+++ b/ftd/t/js/03-common-properties.html
@@ -544,7 +544,9 @@ let main = function (parent) {
     let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
     rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Red Color", inherited);
     rooti0.addEventHandler(fastn_dom.Event.Click, function () {
-      foo__increment(global.foo__value);
+      foo__increment({
+        a: global.foo__value,
+      });
     });
     rooti0.setProperty(fastn_dom.PropertyKind.Color, fastn.formula([global.foo__og,
     global.foo__value,
@@ -1418,11 +1420,15 @@ global.foo__red_yellow = fastn.recordInstance({
   light: "red",
   dark: "yellow"
 });
-let foo__increment = function (a)
+let foo__increment = function (args)
 {
-  let fastn_utils_val_a = fastn_utils.getter(a) + 1;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = fastn_utils.getter(__args__.a) + 1;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   };
 }
 global.foo__value = fastn.mutable(0);

--- a/ftd/t/js/04-variable.html
+++ b/ftd/t/js/04-variable.html
@@ -67,7 +67,9 @@ let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, global.foo__name, inherited);
   parenti0.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__increment(global.foo__i);
+    foo__increment({
+      a: global.foo__i,
+    });
   });
   parenti0.setProperty(fastn_dom.PropertyKind.Padding, fastn.formula([global.foo__i], function () {
     if (function () {
@@ -93,7 +95,10 @@ let main = function (parent) {
   let parenti3 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti3.setProperty(fastn_dom.PropertyKind.StringValue, "Click me to add Tom", inherited);
   parenti3.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__append_string(global.foo__names, "Tom");
+    foo__append_string({
+      a: global.foo__names,
+      v: "Tom",
+    });
   });
   global.foo__names.forLoop(parent, function (root, item, index) {
     let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
@@ -114,10 +119,14 @@ let main = function (parent) {
     }).getParent();
   });
 }
-let foo__increment = function (a) {
-  let fastn_utils_val_a = fastn_utils.getter(a) + 1;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+let foo__increment = function (args) {
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = fastn_utils.getter(__args__.a) + 1;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   };
 }
 global.foo__i = fastn.mutable(9);
@@ -148,8 +157,13 @@ let foo__foo = function (parent, inherited, args)
   ]), inherited);
   return parenti0;
 }
-let foo__append_string = function (a, v) {
-  return (ftd.append(a, v));
+let foo__append_string = function (args) {
+  let __args__ = {
+    a: fastn.mutableList([]),
+    v: null,
+    ...args
+  };
+  return (ftd.append(__args__.a, __args__.v));
 }
 global.foo__names = fastn.mutableList([]);
 let inherited = fastn.recordInstance({

--- a/ftd/t/js/05-dynamic-dom-list.html
+++ b/ftd/t/js/05-dynamic-dom-list.html
@@ -68,12 +68,17 @@ let main = function (parent) {
   let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "Click to change value", inherited);
   parenti1.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__clamp(global.foo__value);
+    foo__clamp({
+      a: global.foo__value,
+    });
   });
   let parenti2 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti2.setProperty(fastn_dom.PropertyKind.StringValue, "Click to add one", inherited);
   parenti2.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__append_integer(global.foo__counters, 1);
+    foo__append_integer({
+      a: global.foo__counters,
+      v: 1,
+    });
   });
   global.foo__counters.forLoop(parent, function (root, item, index) {
     return fastn_dom.conditionalDom(parent, [
@@ -89,21 +94,34 @@ let main = function (parent) {
   });
 }
 global.foo__value = fastn.mutable(0);
-let foo__clamp = function (a) {
-  let fastn_utils_val_a = (fastn_utils.getter(a) + 1) % 2;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+let foo__clamp = function (args) {
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = (fastn_utils.getter(__args__.a) + 1) % 2;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   }
 }
-let foo__append_integer = function (a, v) {
-  return (ftd.append(a, v));
+let foo__append_integer = function (args) {
+  let __args__ = {
+    a: fastn.mutableList([]),
+    v: null,
+    ...args
+  };
+  return (ftd.append(__args__.a, __args__.v));
 }
 global.foo__counters = fastn.mutableList([]);
-let foo__increment = function (a)
+let foo__increment = function (args)
 {
-  let fastn_utils_val_a = fastn_utils.getter(a) + 1;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = fastn_utils.getter(__args__.a) + 1;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   };
 }
 let foo__counter_list = function (parent, inherited, args) {
@@ -121,7 +139,9 @@ let foo__counter_list = function (parent, inherited, args) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Integer);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, __args__.counter, inherited);
   parenti0.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__increment(__args__.counter);
+    foo__increment({
+      a: __args__.counter,
+    });
   });
   return parenti0;
 }

--- a/ftd/t/js/06-dynamic-dom-list-2.html
+++ b/ftd/t/js/06-dynamic-dom-list-2.html
@@ -66,12 +66,18 @@ let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Click to add Tom", inherited);
   parenti0.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__append_string(global.foo__people, "Tom");
+    foo__append_string({
+      a: global.foo__people,
+      v: "Tom",
+    });
   });
   let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "update $first", inherited);
   parenti1.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__set_string(global.foo__first, "Bob");
+    foo__set_string({
+      a: global.foo__first,
+      v: "Bob",
+    });
   });
   global.foo__people.forLoop(parent, function (root, item, index) {
     return foo__show_person(root, inherited, {
@@ -80,17 +86,27 @@ let main = function (parent) {
     });
   });
 }
-let foo__append_string = function (a, v) {
-  return (ftd.append(a, v));
+let foo__append_string = function (args) {
+  let __args__ = {
+    a: fastn.mutableList([]),
+    v: null,
+    ...args
+  };
+  return (ftd.append(__args__.a, __args__.v));
 }
 global.foo__first = fastn.mutable("hello");
 global.foo__people = fastn.mutableList([global.foo__first,
 "world"]);
-let foo__set_string = function (a, v)
+let foo__set_string = function (args)
 {
-  let fastn_utils_val_a = v;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+  let __args__ = {
+    a: null,
+    v: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = __args__.v;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   };
 }
 let foo__show_person = function (parent, inherited, args) {

--- a/ftd/t/js/07-dynamic-dom-record-list.html
+++ b/ftd/t/js/07-dynamic-dom-record-list.html
@@ -66,7 +66,10 @@ let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Click to add Tom", inherited);
   parenti0.addEventHandler(fastn_dom.Event.Click, function () {
-    foo__append_person(global.foo__people, global.foo__tom);
+    foo__append_person({
+      a: global.foo__people,
+      v: global.foo__tom,
+    });
   });
   global.foo__people.forLoop(parent, function (root, item, index) {
     return foo__show_person(root, inherited, {
@@ -75,8 +78,13 @@ let main = function (parent) {
     });
   });
 }
-let foo__append_person = function (a, v) {
-  return (ftd.append(a, v));
+let foo__append_person = function (args) {
+  let __args__ = {
+    a: fastn.mutableList([]),
+    v: null,
+    ...args
+  };
+  return (ftd.append(__args__.a, __args__.v));
 }
 global.foo__first = fastn.recordInstance({
   name: "Jill",

--- a/ftd/t/js/10-color-test.html
+++ b/ftd/t/js/10-color-test.html
@@ -109,7 +109,9 @@ let main = function (parent) {
     let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
     rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Lorem ipsum dolor sit amet. Quo aliquam natus id cumque Quis quo eligendi quia\nqui aliquid dolores. Qui atque delectus quo maxime numquam qui architecto\ndelectus. Qui maxime galisum sit magni placeat sed illum sunt. Ut illo excepturi\naut nulla molestiae et excepturi voluptas aut voluptatem obcaecati id harum quia.\n\nUt esse consequatur ex molestiae consequatur sed nobis consequuntur ut\ntemporibus eveniet ut aperiam esse a rerum libero. Et perferendis voluptas eos\nculpa odit et architecto officiis aut eveniet commodi. Eos quia quia qui nulla\nerror et quaerat dolor vel odit reprehenderit ut nemo numquam non molestias\nillum aut nobis omnis. Qui galisum commodi At internos dolorum sed repudiandae\nquisquam ab repellat molestiae qui quia repudiandae ut doloribus impedit.\n\nA repellendus sapiente id Quis doloremque qui Quis omnis in blanditiis tenetur\nquo esse dolor. 33 vitae modi ut voluptates distinctio est dicta temporibus est\nconsectetur voluptatum et Quis inventore ab dignissimos amet?", inherited);
     rooti0.addEventHandler(fastn_dom.Event.Click, function () {
-      foo__increment(global.foo__value);
+      foo__increment({
+        a: global.foo__value,
+      });
     });
     rooti0.setProperty(fastn_dom.PropertyKind.Padding, fastn_dom.Length.Px(40), inherited);
     rooti0.setProperty(fastn_dom.PropertyKind.Color, fastn.formula([global.foo__og,
@@ -141,11 +143,15 @@ global.foo__bg_og = fastn.recordInstance({
   dark: "#edfce8"
 });
 global.foo__value = fastn.mutable(0);
-let foo__increment = function (a)
+let foo__increment = function (args)
 {
-  let fastn_utils_val_a = fastn_utils.getter(a) + 1;
-  if (!fastn_utils.setter(a, fastn_utils_val_a)) {
-    a = fastn_utils_val_a;
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = fastn_utils.getter(__args__.a) + 1;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
   };
 }
 global.foo__og = fastn.recordInstance({


### PR DESCRIPTION
- Passing named parameter in functions instead of ordered parameter

```ftd
-- ftd.text: Increment
$on-click$: $increment()

-- void increment(a):
integer $a: 1


a = a + 1;
```

Earlier, the above ftd code gets converted into 

```js

rooti0.addEventHandler(fastn_dom.Event.Click, function () {
      foo__increment(1);
});

function increment(a) {
  // <omitted>
}
```

Now it gets convert to 

```js
rooti0.addEventHandler(fastn_dom.Event.Click, function () {
      foo__increment();
});

function increment(args){
   let __args__ = {
     a: 1,
     ...args
   };
   // <omitted>
}
```

We prefer named parameters over ordered parameters:

- No need to pass default value while calling function
- We can implement inheritance.
