### PR TITLE
Added function call as value for component properties in fastn 0.4

### DIFF
--- a/fastn-js/src/lib.rs
+++ b/fastn-js/src/lib.rs
@@ -29,7 +29,9 @@ pub use device::{DeviceBlock, DeviceType};
 pub use event::{Event, EventHandler, Function};
 pub use loop_component::ForLoop;
 pub use mutable_variable::{mutable_integer, mutable_string, MutableList, MutableVariable};
-pub use property::{ConditionalValue, Formula, PropertyKind, SetProperty, SetPropertyValue, Value};
+pub use property::{
+    ConditionalValue, Formula, FormulaType, PropertyKind, SetProperty, SetPropertyValue, Value,
+};
 pub use record::RecordInstance;
 pub use ssr::{ssr, ssr_str, ssr_with_js_string};
 pub use static_variable::{static_integer, static_string, StaticVariable};

--- a/ftd/src/interpreter/things/component.rs
+++ b/ftd/src/interpreter/things/component.rs
@@ -152,14 +152,24 @@ impl Component {
         }
     }
 
+    // Todo: Remove this function after removing 0.3
     pub fn get_children_property(&self) -> Option<ftd::interpreter::Property> {
-        self.properties.iter().find_map(|v| {
-            if v.value.kind().inner_list().is_subsection_ui() {
-                Some(v.to_owned())
-            } else {
-                None
-            }
-        })
+        self.get_children_properties().first().map(|v| v.to_owned())
+    }
+
+    pub fn get_children_properties(&self) -> Vec<ftd::interpreter::Property> {
+        use itertools::Itertools;
+
+        self.properties
+            .iter()
+            .filter_map(|v| {
+                if v.value.kind().inner_list().is_subsection_ui() {
+                    Some(v.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect_vec()
     }
 
     pub fn get_children(

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -1189,9 +1189,9 @@ impl Column {
             .unwrap();
 
         Column {
-            children: component
-                .get_children_property()
-                .map(|v| ftd::js::utils::get_js_value_from_properties(vec![v].as_slice()).unwrap()),
+            children: ftd::js::utils::get_js_value_from_properties(
+                component.get_children_properties().as_slice(),
+            ),
             inherited: InheritedProperties::from(
                 component.properties.as_slice(),
                 component_definition.arguments.as_slice(),
@@ -1291,9 +1291,9 @@ impl Row {
             .component()
             .unwrap();
         Row {
-            children: component
-                .get_children_property()
-                .map(|v| ftd::js::utils::get_js_value_from_properties(vec![v].as_slice()).unwrap()),
+            children: ftd::js::utils::get_js_value_from_properties(
+                component.get_children_properties().as_slice(),
+            ),
             inherited: InheritedProperties::from(
                 component.properties.as_slice(),
                 component_definition.arguments.as_slice(),

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -2726,7 +2726,7 @@ impl ftd::interpreter::Event {
 }
 
 impl ftd::interpreter::FunctionCall {
-    fn to_js_function(
+    pub(crate) fn to_js_function(
         &self,
         doc: &ftd::interpreter::TDoc,
         component_definition_name: &Option<String>,

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -702,7 +702,7 @@ pub struct Boolean {
 
 #[derive(Debug)]
 pub struct Column {
-    pub children: Option<ftd::interpreter::Property>,
+    pub children: Option<ftd::js::Value>,
     pub inherited: InheritedProperties,
     pub container: Container,
     pub common: Common,
@@ -788,7 +788,7 @@ impl Container {
 
 #[derive(Debug)]
 pub struct Row {
-    pub children: Option<ftd::interpreter::Property>,
+    pub children: Option<ftd::js::Value>,
     pub inherited: InheritedProperties,
     pub container: Container,
     pub common: Common,
@@ -1189,7 +1189,9 @@ impl Column {
             .unwrap();
 
         Column {
-            children: component.get_children_property(),
+            children: component
+                .get_children_property()
+                .map(|v| ftd::js::utils::get_js_value_from_properties(vec![v].as_slice()).unwrap()),
             inherited: InheritedProperties::from(
                 component.properties.as_slice(),
                 component_definition.arguments.as_slice(),
@@ -1260,7 +1262,7 @@ impl Column {
         component_statements.extend(self.children.iter().map(|v| {
             fastn_js::ComponentStatement::SetProperty(fastn_js::SetProperty {
                 kind: fastn_js::PropertyKind::Children,
-                value: v.value.to_fastn_js_value(
+                value: v.to_set_property_value(
                     doc,
                     component_definition_name,
                     loop_alias,
@@ -1289,7 +1291,9 @@ impl Row {
             .component()
             .unwrap();
         Row {
-            children: component.get_children_property(),
+            children: component
+                .get_children_property()
+                .map(|v| ftd::js::utils::get_js_value_from_properties(vec![v].as_slice()).unwrap()),
             inherited: InheritedProperties::from(
                 component.properties.as_slice(),
                 component_definition.arguments.as_slice(),
@@ -1361,7 +1365,7 @@ impl Row {
         component_statements.extend(self.children.iter().map(|v| {
             fastn_js::ComponentStatement::SetProperty(fastn_js::SetProperty {
                 kind: fastn_js::PropertyKind::Children,
-                value: v.value.to_fastn_js_value(
+                value: v.to_set_property_value(
                     doc,
                     component_definition_name,
                     loop_alias,

--- a/ftd/src/js/utils.rs
+++ b/ftd/src/js/utils.rs
@@ -49,3 +49,20 @@ pub(crate) fn update_reference(
 fn is_ftd_thing(name: &str) -> bool {
     name.starts_with("ftd#") || name.starts_with("ftd.")
 }
+
+pub(crate) fn get_js_value_from_properties(
+    properties: &[ftd::interpreter::Property],
+) -> Option<ftd::js::Value> {
+    if properties.is_empty() {
+        return None;
+    }
+
+    if properties.len() == 1 {
+        let property = properties.first().unwrap();
+        if property.condition.is_none() {
+            return Some(property.value.to_value());
+        }
+    }
+
+    Some(ftd::js::Value::ConditionalFormula(properties.to_owned()))
+}

--- a/ftd/src/js/value.rs
+++ b/ftd/src/js/value.rs
@@ -325,18 +325,7 @@ impl ftd::interpreter::Argument {
         )
         .unwrap();
 
-        if properties.is_empty() {
-            return None;
-        }
-
-        if properties.len() == 1 {
-            let property = properties.first().unwrap();
-            if property.condition.is_none() {
-                return Some(property.value.to_value());
-            }
-        }
-
-        Some(Value::ConditionalFormula(properties))
+        ftd::js::utils::get_js_value_from_properties(properties.as_slice())
     }
 }
 

--- a/ftd/t/js/15-function-call-in-property.ftd
+++ b/ftd/t/js/15-function-call-in-property.ftd
@@ -1,0 +1,17 @@
+-- decimal $num: 2
+
+-- ftd.text: Hello
+padding.em: $multiply-by-two(a= $num)
+$on-click$: $increment($a = $num)
+
+
+-- decimal multiply-by-two(a):
+decimal a:
+
+a * 2
+
+
+-- void increment(a):
+decimal $a:
+
+a = a + 1;

--- a/ftd/t/js/15-function-call-in-property.html
+++ b/ftd/t/js/15-function-call-in-property.html
@@ -1,0 +1,108 @@
+<html>
+<head>
+    <script src="fastn-js.js"></script>
+
+    <style>
+        /* http://meyerweb.com/eric/tools/css/reset/
+           v2.0 | 20110126
+           License: none (public domain)
+        */
+
+        html, body, div, span, applet, object, iframe,
+        h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+        a, abbr, acronym, address, big, cite, code,
+        del, dfn, em, img, ins, kbd, q, s, samp,
+        small, strike, strong, sub, sup, tt, var,
+        b, u, i, center,
+        dl, dt, dd, ol, ul, li,
+        fieldset, form, label, legend,
+        table, caption, tbody, tfoot, thead, tr, th, td,
+        article, aside, canvas, details, embed,
+        figure, figcaption, footer, header, hgroup,
+        menu, nav, output, ruby, section, summary,
+        time, mark, audio, video {
+            margin: 0;
+            padding: 0;
+            border: 0;
+            font-size: 100%;
+            font: inherit;
+            vertical-align: baseline;
+        }
+        /* HTML5 display-role reset for older browsers */
+        article, aside, details, figcaption, figure,
+        footer, header, hgroup, menu, nav, section {
+            display: block;
+        }
+        body {
+            line-height: 1;
+        }
+        ol, ul {
+            list-style: none;
+        }
+        blockquote, q {
+            quotes: none;
+        }
+        blockquote:before, blockquote:after,
+        q:before, q:after {
+            content: '';
+            content: none;
+        }
+        table {
+            border-collapse: collapse;
+            border-spacing: 0;
+        }
+    </style>
+</head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+<body data-id="1"><div data-id="2" class="p-1">Hello</div></body><style id="styles">
+    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
+	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+	.p-1 { padding: 4em; }
+    </style>
+<script>
+    (function() {
+        let global = {
+};
+let main = function (parent) {
+  let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
+  parenti0.addEventHandler(fastn_dom.Event.Click, function () {
+    foo__increment({
+      a: global.foo__num,
+    });
+  });
+  parenti0.setProperty(fastn_dom.PropertyKind.Padding, fastn_dom.Length.Em(fastn.formula([global.foo__num], function () {
+    return foo__multiply_by_two({
+      a: global.foo__num,
+    });
+  })), inherited);
+}
+let foo__increment = function (args) {
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  let fastn_utils_val___args___a = fastn_utils.getter(__args__.a) + 1;
+  if (!fastn_utils.setter(__args__.a, fastn_utils_val___args___a)) {
+    __args__.a = fastn_utils_val___args___a;
+  };
+}
+global.foo__num = fastn.mutable(2);
+let foo__multiply_by_two = function (args)
+{
+  let __args__ = {
+    a: null,
+    ...args
+  };
+  return (fastn_utils.getter(__args__.a) * 2);
+}
+let inherited = fastn.recordInstance({
+  colors: ftd.default_colors,
+  types: ftd.default_types
+});
+
+        fastn_virtual.hydrate(main);
+        ftd.post_init();
+    })();
+</script>
+</html>


### PR DESCRIPTION
## Function call as value for component property 

With this PR, function call passed as value for component property works:

```ftd
-- ftd.text: Hello
padding.em: $multiply-by-two(a= $num)
```

The value of `padding` property for `ftd.text` component is a function call `multiply-by-two`. This is working now.

## Conditional Children

Now we can add condition over `children` or `ftd.ui list` type properties. (Hopefully, it should work 🤞)