### PR TITLE
Remove wrapper in fastn 0.4

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -641,11 +641,13 @@ class Node2 {
             parent = parent.parent();
         }*/
 
+
         if (this.#parent.getNode) {
             this.#parent = this.#parent.getNode();
         }
 
         if (fastn_utils.isWrapperNode(this.#tagName)) {
+            this.#parent = parentOrSibiling;
             return;
         }
         if (sibiling) {
@@ -969,7 +971,7 @@ class Node2 {
                 if (Array.isArray(staticValue)) {
                     staticValue.forEach((func, index) => {
                         if (index !== 0) {
-                            parentWithSibiling = new ParentNodeWithSibiling(this.#parent, this.#children[index-1]);
+                            parentWithSibiling = new ParentNodeWithSibiling(this.#parent.getParent(), this.#children[index-1]);
                         }
                         this.#children.push(fastn_utils.getStaticValue(func.item)(parentWithSibiling, inherited))
                     });

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -4,27 +4,7 @@ fastn_dom.commentNode = "comment";
 fastn_dom.wrapperNode = "wrapper";
 fastn_dom.commentMessage = "***FASTN***";
 
-fastn_dom.common = {
-    ".ft_row": {
-        "value": {
-            "display": "flex",
-            "align-items": "start",
-            "justify-content": "start",
-            "flex-direction": "row",
-        }
-    },
-    ".ft_column": {
-        "value": {
-            "display": "flex",
-            "align-items": "start",
-            "justify-content": "start",
-            "flex-direction": "column",
-        }
-    }
-};
-
-
-fastn_dom.classes = { ...fastn_dom.common }
+fastn_dom.classes = { }
 fastn_dom.unsanitised_classes = {}
 fastn_dom.class_count = 0;
 fastn_dom.propertyMap = {

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1464,6 +1464,10 @@ class ForLoop {
         return this.#wrapper;
     }
 
+    insertNode(index, node) {
+        this.#nodes.splice(index, 0, node);
+    }
+
     getParent() {
         return this.#parent;
     }

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1442,16 +1442,18 @@ class ForLoop {
         this.#list = list;
         this.#nodes = [];
 
-        let parentWithSibiling = new ParentNodeWithSibiling(parent, this.#wrapper);
         for (let idx in list.getList()) {
-            let node = this.createNode(parentWithSibiling, idx);
-            parentWithSibiling = new ParentNodeWithSibiling(parent, node);
+            let node = this.createNode(idx);
             this.#nodes.push(node);
         }
     }
-    createNode(sibiling, index) {
+    createNode(index) {
+        let parentWithSibiling = new ParentNodeWithSibiling(this.#parent, this.#wrapper);
+        if (index !== 0) {
+            parentWithSibiling = new ParentNodeWithSibiling(this.#parent, this.#nodes[index-1]);
+        }
         let v = this.#list.get(index);
-        return this.#node_constructor(sibiling, v.item, v.index);
+        return this.#node_constructor(parentWithSibiling, v.item, v.index);
     }
 
     getWrapper() {

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1285,13 +1285,19 @@ class Node2 {
             this.addMetaTag("twitter:description", staticValue);
         } else if (kind === fastn_dom.PropertyKind.DocumentProperties.MetaOGImage) {
             // staticValue is of ftd.raw-image-src RecordInstance type
-            this.addMetaTag("og:image", fastn_utils.getStaticValue(staticValue.get('src')));
+            if (!fastn_utils.isNull(staticValue)) {
+                this.addMetaTag("og:image", fastn_utils.getStaticValue(staticValue.get('src')));
+            }
         } else if (kind === fastn_dom.PropertyKind.DocumentProperties.MetaTwitterImage) {
             // staticValue is of ftd.raw-image-src RecordInstance type
-            this.addMetaTag("twitter:image", fastn_utils.getStaticValue(staticValue.get('src')));
+            if (!fastn_utils.isNull(staticValue)) {
+                this.addMetaTag("twitter:image", fastn_utils.getStaticValue(staticValue.get('src')));
+            }
         } else if (kind === fastn_dom.PropertyKind.DocumentProperties.MetaThemeColor) {
             // staticValue is of ftd.color RecordInstance type
-            this.addMetaTag("theme-color", fastn_utils.getStaticValue(staticValue.get('light')));
+            if (!fastn_utils.isNull(staticValue)) {
+                this.addMetaTag("theme-color", fastn_utils.getStaticValue(staticValue.get('light')));
+            }
         } else if (kind === fastn_dom.PropertyKind.IntegerValue
             || kind === fastn_dom.PropertyKind.DecimalValue
             || kind === fastn_dom.PropertyKind.BooleanValue) {

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1367,6 +1367,7 @@ class Node2 {
 }
 
 class ConditionalDom {
+    #marker;
     #parent;
     #node_constructor;
     #condition;
@@ -1374,7 +1375,8 @@ class ConditionalDom {
     #conditionUI;
 
     constructor(parent, deps, condition, node_constructor) {
-        let domNode = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Div);
+        this.#marker = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Comment);
+        this.#parent = parent;
 
         this.#conditionUI = null;
         let closure = fastn.closure(() => {
@@ -1382,7 +1384,7 @@ class ConditionalDom {
                 if (this.#conditionUI) {
                     this.#conditionUI.destroy();
                 }
-                this.#conditionUI = node_constructor(domNode);
+                this.#conditionUI = node_constructor(new ParentNodeWithSibiling(this.#parent, this.#marker));
             } else if (this.#conditionUI) {
                 this.#conditionUI.destroy();
                 this.#conditionUI = null;
@@ -1394,15 +1396,17 @@ class ConditionalDom {
             }
         });
 
-
-        this.#parent = domNode;
         this.#node_constructor = node_constructor;
         this.#condition = condition;
         this.#mutables = [];
     }
 
     getParent() {
-        return this.#parent;
+        let nodes =  [this.#marker];
+        if (this.#conditionUI) {
+            nodes.push(this.#conditionUI);
+        }
+        nodes
     }
 }
 

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1,7 +1,7 @@
 let fastn_dom = {};
 
 fastn_dom.commentNode = "comment";
-fastn_dom.commentMessage = "***DON'T REMOVE THIS COMMENT. THIS IS MARKER***";
+fastn_dom.commentMessage = "***FASTN***";
 
 fastn_dom.common = {
     ".ft_row": {

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1275,7 +1275,8 @@ class Node2 {
                 const src = staticValue.get(is_dark_mode ? 'dark' : 'light');
 
                 this.attachAttribute("src", fastn_utils.getStaticValue(src));
-            }));
+            }).addNodeProperty(this, null, inherited));
+            this.#mutables.push(ftd.dark_mode);
         } else if (kind === fastn_dom.PropertyKind.Alt) {
             this.attachAttribute("alt", staticValue);
         } else if (kind === fastn_dom.PropertyKind.YoutubeSrc) {

--- a/fastn-js/js/fastn.js
+++ b/fastn-js/js/fastn.js
@@ -192,7 +192,8 @@ class MutableList {
         }
 
         for (let i in this.#watchers) {
-            this.#watchers[i].createNode(idx);
+            let forLoop = this.#watchers[i];
+            forLoop.insertNode(idx, forLoop.createNode(idx));
         }
     }
     push(value) {

--- a/fastn-js/js/ftd.js
+++ b/fastn-js/js/ftd.js
@@ -2,6 +2,7 @@ let ftd = {
     // source: https://stackoverflow.com/questions/400212/ (cc-by-sa)
     riveNodes: {},
     is_empty(value) {
+        value = fastn_utils.getFlattenStaticValue(value);
         return fastn_utils.isNull(value) || value.length === 0;
     },
 

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -23,6 +23,8 @@ let fastn_utils = {
             attributes["type"] = "checkbox";
         } else if (kind === fastn_dom.ElementKind.TextInput) {
             node = "input";
+        } else if (kind === fastn_dom.ElementKind.Comment) {
+            node = fastn_dom.commentNode;
         }
         return [node, css, attributes];
     },
@@ -151,6 +153,31 @@ let fastn_utils = {
 
     isNull(a) {
         return a === null || a === undefined;
+    },
+
+    isCommentNode(node) {
+      return node === fastn_dom.commentNode
+    },
+
+    nextSibling(node) {
+        if (node.nextSibling) {
+          return node.nextSibling;
+        }
+        if (node.getNode && node.getNode().nextSibling !== undefined) {
+            return node.getNode().nextSibling;
+        }
+        return node.getParent().getChildren().indexOf(node.getNode()) + 1;
+    },
+
+    getParent(parent) {
+        if (!fastn_utils.isNull(parent)
+            && parent.isSibiling
+            && parent.isSibiling()
+        ) {
+            return parent.getParent();
+        } else {
+            return parent;
+        }
     }
 }
 

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -159,26 +159,15 @@ let fastn_utils = {
       return node === fastn_dom.commentNode
     },
 
-    nextSibling(node) {
+    nextSibling(node, parent) {
         if (node.nextSibling) {
           return node.nextSibling;
         }
         if (node.getNode && node.getNode().nextSibling !== undefined) {
             return node.getNode().nextSibling;
         }
-        return node.getParent().getChildren().indexOf(node.getNode()) + 1;
+        return parent.getChildren().indexOf(node.getNode()) + 1;
     },
-
-    getParent(parent) {
-        if (!fastn_utils.isNull(parent)
-            && parent.isSibiling
-            && parent.isSibiling()
-        ) {
-            return parent.getParent();
-        } else {
-            return parent;
-        }
-    }
 }
 
 

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -160,6 +160,10 @@ let fastn_utils = {
     },
 
     nextSibling(node, parent) {
+        // For Conditional DOM
+        if (Array.isArray(node)) {
+            node = node[node.length - 1];
+        }
         if (node.nextSibling) {
           return node.nextSibling;
         }

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -12,8 +12,7 @@ let fastn_utils = {
             node = "iframe";
         } else if (kind === fastn_dom.ElementKind.Image) {
             node = "img";
-        } else if (kind === fastn_dom.ElementKind.Div ||
-            kind === fastn_dom.ElementKind.ContainerElement ||
+        } else if (kind === fastn_dom.ElementKind.ContainerElement ||
             kind === fastn_dom.ElementKind.Text) {
             node = "div";
         } else if (kind === fastn_dom.ElementKind.Rive) {
@@ -25,6 +24,8 @@ let fastn_utils = {
             node = "input";
         } else if (kind === fastn_dom.ElementKind.Comment) {
             node = fastn_dom.commentNode;
+        } else if (kind === fastn_dom.ElementKind.Wrapper) {
+            node = fastn_dom.wrapperNode;
         }
         return [node, css, attributes];
     },
@@ -156,7 +157,11 @@ let fastn_utils = {
     },
 
     isCommentNode(node) {
-      return node === fastn_dom.commentNode
+      return node === fastn_dom.commentNode;
+    },
+
+    isWrapperNode(node) {
+        return node === fastn_dom.wrapperNode;
     },
 
     nextSibling(node, parent) {

--- a/fastn-js/js/virtual.js
+++ b/fastn-js/js/virtual.js
@@ -107,11 +107,18 @@ class Document2 {
             return window.document.body;
         }
 
-        if (fastn_utils.isCommentNode(tagName)) {
-            return window.document.createComment(fastn_dom.commentMessage);
-        } else if (hydrating) {
-            return this.getElementByDataID(id_counter);
-        }else {
+        if (hydrating) {
+            let node = this.getElementByDataID(id_counter);
+            if (fastn_utils.isCommentNode(tagName)) {
+                let comment= window.document.createComment(fastn_dom.commentMessage);
+                node.parentNode.replaceChild(comment, node);
+                return comment;
+            }
+            return node;
+        } else {
+            if (fastn_utils.isCommentNode(tagName)) {
+                return window.document.createComment(fastn_dom.commentMessage);
+            }
             return window.document.createElement(tagName);
         }
     }

--- a/fastn-js/js/virtual.js
+++ b/fastn-js/js/virtual.js
@@ -104,7 +104,7 @@ class Document2 {
         }
 
         if (fastn_utils.isWrapperNode(tagName)) {
-            return;
+            return window.document.createComment(fastn_dom.commentMessage);
         }
         if (hydrating) {
             let node = this.getElementByDataID(id_counter);

--- a/fastn-js/js/virtual.js
+++ b/fastn-js/js/virtual.js
@@ -19,7 +19,8 @@ class Node {
     #tagName
     #children
     #attributes
-    constructor(id, tagName) {
+    #parent
+    constructor(id, tagName, parent) {
         this.#tagName = tagName;
         this.#id = id;
         this.classList = new ClassList();
@@ -28,9 +29,18 @@ class Node {
         this.innerHTML = "";
         this.style = {};
         this.onclick = null;
+        this.#parent = parent;
     }
     appendChild(c) {
         this.#children.push(c);
+    }
+
+    insertBefore(node, index) {
+        this.#children.splice(index, 0, node);
+    }
+
+    getChildren() {
+        return this.#children;
     }
 
     setAttribute(attribute, value) {
@@ -84,19 +94,24 @@ class Node {
 }
 
 class Document2 {
-    createElement(tagName) {
+    createElement(tagName, parent) {
         id_counter++;
+
+        parent = fastn_utils.getParent(parent);
+
         if (ssr) {
-            return new Node(id_counter, tagName);
+            return new Node(id_counter, tagName, parent);
         }
 
         if (tagName === "body") {
             return window.document.body;
         }
 
-        if (hydrating) {
+        if (fastn_utils.isCommentNode(tagName)) {
+            return window.document.createComment(fastn_dom.commentMessage);
+        } else if (hydrating) {
             return this.getElementByDataID(id_counter);
-        } else {
+        }else {
             return window.document.createElement(tagName);
         }
     }

--- a/fastn-js/js/virtual.js
+++ b/fastn-js/js/virtual.js
@@ -103,6 +103,9 @@ class Document2 {
             return window.document.body;
         }
 
+        if (fastn_utils.isWrapperNode(tagName)) {
+            return;
+        }
         if (hydrating) {
             let node = this.getElementByDataID(id_counter);
             if (fastn_utils.isCommentNode(tagName)) {

--- a/fastn-js/js/virtual.js
+++ b/fastn-js/js/virtual.js
@@ -19,8 +19,7 @@ class Node {
     #tagName
     #children
     #attributes
-    #parent
-    constructor(id, tagName, parent) {
+    constructor(id, tagName) {
         this.#tagName = tagName;
         this.#id = id;
         this.classList = new ClassList();
@@ -29,7 +28,6 @@ class Node {
         this.innerHTML = "";
         this.style = {};
         this.onclick = null;
-        this.#parent = parent;
     }
     appendChild(c) {
         this.#children.push(c);
@@ -94,13 +92,11 @@ class Node {
 }
 
 class Document2 {
-    createElement(tagName, parent) {
+    createElement(tagName) {
         id_counter++;
 
-        parent = fastn_utils.getParent(parent);
-
         if (ssr) {
-            return new Node(id_counter, tagName, parent);
+            return new Node(id_counter, tagName);
         }
 
         if (tagName === "body") {

--- a/fastn-js/src/component_invocation.rs
+++ b/fastn-js/src/component_invocation.rs
@@ -21,7 +21,6 @@ impl Kernel {
 
 #[derive(Copy, Clone, Debug)]
 pub enum ElementKind {
-    Div,
     Row,
     Column,
     ContainerElement,

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -212,7 +212,7 @@ impl Value {
     pub(crate) fn to_js(&self, element_name: &Option<String>) -> String {
         use itertools::Itertools;
         match self {
-            Value::String(s) => format!("\"{}\"", s.replace('\n', "\\n")),
+            Value::String(s) => format!("\"{}\"", s.replace('\n', "\\n").replace("\"", "\\\"")),
             Value::Integer(i) => i.to_string(),
             Value::Decimal(f) => f.to_string(),
             Value::Boolean(b) => b.to_string(),

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -212,7 +212,7 @@ impl Value {
     pub(crate) fn to_js(&self, element_name: &Option<String>) -> String {
         use itertools::Itertools;
         match self {
-            Value::String(s) => format!("\"{}\"", s.replace('\n', "\\n").replace("\"", "\\\"")),
+            Value::String(s) => format!("\"{}\"", s.replace('\n', "\\n").replace('\"', "\\\"")),
             Value::Integer(i) => i.to_string(),
             Value::Decimal(f) => f.to_string(),
             Value::Boolean(b) => b.to_string(),

--- a/fastn-js/src/ssr.rs
+++ b/fastn-js/src/ssr.rs
@@ -1,7 +1,7 @@
 pub fn ssr_str(js: &str) -> String {
     let all_js = fastn_js::all_js_with_test();
     let js = format!("{all_js}{js}");
-    dbg!(&js);
+    // dbg!(&js);
 
     #[cfg(target_os = "windows")]
     {

--- a/fastn-js/src/ssr.rs
+++ b/fastn-js/src/ssr.rs
@@ -1,7 +1,6 @@
 pub fn ssr_str(js: &str) -> String {
     let all_js = fastn_js::all_js_with_test();
     let js = format!("{all_js}{js}");
-    // dbg!(&js);
 
     #[cfg(target_os = "windows")]
     {

--- a/fastn-js/src/ssr.rs
+++ b/fastn-js/src/ssr.rs
@@ -1,6 +1,7 @@
 pub fn ssr_str(js: &str) -> String {
     let all_js = fastn_js::all_js_with_test();
     let js = format!("{all_js}{js}");
+    dbg!(&js);
 
     #[cfg(target_os = "windows")]
     {

--- a/fastn-js/src/to_js.rs
+++ b/fastn-js/src/to_js.rs
@@ -156,7 +156,6 @@ impl fastn_js::Function {
 impl fastn_js::ElementKind {
     pub fn to_js(&self) -> &'static str {
         match self {
-            fastn_js::ElementKind::Div => "fastn_dom.ElementKind.Div",
             fastn_js::ElementKind::Row => "fastn_dom.ElementKind.Row",
             fastn_js::ElementKind::ContainerElement => "fastn_dom.ElementKind.ContainerElement",
             fastn_js::ElementKind::Column => "fastn_dom.ElementKind.Column",
@@ -166,7 +165,7 @@ impl fastn_js::ElementKind {
             fastn_js::ElementKind::Text => "fastn_dom.ElementKind.Text",
             fastn_js::ElementKind::Image => "fastn_dom.ElementKind.Image",
             fastn_js::ElementKind::IFrame => "fastn_dom.ElementKind.IFrame",
-            fastn_js::ElementKind::Device => "fastn_dom.ElementKind.Div",
+            fastn_js::ElementKind::Device => "fastn_dom.ElementKind.Wrapper",
             fastn_js::ElementKind::CheckBox => "fastn_dom.ElementKind.CheckBox",
             fastn_js::ElementKind::TextInput => "fastn_dom.ElementKind.TextInput",
             fastn_js::ElementKind::Rive => "fastn_dom.ElementKind.Rive",

--- a/ftd/ftd-js.css
+++ b/ftd/ftd-js.css
@@ -48,7 +48,8 @@ table {
 }*/
 
 *, :after, :before {
-    box-sizing: inherit;
+    /*box-sizing: inherit;*/
+    box-sizing: border-box;
 }
 
 *, pre, div {
@@ -117,6 +118,21 @@ pre code {
     display: flex;
     align-items: start;
     justify-content: start
+}
+
+.ft_row {
+    display: flex;
+    align-items: start;
+    justify-content: start;
+    flex-direction: row;
+    box-sizing: border-box;
+}
+.ft_column {
+    display: flex;
+    align-items: start;
+    justify-content: start;
+    flex-direction: column;
+    box-sizing: border-box;
 }
 
 .ft_row {

--- a/ftd/src/html/test.rs
+++ b/ftd/src/html/test.rs
@@ -77,7 +77,9 @@ pub fn interpret_helper(
 
 #[track_caller]
 fn p(s: &str, t: &str, fix: bool, file_location: &std::path::PathBuf) {
+    dbg!("1");
     let doc = interpret_helper("foo", s).unwrap_or_else(|e| panic!("{:?}", e));
+    dbg!("2");
     let executor =
         ftd::executor::ExecuteDoc::from_interpreter(doc).unwrap_or_else(|e| panic!("{:?}", e));
     let node = ftd::node::NodeData::from_rt(executor);

--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -1014,50 +1014,76 @@ impl PropertyValue {
                     .trim_start_matches(ftd::interpreter::utils::REFERENCE)
                     .to_string();
 
-                let (_, found_kind, _) = try_ok_state!(doc.get_kind_with_argument(
-                    reference.as_str(),
-                    value.line_number(),
-                    definition_name_with_arguments,
-                    loop_object_name_and_kind,
-                )?);
+                // Todo: remove it after 0.3
+                if reference.starts_with("inherited.colors")
+                    || reference.starts_with("inherited.types")
+                {
+                    let found_kind = dbg!(doc.get_kind_with_argument(
+                        reference.as_str(),
+                        value.line_number(),
+                        definition_name_with_arguments,
+                        loop_object_name_and_kind,
+                    ))
+                    .ok()
+                    .map(|v| v.into_optional().map(|v| v.1))
+                    .flatten();
 
-                match expected_kind {
-                    Some(ekind)
-                        if !ekind.kind.is_same_as(&found_kind.kind)
-                            && (ekind.kind.ref_inner().is_record()
-                                || ekind.kind.ref_inner().is_or_type()) =>
-                    {
-                        return Ok(PropertyValue::value_from_ast_value(
-                            value,
-                            doc,
-                            mutable,
-                            expected_kind,
-                            definition_name_with_arguments,
-                            loop_object_name_and_kind,
-                        )?
-                        .map(Some));
+                    if let Some(found_kind) = found_kind {
+                        match expected_kind {
+                            Some(ekind)
+                                if !ekind.kind.is_same_as(&found_kind.kind)
+                                    && (ekind.kind.ref_inner().is_record()
+                                        || ekind.kind.ref_inner().is_or_type()) =>
+                            {
+                                return Ok(PropertyValue::value_from_ast_value(
+                                    value,
+                                    doc,
+                                    mutable,
+                                    expected_kind,
+                                    definition_name_with_arguments,
+                                    loop_object_name_and_kind,
+                                )?
+                                .map(Some));
+                            }
+                            Some(ekind) if !ekind.kind.is_same_as(&found_kind.kind) => {
+                                return ftd::interpreter::utils::e2(
+                                    format!(
+                                        "3 Expected kind `{:?}`, found: `{:?}`",
+                                        ekind, found_kind
+                                    )
+                                    .as_str(),
+                                    doc.name,
+                                    value.line_number(),
+                                );
+                            }
+                            _ => {}
+                        }
+                        let kind = get_kind(expected_kind, &found_kind);
+
+                        return Ok(ftd::interpreter::StateWithThing::new_thing(Some(
+                            ftd::interpreter::PropertyValue::Reference {
+                                name: reference,
+                                kind: kind.to_owned(),
+                                source: PropertyValueSource::Global,
+                                is_mutable: false,
+                                line_number: 0,
+                            },
+                        )));
                     }
-                    Some(ekind) if !ekind.kind.is_same_as(&found_kind.kind) => {
-                        return ftd::interpreter::utils::e2(
-                            format!("3 Expected kind `{:?}`, found: `{:?}`", ekind, found_kind)
-                                .as_str(),
-                            doc.name,
-                            value.line_number(),
-                        )
-                    }
-                    _ => {}
                 }
-                let kind = get_kind(expected_kind, &found_kind);
-
-                Ok(ftd::interpreter::StateWithThing::new_thing(Some(
-                    ftd::interpreter::PropertyValue::Reference {
-                        name: reference,
-                        kind: kind.to_owned(),
-                        source: PropertyValueSource::Global,
-                        is_mutable: false,
-                        line_number: 0,
-                    },
-                )))
+                if let Some(kind) = expected_kind {
+                    Ok(ftd::interpreter::StateWithThing::new_thing(Some(
+                        ftd::interpreter::PropertyValue::Reference {
+                            name: expression.trim_start_matches('$').to_string(),
+                            kind: kind.to_owned(),
+                            source: PropertyValueSource::Global,
+                            is_mutable: false,
+                            line_number: 0,
+                        },
+                    )))
+                } else {
+                    ftd::interpreter::utils::e2("Kind not found", doc.name, value.line_number())
+                }
             }
             Ok(expression) if expression.eq(ftd::interpreter::FTD_SPECIAL_VALUE) => {
                 Ok(ftd::interpreter::StateWithThing::new_thing(Some(

--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -1025,8 +1025,7 @@ impl PropertyValue {
                         loop_object_name_and_kind,
                     ))
                     .ok()
-                    .map(|v| v.into_optional().map(|v| v.1))
-                    .flatten();
+                    .and_then(|v| v.into_optional().map(|v| v.1));
 
                     if let Some(found_kind) = found_kind {
                         match expected_kind {

--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -1010,19 +1010,54 @@ impl PropertyValue {
                 if expression
                     .starts_with(format!("${}.", ftd::interpreter::FTD_INHERITED).as_str()) =>
             {
-                if let Some(kind) = expected_kind {
-                    Ok(ftd::interpreter::StateWithThing::new_thing(Some(
-                        ftd::interpreter::PropertyValue::Reference {
-                            name: expression.trim_start_matches('$').to_string(),
-                            kind: kind.to_owned(),
-                            source: PropertyValueSource::Global,
-                            is_mutable: false,
-                            line_number: 0,
-                        },
-                    )))
-                } else {
-                    ftd::interpreter::utils::e2("Kind not found", doc.name, value.line_number())
+                let reference = expression
+                    .trim_start_matches(ftd::interpreter::utils::REFERENCE)
+                    .to_string();
+
+                let (_, found_kind, _) = try_ok_state!(doc.get_kind_with_argument(
+                    reference.as_str(),
+                    value.line_number(),
+                    definition_name_with_arguments,
+                    loop_object_name_and_kind,
+                )?);
+
+                match expected_kind {
+                    Some(ekind)
+                        if !ekind.kind.is_same_as(&found_kind.kind)
+                            && (ekind.kind.ref_inner().is_record()
+                                || ekind.kind.ref_inner().is_or_type()) =>
+                    {
+                        return Ok(PropertyValue::value_from_ast_value(
+                            value,
+                            doc,
+                            mutable,
+                            expected_kind,
+                            definition_name_with_arguments,
+                            loop_object_name_and_kind,
+                        )?
+                        .map(Some));
+                    }
+                    Some(ekind) if !ekind.kind.is_same_as(&found_kind.kind) => {
+                        return ftd::interpreter::utils::e2(
+                            format!("3 Expected kind `{:?}`, found: `{:?}`", ekind, found_kind)
+                                .as_str(),
+                            doc.name,
+                            value.line_number(),
+                        )
+                    }
+                    _ => {}
                 }
+                let kind = get_kind(expected_kind, &found_kind);
+
+                Ok(ftd::interpreter::StateWithThing::new_thing(Some(
+                    ftd::interpreter::PropertyValue::Reference {
+                        name: reference,
+                        kind: kind.to_owned(),
+                        source: PropertyValueSource::Global,
+                        is_mutable: false,
+                        line_number: 0,
+                    },
+                )))
             }
             Ok(expression) if expression.eq(ftd::interpreter::FTD_SPECIAL_VALUE) => {
                 Ok(ftd::interpreter::StateWithThing::new_thing(Some(

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -799,6 +799,7 @@ impl Container {
         rdata: &ftd::js::ResolverData,
         component_name: &str,
         has_rive_components: &mut bool,
+        should_return: bool,
     ) -> Vec<fastn_js::ComponentStatement> {
         let mut component_statements = vec![];
 
@@ -824,6 +825,7 @@ impl Container {
                     doc,
                     &rdata.clone_with_new_inherited_variable(&inherited_variable_name),
                     has_rive_components,
+                    should_return,
                 ),
                 element_name: component_name.to_string(),
                 inherited: inherited_variable_name.to_string(),
@@ -1203,6 +1205,7 @@ impl Document {
             rdata,
             kernel.name.as_str(),
             has_rive_components,
+            false,
         ));
 
         component_statements.extend(self.metadata.to_component_statements(
@@ -1458,6 +1461,7 @@ impl Column {
             rdata,
             kernel.name.as_str(),
             has_rive_components,
+            false,
         ));
 
         if should_return {
@@ -1524,6 +1528,7 @@ impl Row {
             rdata,
             kernel.name.as_str(),
             has_rive_components,
+            false,
         ));
 
         if should_return {
@@ -1585,6 +1590,7 @@ impl ContainerElement {
             rdata,
             kernel.name.as_str(),
             has_rive_components,
+            false,
         ));
 
         if should_return {
@@ -1647,6 +1653,7 @@ impl Device {
             &rdata.clone_with_new_device(&Some(self.device.clone())),
             kernel.name.as_str(),
             has_rive_components,
+            true,
         ));
         component_statements.push(fastn_js::ComponentStatement::Return {
             component_name: kernel.name,

--- a/ftd/src/js/mod.rs
+++ b/ftd/src/js/mod.rs
@@ -346,9 +346,11 @@ impl ftd::interpreter::Component {
 
         if let Some(iteration) = self.iteration.as_ref() {
             component_statements = vec![fastn_js::ComponentStatement::ForLoop(fastn_js::ForLoop {
-                list_variable: iteration
-                    .on
-                    .to_fastn_js_value(doc, &rdata.clone_with_new_loop_alias(&loop_alias)),
+                list_variable: iteration.on.to_fastn_js_value(
+                    doc,
+                    &rdata.clone_with_new_loop_alias(&loop_alias),
+                    false,
+                ),
                 statements: component_statements,
                 parent: parent.to_string(),
                 should_return,

--- a/ftd/src/js/utils.rs
+++ b/ftd/src/js/utils.rs
@@ -93,6 +93,7 @@ pub(crate) fn update_reference_with_none(reference: &str) -> String {
 
 pub(crate) fn update_reference(reference: &str, rdata: &ftd::js::ResolverData) -> String {
     let name = reference.to_string();
+    dbg!(&name);
 
     if let Some(component_definition_name) = rdata.component_definition_name {
         if let Some(alias) = name.strip_prefix(format!("{component_definition_name}.").as_str()) {

--- a/ftd/src/js/value.rs
+++ b/ftd/src/js/value.rs
@@ -13,7 +13,12 @@ impl Value {
         doc: &ftd::interpreter::TDoc,
         has_rive_components: &mut bool,
     ) -> fastn_js::SetPropertyValue {
-        self.to_set_property_value_with_ui(doc, &ftd::js::ResolverData::none(), has_rive_components)
+        self.to_set_property_value_with_ui(
+            doc,
+            &ftd::js::ResolverData::none(),
+            has_rive_components,
+            false,
+        )
     }
 
     pub(crate) fn to_set_property_value(
@@ -21,7 +26,7 @@ impl Value {
         doc: &ftd::interpreter::TDoc,
         rdata: &ftd::js::ResolverData,
     ) -> fastn_js::SetPropertyValue {
-        self.to_set_property_value_with_ui(doc, rdata, &mut false)
+        self.to_set_property_value_with_ui(doc, rdata, &mut false, false)
     }
 
     pub(crate) fn to_set_property_value_with_ui(
@@ -29,9 +34,12 @@ impl Value {
         doc: &ftd::interpreter::TDoc,
         rdata: &ftd::js::ResolverData,
         has_rive_components: &mut bool,
+        should_return: bool,
     ) -> fastn_js::SetPropertyValue {
         match self {
-            Value::Data(value) => value.to_fastn_js_value(doc, rdata, has_rive_components),
+            Value::Data(value) => {
+                value.to_fastn_js_value(doc, rdata, has_rive_components, should_return)
+            }
             Value::Reference(name) => {
                 fastn_js::SetPropertyValue::Reference(ftd::js::utils::update_reference(name, rdata))
             }
@@ -94,7 +102,7 @@ fn properties_to_js_conditional_formula(
                 .condition
                 .as_ref()
                 .map(|condition| condition.update_node_with_variable_reference_js(rdata)),
-            expression: property.value.to_fastn_js_value(doc, rdata),
+            expression: property.value.to_fastn_js_value(doc, rdata, false),
         });
     }
 
@@ -246,15 +254,21 @@ impl ftd::interpreter::PropertyValue {
         doc: &ftd::interpreter::TDoc,
         has_rive_components: &mut bool,
     ) -> fastn_js::SetPropertyValue {
-        self.to_fastn_js_value_with_ui(doc, &ftd::js::ResolverData::none(), has_rive_components)
+        self.to_fastn_js_value_with_ui(
+            doc,
+            &ftd::js::ResolverData::none(),
+            has_rive_components,
+            false,
+        )
     }
 
     pub(crate) fn to_fastn_js_value(
         &self,
         doc: &ftd::interpreter::TDoc,
         rdata: &ftd::js::ResolverData,
+        should_return: bool,
     ) -> fastn_js::SetPropertyValue {
-        self.to_fastn_js_value_with_ui(doc, rdata, &mut false)
+        self.to_fastn_js_value_with_ui(doc, rdata, &mut false, should_return)
     }
 
     pub(crate) fn to_fastn_js_value_with_ui(
@@ -262,9 +276,14 @@ impl ftd::interpreter::PropertyValue {
         doc: &ftd::interpreter::TDoc,
         rdata: &ftd::js::ResolverData,
         has_rive_components: &mut bool,
+        should_return: bool,
     ) -> fastn_js::SetPropertyValue {
-        self.to_value()
-            .to_set_property_value_with_ui(doc, rdata, has_rive_components)
+        self.to_value().to_set_property_value_with_ui(
+            doc,
+            rdata,
+            has_rive_components,
+            should_return,
+        )
     }
 
     pub(crate) fn to_value(&self) -> ftd::js::Value {
@@ -291,6 +310,7 @@ impl ftd::interpreter::Value {
         doc: &ftd::interpreter::TDoc,
         rdata: &ftd::js::ResolverData,
         has_rive_components: &mut bool,
+        should_return: bool,
     ) -> fastn_js::SetPropertyValue {
         use itertools::Itertools;
 
@@ -300,7 +320,7 @@ impl ftd::interpreter::Value {
             }
             ftd::interpreter::Value::Optional { data, .. } => {
                 if let Some(data) = data.as_ref() {
-                    data.to_fastn_js_value(doc, rdata, has_rive_components)
+                    data.to_fastn_js_value(doc, rdata, has_rive_components, should_return)
                 } else {
                     fastn_js::SetPropertyValue::Value(fastn_js::Value::Null)
                 }
@@ -324,7 +344,7 @@ impl ftd::interpreter::Value {
                 if has_value {
                     return fastn_js::SetPropertyValue::Value(fastn_js::Value::OrType {
                         variant: js_variant,
-                        value: Some(Box::new(value.to_fastn_js_value(doc, rdata))),
+                        value: Some(Box::new(value.to_fastn_js_value(doc, rdata, should_return))),
                     });
                 }
                 fastn_js::SetPropertyValue::Value(fastn_js::Value::OrType {
@@ -336,7 +356,14 @@ impl ftd::interpreter::Value {
                 fastn_js::SetPropertyValue::Value(fastn_js::Value::List {
                     value: data
                         .iter()
-                        .map(|v| v.to_fastn_js_value_with_ui(doc, rdata, has_rive_components))
+                        .map(|v| {
+                            v.to_fastn_js_value_with_ui(
+                                doc,
+                                rdata,
+                                has_rive_components,
+                                should_return,
+                            )
+                        })
                         .collect_vec(),
                 })
             }
@@ -344,7 +371,12 @@ impl ftd::interpreter::Value {
                 fastn_js::SetPropertyValue::Value(fastn_js::Value::Record {
                     fields: fields
                         .iter()
-                        .map(|(k, v)| (k.to_string(), v.to_fastn_js_value(doc, rdata)))
+                        .map(|(k, v)| {
+                            (
+                                k.to_string(),
+                                v.to_fastn_js_value(doc, rdata, should_return),
+                            )
+                        })
                         .collect_vec(),
                 })
             }
@@ -355,7 +387,7 @@ impl ftd::interpreter::Value {
                         0,
                         doc,
                         &rdata.clone_with_default_inherited_variable(),
-                        false,
+                        should_return,
                         has_rive_components,
                     ),
                 })

--- a/ftd/t/html/55-inherited.ftd
+++ b/ftd/t/html/55-inherited.ftd
@@ -1,4 +1,4 @@
--- string inherited-name: $inherited.name
+/-- string inherited-name: $inherited.name
 
 -- ftd.column:
 colors: $main
@@ -16,10 +16,10 @@ color: $inherited.colors.background.step-1
 
 
 
--- foo:
+/-- foo:
 name: Foo
 
--- ftd.text: $inherited-name
+-- ftd.text: $inherited.name
 -- bar:
 
 -- foo:
@@ -40,21 +40,21 @@ name: FOO2
 -- end: foo
 
 
--- pink-block:
+/-- pink-block:
 
 -- render-title:
 
 -- end: pink-block
 
 
--- orange-block:
+/-- orange-block:
 
 -- render-title:
 
 -- end: orange-block
 
 
--- green-block:
+/-- green-block:
 
 -- render-title:
 

--- a/ftd/t/html/55-inherited.ftd
+++ b/ftd/t/html/55-inherited.ftd
@@ -1,4 +1,4 @@
-/-- string inherited-name: $inherited.name
+-- string inherited-name: $inherited.name
 
 -- ftd.column:
 colors: $main
@@ -16,7 +16,7 @@ color: $inherited.colors.background.step-1
 
 
 
-/-- foo:
+-- foo:
 name: Foo
 
 -- ftd.text: $inherited.name
@@ -40,21 +40,22 @@ name: FOO2
 -- end: foo
 
 
-/-- pink-block:
+
+-- pink-block:
 
 -- render-title:
 
 -- end: pink-block
 
 
-/-- orange-block:
+-- orange-block:
 
 -- render-title:
 
 -- end: orange-block
 
 
-/-- green-block:
+-- green-block:
 
 -- render-title:
 

--- a/ftd/t/html/55-inherited.html
+++ b/ftd/t/html/55-inherited.html
@@ -474,15 +474,6 @@
 "dark": "#D84836",
 "light": "#D84836"
 },
-"foo#foo:name:1": "Foo",
-"foo#foo:name:1,1,2": "FOO2",
-"foo#foo:wrapper:1": [],
-"foo#foo:wrapper:1,1,2": [],
-"foo#green-block:title-color:4": {
-"dark": "darkgreen",
-"light": "darkgreen"
-},
-"foo#green-block:wrapper:4": [],
 "foo#info-base-": {
 "dark": "#233a5dc7",
 "light": "#DAE7FB"
@@ -821,20 +812,10 @@
 }
 }
 },
-"foo#orange-block:title-color:3": {
-"dark": "orange",
-"light": "orange"
-},
-"foo#orange-block:wrapper:3": [],
 "foo#overlay-": {
 "dark": "#000000",
 "light": "#000000"
 },
-"foo#pink-block:title-color:2": {
-"dark": "red",
-"light": "red"
-},
-"foo#pink-block:wrapper:2": [],
 "foo#scrim-": {
 "dark": "#393939",
 "light": "#393939"
@@ -1685,7 +1666,7 @@ margin-block-end: 1em;
 </head>
 <body style="height: 100%; margin: 0;">
 
-<div data-id="main" style="height: 100%; width: 100%" class="ft_common ft_column"><div data-id="0:main" style="" class="ft_common ft_column"><div data-id="0,0:main" style="color: rgba(0,0,255,1)" class="ft_common ft_md">Hello</div></div><div data-id="1:main" style="" class="ft_common ft_column"><div data-id="1,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1:main" style="" class="ft_common ft_column"><div data-id="1,1,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,1:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,2:main" style="" class="ft_common ft_column"><div data-id="1,1,2,0:main" style="" class="ft_common ft_md">FOO2</div><div data-id="1,1,2,1:main" style="" class="ft_common ft_column"><div data-id="1,1,2,1,0:main" style="" class="ft_common ft_md">FOO2</div><div data-id="1,1,2,1,1:main" style="" class="ft_common ft_md">FOO2</div></div></div><div data-id="1,1,3:main" style="" class="ft_common ft_column"><div data-id="1,1,3,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,3,1:main" style="" class="ft_common ft_md">Foo</div></div></div></div><div data-id="2:main" style="align-items: center; background-color: rgba(255,192,203,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="2,0:main" style="color: rgba(255,0,0,1)" class="ft_common ft_md">Title</div></div><div data-id="3:main" style="align-items: center; background-color: rgba(255,255,0,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="3,0:main" style="color: rgba(255,165,0,1)" class="ft_common ft_md">Title</div></div><div data-id="4:main" style="align-items: center; background-color: rgba(110,207,110,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="4,0:main" style="color: rgba(0,100,0,1)" class="ft_common ft_md">Title</div></div></div>
+<div data-id="main" style="height: 100%; width: 100%" class="ft_common ft_column"><div data-id="0:main" style="" class="ft_common ft_column"><div data-id="0,0:main" style="color: rgba(0,0,255,1)" class="ft_common ft_md">Hello</div></div></div>
 
 
 <script>
@@ -2905,86 +2886,7 @@ document.querySelector(`[data-id="0,0:main"]`).style["color"] = resolve_referenc
 }
 else {document.querySelector(`[data-id="0,0:main"]`).style["color"] = resolve_reference("foo#main.background.step-1", data).dark;}
 }
-window.node_change_main["1,0:main__text"] = function(data) {
-document.querySelector(`[data-id="1,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
-}
-window.node_change_main["1,1,0:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,0:main"]`).innerHTML = resolve_reference("foo#inherited-name", data);
-}
-window.node_change_main["1,1,1:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
-}
-window.node_change_main["1,1,2,0:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,2,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
-}
-window.node_change_main["1,1,2,1,0:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,2,1,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
-}
-window.node_change_main["1,1,2,1,1:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,2,1,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
-}
-window.node_change_main["1,1,3,0:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,3,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
-}
-window.node_change_main["1,1,3,1:main__text"] = function(data) {
-document.querySelector(`[data-id="1,1,3,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
-}
-window.node_change_main["2,0:main__color"] = function(data) {
-if(!data["ftd#dark-mode"]){
-document.querySelector(`[data-id="2,0:main"]`).style["color"] = resolve_reference("foo#pink-block:title-color:2", data).light;
-}
-else {document.querySelector(`[data-id="2,0:main"]`).style["color"] = resolve_reference("foo#pink-block:title-color:2", data).dark;}
-}
-window.node_change_main["3,0:main__color"] = function(data) {
-if(!data["ftd#dark-mode"]){
-document.querySelector(`[data-id="3,0:main"]`).style["color"] = resolve_reference("foo#orange-block:title-color:3", data).light;
-}
-else {document.querySelector(`[data-id="3,0:main"]`).style["color"] = resolve_reference("foo#orange-block:title-color:3", data).dark;}
-}
-window.node_change_main["4,0:main__color"] = function(data) {
-if(!data["ftd#dark-mode"]){
-document.querySelector(`[data-id="4,0:main"]`).style["color"] = resolve_reference("foo#green-block:title-color:4", data).light;
-}
-else {document.querySelector(`[data-id="4,0:main"]`).style["color"] = resolve_reference("foo#green-block:title-color:4", data).dark;}
-}
 window.set_value_main = {};
-window.set_value_main["foo#foo:name:1"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#foo:name:1", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#foo:name:1", "main");
-window.ftd.call_immutable_value_changes("foo#foo:name:1", "main");
-window.ftd.utils.node_change_call("main","1,0:main__text", data);
-window.ftd.utils.node_change_call("main","1,1,1:main__text", data);
-window.ftd.utils.node_change_call("main","1,1,3,0:main__text", data);
-window.ftd.utils.node_change_call("main","1,1,3,1:main__text", data);
-};
-
-window.set_value_main["foo#foo:name:1,1,2"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#foo:name:1,1,2", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#foo:name:1,1,2", "main");
-window.ftd.call_immutable_value_changes("foo#foo:name:1,1,2", "main");
-window.ftd.utils.node_change_call("main","1,1,2,0:main__text", data);
-window.ftd.utils.node_change_call("main","1,1,2,1,0:main__text", data);
-window.ftd.utils.node_change_call("main","1,1,2,1,1:main__text", data);
-};
-
-window.set_value_main["foo#green-block:title-color:4"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#green-block:title-color:4", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#green-block:title-color:4", "main");
-window.ftd.call_immutable_value_changes("foo#green-block:title-color:4", "main");
-window.ftd.utils.node_change_call("main","4,0:main__color", data);
-};
-
-window.set_value_main["foo#inherited-name"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#inherited-name", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#inherited-name", "main");
-window.ftd.call_immutable_value_changes("foo#inherited-name", "main");
-window.ftd.utils.node_change_call("main","1,1,0:main__text", data);
-};
-
 window.set_value_main["foo#main"] = function (data, new_value, remaining) {
 window.ftd.utils.set_value_helper(data, "foo#main", remaining, new_value);
 
@@ -2993,43 +2895,12 @@ window.ftd.call_immutable_value_changes("foo#main", "main");
 window.ftd.utils.node_change_call("main","0,0:main__color", data);
 };
 
-window.set_value_main["foo#orange-block:title-color:3"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#orange-block:title-color:3", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#orange-block:title-color:3", "main");
-window.ftd.call_immutable_value_changes("foo#orange-block:title-color:3", "main");
-window.ftd.utils.node_change_call("main","3,0:main__color", data);
-};
-
-window.set_value_main["foo#pink-block:title-color:2"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "foo#pink-block:title-color:2", remaining, new_value);
-
-window.ftd.call_mutable_value_changes("foo#pink-block:title-color:2", "main");
-window.ftd.call_immutable_value_changes("foo#pink-block:title-color:2", "main");
-window.ftd.utils.node_change_call("main","2,0:main__color", data);
-};
-
 window.set_value_main["ftd#dark-mode"] = function (data, new_value, remaining) {
 window.ftd.utils.set_value_helper(data, "ftd#dark-mode", remaining, new_value);
 
 window.ftd.call_mutable_value_changes("ftd#dark-mode", "main");
 window.ftd.call_immutable_value_changes("ftd#dark-mode", "main");
 window.ftd.utils.node_change_call("main","0,0:main__color", data);
-window.ftd.utils.node_change_call("main","2,0:main__color", data);
-window.ftd.utils.node_change_call("main","3,0:main__color", data);
-window.ftd.utils.node_change_call("main","4,0:main__color", data);
-};
-
-window.set_value_main["inherited.name"] = function (data, new_value, remaining) {
-window.ftd.utils.set_value_helper(data, "inherited.name", remaining, new_value);
-if(!!window["resolve_value_main"] && !!window["resolve_value_main"]["foo#inherited-name"]){window["resolve_value_main"]["foo#inherited-name"](data);
-} else {
-let value = resolve_reference("inherited.name", data, null);
-set_data_value(data, "foo#inherited-name", value);
-}
-window.ftd.call_mutable_value_changes("inherited.name", "main");
-window.ftd.call_immutable_value_changes("inherited.name", "main");
-window.ftd.utils.node_change_call("main","1,1,0:main__text", data);
 };
 
 

--- a/ftd/t/html/55-inherited.html
+++ b/ftd/t/html/55-inherited.html
@@ -474,6 +474,15 @@
 "dark": "#D84836",
 "light": "#D84836"
 },
+"foo#foo:name:1": "Foo",
+"foo#foo:name:1,1,2": "FOO2",
+"foo#foo:wrapper:1": [],
+"foo#foo:wrapper:1,1,2": [],
+"foo#green-block:title-color:4": {
+"dark": "darkgreen",
+"light": "darkgreen"
+},
+"foo#green-block:wrapper:4": [],
 "foo#info-base-": {
 "dark": "#233a5dc7",
 "light": "#DAE7FB"
@@ -812,10 +821,20 @@
 }
 }
 },
+"foo#orange-block:title-color:3": {
+"dark": "orange",
+"light": "orange"
+},
+"foo#orange-block:wrapper:3": [],
 "foo#overlay-": {
 "dark": "#000000",
 "light": "#000000"
 },
+"foo#pink-block:title-color:2": {
+"dark": "red",
+"light": "red"
+},
+"foo#pink-block:wrapper:2": [],
 "foo#scrim-": {
 "dark": "#393939",
 "light": "#393939"
@@ -1666,7 +1685,7 @@ margin-block-end: 1em;
 </head>
 <body style="height: 100%; margin: 0;">
 
-<div data-id="main" style="height: 100%; width: 100%" class="ft_common ft_column"><div data-id="0:main" style="" class="ft_common ft_column"><div data-id="0,0:main" style="color: rgba(0,0,255,1)" class="ft_common ft_md">Hello</div></div></div>
+<div data-id="main" style="height: 100%; width: 100%" class="ft_common ft_column"><div data-id="0:main" style="" class="ft_common ft_column"><div data-id="0,0:main" style="color: rgba(0,0,255,1)" class="ft_common ft_md">Hello</div></div><div data-id="1:main" style="" class="ft_common ft_column"><div data-id="1,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1:main" style="" class="ft_common ft_column"><div data-id="1,1,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,1:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,2:main" style="" class="ft_common ft_column"><div data-id="1,1,2,0:main" style="" class="ft_common ft_md">FOO2</div><div data-id="1,1,2,1:main" style="" class="ft_common ft_column"><div data-id="1,1,2,1,0:main" style="" class="ft_common ft_md">FOO2</div><div data-id="1,1,2,1,1:main" style="" class="ft_common ft_md">FOO2</div></div></div><div data-id="1,1,3:main" style="" class="ft_common ft_column"><div data-id="1,1,3,0:main" style="" class="ft_common ft_md">Foo</div><div data-id="1,1,3,1:main" style="" class="ft_common ft_md">Foo</div></div></div></div><div data-id="2:main" style="align-items: center; background-color: rgba(255,192,203,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="2,0:main" style="color: rgba(255,0,0,1)" class="ft_common ft_md">Title</div></div><div data-id="3:main" style="align-items: center; background-color: rgba(255,255,0,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="3,0:main" style="color: rgba(255,165,0,1)" class="ft_common ft_md">Title</div></div><div data-id="4:main" style="align-items: center; background-color: rgba(110,207,110,1); height: 100px; justify-content: center; width: 100px" class="ft_common ft_column"><div data-id="4,0:main" style="color: rgba(0,100,0,1)" class="ft_common ft_md">Title</div></div></div>
 
 
 <script>
@@ -2886,7 +2905,79 @@ document.querySelector(`[data-id="0,0:main"]`).style["color"] = resolve_referenc
 }
 else {document.querySelector(`[data-id="0,0:main"]`).style["color"] = resolve_reference("foo#main.background.step-1", data).dark;}
 }
+window.node_change_main["1,0:main__text"] = function(data) {
+document.querySelector(`[data-id="1,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
+}
+window.node_change_main["1,1,0:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
+}
+window.node_change_main["1,1,1:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
+}
+window.node_change_main["1,1,2,0:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,2,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
+}
+window.node_change_main["1,1,2,1,0:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,2,1,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
+}
+window.node_change_main["1,1,2,1,1:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,2,1,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1,1,2", data);
+}
+window.node_change_main["1,1,3,0:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,3,0:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
+}
+window.node_change_main["1,1,3,1:main__text"] = function(data) {
+document.querySelector(`[data-id="1,1,3,1:main"]`).innerHTML = resolve_reference("foo#foo:name:1", data);
+}
+window.node_change_main["2,0:main__color"] = function(data) {
+if(!data["ftd#dark-mode"]){
+document.querySelector(`[data-id="2,0:main"]`).style["color"] = resolve_reference("foo#pink-block:title-color:2", data).light;
+}
+else {document.querySelector(`[data-id="2,0:main"]`).style["color"] = resolve_reference("foo#pink-block:title-color:2", data).dark;}
+}
+window.node_change_main["3,0:main__color"] = function(data) {
+if(!data["ftd#dark-mode"]){
+document.querySelector(`[data-id="3,0:main"]`).style["color"] = resolve_reference("foo#orange-block:title-color:3", data).light;
+}
+else {document.querySelector(`[data-id="3,0:main"]`).style["color"] = resolve_reference("foo#orange-block:title-color:3", data).dark;}
+}
+window.node_change_main["4,0:main__color"] = function(data) {
+if(!data["ftd#dark-mode"]){
+document.querySelector(`[data-id="4,0:main"]`).style["color"] = resolve_reference("foo#green-block:title-color:4", data).light;
+}
+else {document.querySelector(`[data-id="4,0:main"]`).style["color"] = resolve_reference("foo#green-block:title-color:4", data).dark;}
+}
 window.set_value_main = {};
+window.set_value_main["foo#foo:name:1"] = function (data, new_value, remaining) {
+window.ftd.utils.set_value_helper(data, "foo#foo:name:1", remaining, new_value);
+
+window.ftd.call_mutable_value_changes("foo#foo:name:1", "main");
+window.ftd.call_immutable_value_changes("foo#foo:name:1", "main");
+window.ftd.utils.node_change_call("main","1,0:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,0:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,1:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,3,0:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,3,1:main__text", data);
+};
+
+window.set_value_main["foo#foo:name:1,1,2"] = function (data, new_value, remaining) {
+window.ftd.utils.set_value_helper(data, "foo#foo:name:1,1,2", remaining, new_value);
+
+window.ftd.call_mutable_value_changes("foo#foo:name:1,1,2", "main");
+window.ftd.call_immutable_value_changes("foo#foo:name:1,1,2", "main");
+window.ftd.utils.node_change_call("main","1,1,2,0:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,2,1,0:main__text", data);
+window.ftd.utils.node_change_call("main","1,1,2,1,1:main__text", data);
+};
+
+window.set_value_main["foo#green-block:title-color:4"] = function (data, new_value, remaining) {
+window.ftd.utils.set_value_helper(data, "foo#green-block:title-color:4", remaining, new_value);
+
+window.ftd.call_mutable_value_changes("foo#green-block:title-color:4", "main");
+window.ftd.call_immutable_value_changes("foo#green-block:title-color:4", "main");
+window.ftd.utils.node_change_call("main","4,0:main__color", data);
+};
+
 window.set_value_main["foo#main"] = function (data, new_value, remaining) {
 window.ftd.utils.set_value_helper(data, "foo#main", remaining, new_value);
 
@@ -2895,12 +2986,31 @@ window.ftd.call_immutable_value_changes("foo#main", "main");
 window.ftd.utils.node_change_call("main","0,0:main__color", data);
 };
 
+window.set_value_main["foo#orange-block:title-color:3"] = function (data, new_value, remaining) {
+window.ftd.utils.set_value_helper(data, "foo#orange-block:title-color:3", remaining, new_value);
+
+window.ftd.call_mutable_value_changes("foo#orange-block:title-color:3", "main");
+window.ftd.call_immutable_value_changes("foo#orange-block:title-color:3", "main");
+window.ftd.utils.node_change_call("main","3,0:main__color", data);
+};
+
+window.set_value_main["foo#pink-block:title-color:2"] = function (data, new_value, remaining) {
+window.ftd.utils.set_value_helper(data, "foo#pink-block:title-color:2", remaining, new_value);
+
+window.ftd.call_mutable_value_changes("foo#pink-block:title-color:2", "main");
+window.ftd.call_immutable_value_changes("foo#pink-block:title-color:2", "main");
+window.ftd.utils.node_change_call("main","2,0:main__color", data);
+};
+
 window.set_value_main["ftd#dark-mode"] = function (data, new_value, remaining) {
 window.ftd.utils.set_value_helper(data, "ftd#dark-mode", remaining, new_value);
 
 window.ftd.call_mutable_value_changes("ftd#dark-mode", "main");
 window.ftd.call_immutable_value_changes("ftd#dark-mode", "main");
 window.ftd.utils.node_change_call("main","0,0:main__color", data);
+window.ftd.utils.node_change_call("main","2,0:main__color", data);
+window.ftd.utils.node_change_call("main","3,0:main__color", data);
+window.ftd.utils.node_change_call("main","4,0:main__color", data);
 };
 
 

--- a/ftd/t/js/01-basic.ftd
+++ b/ftd/t/js/01-basic.ftd
@@ -1,4 +1,4 @@
--- ftd.text: Hello
+-- ftd.text: "Hello"
 
 -- ftd.text: Hello
 background.solid: $inherited.colors.background.step-1

--- a/ftd/t/js/01-basic.ftd
+++ b/ftd/t/js/01-basic.ftd
@@ -1,5 +1,15 @@
 -- ftd.text: Hello
 
+-- ftd.text: Hello
+background.solid: $inherited.colors.background.step-1
+
+-- ftd.text: Hello
+background.solid: $bg-og
+
+-- ftd.color bg-og:
+light: yellow
+dark: green
+
 -- string append(a,b):
 string a:
 string b:

--- a/ftd/t/js/01-basic.html
+++ b/ftd/t/js/01-basic.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2">Hello</div><div data-id="3" class="bgc-1">Hello</div><div data-id="4" class="bgc-2">Hello</div></body><style id="styles">
+<body data-id="1"><div data-id="2">"Hello"</div><div data-id="3" class="bgc-1">Hello</div><div data-id="4" class="bgc-2">Hello</div></body><style id="styles">
     .bgc-1 { background-color: #f3f3f3; }
 	body.dark .bgc-1 { background-color: #141414; }
 	.bgc-2 { background-color: yellow; }
@@ -19,7 +19,7 @@
 };
 let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
-  parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
+  parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "\"Hello\"", inherited);
   let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
   parenti1.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("step_1")), inherited);

--- a/ftd/t/js/01-basic.html
+++ b/ftd/t/js/01-basic.html
@@ -7,13 +7,11 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="bgc-1">Hello</div><div data-id="3" class="bgc-2">Hello</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.bgc-1 { background-color: #f3f3f3; }
+<body data-id="1"><div data-id="2">Hello</div><div data-id="3" class="bgc-1">Hello</div><div data-id="4" class="bgc-2">Hello</div></body><style id="styles">
+    .bgc-1 { background-color: #f3f3f3; }
 	body.dark .bgc-1 { background-color: #141414; }
-	.bgc-2 { background-color: #170d03; }
-	body.dark .bgc-2 { background-color: #edfce8; }
+	.bgc-2 { background-color: yellow; }
+	body.dark .bgc-2 { background-color: green; }
     </style>
 <script>
     (function() {
@@ -22,14 +20,16 @@
 let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
-  parenti0.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("step_1")), inherited);
   let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
-  parenti1.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(global.foo__bg_og), inherited);
+  parenti1.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("step_1")), inherited);
+  let parenti2 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti2.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
+  parenti2.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(global.foo__bg_og), inherited);
 }
 fastn_utils.createNestedObject(global, "foo__bg_og", fastn.recordInstance({
-  light: "#170d03",
-  dark: "#edfce8"
+  light: "yellow",
+  dark: "green"
 }));
 
         fastn_virtual.hydrate(main);

--- a/ftd/t/js/01-basic.html
+++ b/ftd/t/js/01-basic.html
@@ -7,9 +7,13 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2">Hello</div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="bgc-1">Hello</div><div data-id="3" class="bgc-2">Hello</div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+	.bgc-1 { background-color: #f3f3f3; }
+	body.dark .bgc-1 { background-color: #141414; }
+	.bgc-2 { background-color: #170d03; }
+	body.dark .bgc-2 { background-color: #edfce8; }
     </style>
 <script>
     (function() {
@@ -18,7 +22,15 @@
 let main = function (parent) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
+  parenti0.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("step_1")), inherited);
+  let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
+  parenti1.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(global.foo__bg_og), inherited);
 }
+fastn_utils.createNestedObject(global, "foo__bg_og", fastn.recordInstance({
+  light: "#170d03",
+  dark: "#edfce8"
+}));
 
         fastn_virtual.hydrate(main);
         ftd.post_init();

--- a/ftd/t/js/02-property.html
+++ b/ftd/t/js/02-property.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="w-1">Hello</div><div data-id="3" class="w-2">Hello 30</div><div data-id="4" class="w-1">Hello 20</div><div data-id="5" class="w-3">fill-container</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 20px; }
+    .w-1 { width: 20px; }
 	.w-2 { width: 30px; }
 	.w-3 { width: 100%; }
     </style>

--- a/ftd/t/js/03-common-properties.html
+++ b/ftd/t/js/03-common-properties.html
@@ -73,9 +73,7 @@ She smiled, and smiled, and passed it off Ere from the door she stept-</div><div
 
 'It was a wicked woman's curse,' Quoth she, 'and what care I?'
 She smiled, and smiled, and passed it off Ere from the door she stept-</div></div><div data-id="131" class="ft_column w-57"><div data-id="132" class="as-125 c-126">Start</div><div data-id="133" class="as-127 c-126">Center</div><div data-id="134" class="as-128 c-126">End</div></div><div data-id="135" class="a,b,c,d c-126">This is text with class</div><div data-id="136" class="ft_column w-129 p-58 m-110 bw-49 bs-23 bc-40"><div data-id="137" class="ft_column w-120 p-58 bw-49 bs-23 bc-130"><div data-id="138" class="pos-131 t-71 l-132 c-133">Inside Inner Container</div></div></div><div data-id="139" class="ft_column w-129 p-58 m-110 bw-49 bs-23 bc-40"><div data-id="140" class="ft_column w-120 p-58 bw-49 bs-23 bc-134"><div data-id="141" class="pos-131 t-71 l-132 c-98">Inside Outer Container</div></div></div><div data-id="142" class="ft_row w-1 jc-94"><div data-id="143">32</div><div data-id="144">1.123</div><div data-id="145">true</div></div><div data-id="146" class="ft_column w-1 bgc-135"><div data-id="147" class="c-126 fst-136 fwt-137">These are stylized values</div><div data-id="148" class="c-126 fwt-138">1234</div><div data-id="149" class="c-126 td-139 fst-136">3.142</div><div data-id="150" class="c-126 fwt-140">true</div></div><div data-id="151" class="ft_column w-1 m-141"><h1 data-id="152" class="c-98">Hello World</h1></div><div data-id="153" class="ft_column w-66 m-141 bw-49 bs-23 bc-40 c-133 ali-115"><div data-id="154">One</div><div data-id="155">Two</div><div data-id="156">Three</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.bgc-2 { background-color: yellow; }
 	body.dark .bgc-2 { background-color: lightgreen; }
 	.p-3 { padding: 10px; }

--- a/ftd/t/js/04-variable.html
+++ b/ftd/t/js/04-variable.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="m-2">Arpita</div><div data-id="3" class="ft_column"><div data-id="4">Foo says Hello</div><div data-id="5">Foo 2</div></div><comment data-id="6"></comment><div data-id="7">Click me to add Tom</div><comment data-id="8"></comment><div data-id="9">End</div><comment data-id="10"></comment></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.m-2 { margin: 9px; }
+    .m-2 { margin: 9px; }
     </style>
 <script>
     (function() {

--- a/ftd/t/js/04-variable.html
+++ b/ftd/t/js/04-variable.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="m-2">Arpita</div><div data-id="3" class="ft_column"><div data-id="4">Foo says Hello</div><div data-id="5">Foo 2</div></div><div data-id="6"></div><div data-id="7">Click me to add Tom</div><div data-id="8"></div><div data-id="9">End</div><div data-id="10"></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="m-2">Arpita</div><div data-id="3" class="ft_column"><div data-id="4">Foo says Hello</div><div data-id="5">Foo 2</div></div><comment data-id="6"></comment><div data-id="7">Click me to add Tom</div><comment data-id="8"></comment><div data-id="9">End</div><comment data-id="10"></comment></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
 	.m-2 { margin: 9px; }

--- a/ftd/t/js/05-dynamic-dom-list.html
+++ b/ftd/t/js/05-dynamic-dom-list.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">0</div><div data-id="3">Click to change value</div><div data-id="4">Click to add one</div><comment data-id="5"></comment></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/05-dynamic-dom-list.html
+++ b/ftd/t/js/05-dynamic-dom-list.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2">0</div><div data-id="3">Click to change value</div><div data-id="4">Click to add one</div><div data-id="5"></div></body><style id="styles">
+<body data-id="1"><div data-id="2">0</div><div data-id="3">Click to change value</div><div data-id="4">Click to add one</div><comment data-id="5"></comment></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>

--- a/ftd/t/js/06-dynamic-dom-list-2.html
+++ b/ftd/t/js/06-dynamic-dom-list-2.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2">Click to add Tom</div><div data-id="3">update $first</div><div data-id="4"><div data-id="5" class="ft_column"><div data-id="6">hello</div><div data-id="7">0</div></div><div data-id="8" class="ft_column"><div data-id="9">world</div><div data-id="10">1</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2">Click to add Tom</div><div data-id="3">update $first</div><comment data-id="4"></comment><div data-id="5" class="ft_column"><div data-id="6">hello</div><div data-id="7">0</div></div><div data-id="8" class="ft_column"><div data-id="9">world</div><div data-id="10">1</div></div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>

--- a/ftd/t/js/06-dynamic-dom-list-2.html
+++ b/ftd/t/js/06-dynamic-dom-list-2.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">Click to add Tom</div><div data-id="3">update $first</div><comment data-id="4"></comment><div data-id="5" class="ft_column"><div data-id="6">hello</div><div data-id="7">0</div></div><div data-id="8" class="ft_column"><div data-id="9">world</div><div data-id="10">1</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/07-dynamic-dom-record-list.html
+++ b/ftd/t/js/07-dynamic-dom-record-list.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2">Click to add Tom</div><div data-id="3"><div data-id="4" class="ft_column"><div data-id="5">Jill</div><div data-id="6">I am Jill</div><div data-id="7">0</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2">Click to add Tom</div><comment data-id="3"></comment><div data-id="4" class="ft_column"><div data-id="5">Jill</div><div data-id="6">I am Jill</div><div data-id="7">0</div></div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>

--- a/ftd/t/js/07-dynamic-dom-record-list.html
+++ b/ftd/t/js/07-dynamic-dom-record-list.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">Click to add Tom</div><comment data-id="3"></comment><div data-id="4" class="ft_column"><div data-id="5">Jill</div><div data-id="6">I am Jill</div><div data-id="7">0</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/08-inherited.html
+++ b/ftd/t/js/08-inherited.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="c-1 bgc-2">Hello from foo</div><div data-id="3" class="c-1 bgc-2">ftd.text says Hello</div><div data-id="4" class="ft_column w-3 h-4"><div data-id="5" class="ft_column w-3 h-5 bgc-6"><div data-id="6" class="c-7">Hello</div><div data-id="7" class="c-8 bgc-9">Hello from foo</div></div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.c-1 { color: #141414; }
+    .c-1 { color: #141414; }
 	body.dark .c-1 { color: #ffffff; }
 	.bgc-2 { background-color: #e7e7e4; }
 	body.dark .bgc-2 { background-color: #18181b; }

--- a/ftd/t/js/08-inherited.html
+++ b/ftd/t/js/08-inherited.html
@@ -7,18 +7,24 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="c-1">Hello from foo</div><div data-id="3" class="c-1">ftd.text says Hello</div><div data-id="4" class="ft_column w-2 h-3"><div data-id="5" class="ft_column w-2 h-4"><div data-id="6" class="c-5">Hello</div><div data-id="7" class="c-6">Hello from foo</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="c-1 bgc-2">Hello from foo</div><div data-id="3" class="c-1 bgc-2">ftd.text says Hello</div><div data-id="4" class="ft_column w-3 h-4"><div data-id="5" class="ft_column w-3 h-5 bgc-6"><div data-id="6" class="c-7">Hello</div><div data-id="7" class="c-8 bgc-9">Hello from foo</div></div></div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
 	.c-1 { color: #141414; }
 	body.dark .c-1 { color: #ffffff; }
-	.w-2 { width: 100%; }
-	.h-3 { height: 200px; }
-	.h-4 { height: 100%; }
-	.c-5 { color: #707070; }
-	body.dark .c-5 { color: #D9D9D9; }
-	.c-6 { color: #333333; }
-	body.dark .c-6 { color: #FFFFFF; }
+	.bgc-2 { background-color: #e7e7e4; }
+	body.dark .bgc-2 { background-color: #18181b; }
+	.w-3 { width: 100%; }
+	.h-4 { height: 200px; }
+	.h-5 { height: 100%; }
+	.bgc-6 { background-color: #FDFAF1; }
+	body.dark .bgc-6 { background-color: #111111; }
+	.c-7 { color: #707070; }
+	body.dark .c-7 { color: #D9D9D9; }
+	.c-8 { color: #333333; }
+	body.dark .c-8 { color: #FFFFFF; }
+	.bgc-9 { background-color: #FFFFFF; }
+	body.dark .bgc-9 { background-color: #000000; }
     </style>
 <script>
     (function() {
@@ -29,7 +35,7 @@ let main = function (parent) {
   let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "ftd.text says Hello", inherited);
   parenti1.setProperty(fastn_dom.PropertyKind.Color, inherited.get("colors").get("text_strong"), inherited);
-  parenti1.setProperty(fastn_dom.PropertyKind.Background, inherited.get("colors").get("background").get("base"), inherited);
+  parenti1.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("base")), inherited);
   let parenti2 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Column);
   parenti2.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
   parenti2.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.Fixed(fastn_dom.Length.Px(200)), inherited);
@@ -40,7 +46,7 @@ let main = function (parent) {
     let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Column);
     rooti0.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
     rooti0.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.FillContainer, inherited);
-    rooti0.setProperty(fastn_dom.PropertyKind.Background, inherited.get("colors").get("background").get("step_1"), inherited);
+    rooti0.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("step_1")), inherited);
     rooti0.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello", inherited);
@@ -68,7 +74,7 @@ let foo__foo = function (parent, inherited, args) {
   let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
   parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello from foo", inherited);
   parenti0.setProperty(fastn_dom.PropertyKind.Color, inherited.get("colors").get("text_strong"), inherited);
-  parenti0.setProperty(fastn_dom.PropertyKind.Background, inherited.get("colors").get("background").get("base"), inherited);
+  parenti0.setProperty(fastn_dom.PropertyKind.Background, fastn_dom.BackgroundStyle.Solid(inherited.get("colors").get("background").get("base")), inherited);
   return parenti0;
 }
 fastn_utils.createNestedObject(global, "foo__base_", fastn.recordInstance({

--- a/ftd/t/js/09-text-properties.html
+++ b/ftd/t/js/09-text-properties.html
@@ -19,9 +19,7 @@ leap into electronic typesetting, remaining essentially unchanged. It was
 popularised in the 1960s with the release of Letraset sheets containing
 Lorem Ipsum passages, and more recently with desktop publishing software
 like Aldus PageMaker including versions of Lorem Ipsum.</div></div><div data-id="15" class="d-32">This has block display</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.bw-2 { border-width: 2px; }
 	.bs-3 { border-style: double; }
 	.bc-4 { border-color: blue; }

--- a/ftd/t/js/10-color-test.html
+++ b/ftd/t/js/10-color-test.html
@@ -22,9 +22,7 @@ quisquam ab repellat molestiae qui quia repudiandae ut doloribus impedit.
 A repellendus sapiente id Quis doloremque qui Quis omnis in blanditiis tenetur
 quo esse dolor. 33 vitae modi ut voluptates distinctio est dicta temporibus est
 consectetur voluptatum et Quis inventore ab dignissimos amet?</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.bgc-2 { background-color: #170d03; }
 	body.dark .bgc-2 { background-color: #edfce8; }
 	.p-3 { padding: 40px; }

--- a/ftd/t/js/11-device.ftd
+++ b/ftd/t/js/11-device.ftd
@@ -1,3 +1,4 @@
+-- ftd.text: ====Start====
 -- ftd.desktop:
 
 -- ftd.text: Hello from desktop
@@ -5,9 +6,13 @@
 
 -- end: ftd.desktop
 
+-- ftd.text: ====Middle====
+
 -- ftd.mobile:
 
 -- ftd.text: Hello from mobile
 -- ftd.text: Hello again from mobile
 
 -- end: ftd.mobile
+
+-- ftd.text: ====End====

--- a/ftd/t/js/11-device.html
+++ b/ftd/t/js/11-device.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2"><div data-id="3"><div data-id="4">Hello from desktop</div><div data-id="5">Hello again from desktop</div></div></div><div data-id="6"></div></body><style id="styles">
+<body data-id="1"><comment data-id="2"></comment><div data-id="3"><div data-id="4">Hello from desktop</div><div data-id="5">Hello again from desktop</div></div><comment data-id="6"></comment></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>

--- a/ftd/t/js/11-device.html
+++ b/ftd/t/js/11-device.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">====Start====</div><comment data-id="3"></comment><div data-id="5">Hello from desktop</div><div data-id="6">Hello again from desktop</div><div data-id="7">====Middle====</div><comment data-id="8"></comment><div data-id="9">====End====</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/11-device.html
+++ b/ftd/t/js/11-device.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><comment data-id="2"></comment><div data-id="4">Hello from desktop</div><div data-id="5">Hello again from desktop</div><comment data-id="6"></comment></body><style id="styles">
+<body data-id="1"><div data-id="2">====Start====</div><comment data-id="3"></comment><div data-id="5">Hello from desktop</div><div data-id="6">Hello again from desktop</div><div data-id="7">====Middle====</div><comment data-id="8"></comment><div data-id="9">====End====</div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>
@@ -16,13 +16,15 @@
         let global = {
 };
 let main = function (parent) {
+  let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "====Start====", inherited);
   fastn_dom.conditionalDom(parent, [
     ftd.device
   ], function () {
     return (ftd.device.get() === "desktop");
   }, function (root) {
-    let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
-    rooti0.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
+    let rooti1 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
+    rooti1.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello from desktop", inherited);
       return rooti0;
@@ -33,15 +35,17 @@ let main = function (parent) {
       return rooti0;
     }
     ]), inherited);
-    return rooti0;
+    return rooti1;
   });
+  let parenti2 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti2.setProperty(fastn_dom.PropertyKind.StringValue, "====Middle====", inherited);
   fastn_dom.conditionalDom(parent, [
     ftd.device
   ], function () {
     return (ftd.device.get() === "mobile");
   }, function (root) {
-    let rooti1 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
-    rooti1.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
+    let rooti3 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
+    rooti3.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello from mobile", inherited);
       return rooti0;
@@ -52,8 +56,10 @@ let main = function (parent) {
       return rooti0;
     }
     ]), inherited);
-    return rooti1;
+    return rooti3;
   });
+  let parenti4 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+  parenti4.setProperty(fastn_dom.PropertyKind.StringValue, "====End====", inherited);
 }
 
         fastn_virtual.hydrate(main);

--- a/ftd/t/js/11-device.html
+++ b/ftd/t/js/11-device.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><comment data-id="2"></comment><div data-id="3"><div data-id="4">Hello from desktop</div><div data-id="5">Hello again from desktop</div></div><comment data-id="6"></comment></body><style id="styles">
+<body data-id="1"><comment data-id="2"></comment><div data-id="4">Hello from desktop</div><div data-id="5">Hello again from desktop</div><comment data-id="6"></comment></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
     </style>
@@ -21,14 +21,16 @@ let main = function (parent) {
   ], function () {
     return (ftd.device.get() === "desktop");
   }, function (root) {
-    let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Div);
+    let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
     rooti0.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello from desktop", inherited);
+      return rooti0;
     },
     function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello again from desktop", inherited);
+      return rooti0;
     }
     ]), inherited);
     return rooti0;
@@ -38,14 +40,16 @@ let main = function (parent) {
   ], function () {
     return (ftd.device.get() === "mobile");
   }, function (root) {
-    let rooti1 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Div);
+    let rooti1 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Wrapper);
     rooti1.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello from mobile", inherited);
+      return rooti0;
     },
     function (root, inherited) {
       let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
       rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Hello again from mobile", inherited);
+      return rooti0;
     }
     ]), inherited);
     return rooti1;

--- a/ftd/t/js/12-children.html
+++ b/ftd/t/js/12-children.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column w-1"><div data-id="3">My page</div><div data-id="4" class="ft_column c-2"><div data-id="5">Hello</div><div data-id="6">World</div></div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.c-2 { color: red; }
     </style>
 <script>

--- a/ftd/t/js/13-non-style-properties.html
+++ b/ftd/t/js/13-non-style-properties.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column w-1 ali-2"><a data-id="3" href="https://www.fastn.com" class="m-3">This is a link</a></div><div data-id="4" class="ft_column w-1 ali-2"><a data-id="5" href="https://www.fastn.com" target="_blank" class="m-3">This is a link (will open in new tab)</a></div><div data-id="6" class="ft_column w-1 mt-4 mb-5"><input data-id="7" type="checkbox" checked></input><input data-id="8" type="checkbox" checked="false" disabled></input></div><div data-id="9" class="ft_column w-1 mt-4 mb-5"><input data-id="10" placeholder="Enter some text"></input><textarea data-id="11" placeholder="Multiline input"></textarea><input data-id="12" type="password"></input><input data-id="13" placeholder="This would be disabled" disabled></input><input data-id="14" value="This is default text"></input></div><iframe data-id="15" loading="lazy" src="https://www.openstreetmap.org/export/embed.html?bbox=-0.004017949104309083%2C51.47612752641776%2C0.00030577182769775396%2C51.478569861898606&layer=mapnik"></iframe><div data-id="16" class="ft_column">-- ftd.text: Hello World</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.ali-2 { align-items: center; }
 	.m-3 { margin: 20px; }
 	.mt-4 { margin-top: 30px; }

--- a/ftd/t/js/14-code.html
+++ b/ftd/t/js/14-code.html
@@ -40,9 +40,7 @@ by humans is still a pretty neat idea of escalating knowledge throughout the
 universe.
 
 -- end: ftd.column</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: fit-content; }
+    .w-1 { width: fit-content; }
 	.bgc-2 { background-color: #0d260d; }
 	.role-3 {  font-family: sans-serif; font-size: 14px; font-weight: 400; line-height: 24px; }
 	body.mobile .role-3 {  font-family: sans-serif; font-size: 12px; font-weight: 400; line-height: 16px; }

--- a/ftd/t/js/15-function-call-in-property.html
+++ b/ftd/t/js/15-function-call-in-property.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="p-1">Hello</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.p-1 { padding: 4em; }
+    .p-1 { padding: 4em; }
     </style>
 <script>
     (function() {

--- a/ftd/t/js/16-container.html
+++ b/ftd/t/js/16-container.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2"><div data-id="3">Hello world</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/17-clone.html
+++ b/ftd/t/js/17-clone.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column w-1 p-2 g-3"><div data-id="3">Ritesh</div><div data-id="4">Ritesh</div><div data-id="5">Ritesh</div><div data-id="6">Change name 1</div><div data-id="7">Change name 2</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.p-2 { padding: 10px; }
 	.g-3 { gap: 5px; }
     </style>

--- a/ftd/t/js/17-events.html
+++ b/ftd/t/js/17-events.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="c-1">Hello</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.c-1 { color: green; }
+    .c-1 { color: green; }
     </style>
 <script>
     (function() {

--- a/ftd/t/js/18-rive.html
+++ b/ftd/t/js/18-rive.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><canvas data-id="2" class="w-1 bgc-2"></canvas><canvas data-id="3" class="w-3"></canvas><div data-id="4">Start Idle</div><canvas data-id="5"></canvas><div data-id="6">Idle/ Run</div><div data-id="7">Wiper On/Off</div><div data-id="8">Rainy On/Off</div><div data-id="9">No Wiper On/Off</div><div data-id="10">Sunny On/Off</div><div data-id="11">Stationary On/Off</div><div data-id="12">Bouncing On/Off</div><div data-id="13">Broken On/Off</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 500px; }
+    .w-1 { width: 500px; }
 	.bgc-2 { background-color: yellow; }
 	.w-3 { width: 440px; }
     </style>

--- a/ftd/t/js/19-image.html
+++ b/ftd/t/js/19-image.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><img data-id="2" src="https://fastn.com/-/fastn.com/images/cs/show-cs-1.jpg" class="w-1 h-2"></img></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 200px; }
+    .w-1 { width: 200px; }
 	.h-2 { height: 115px; }
     </style>
 <script>

--- a/ftd/t/js/20-background-properties.html
+++ b/ftd/t/js/20-background-properties.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column w-1 pt-2 pb-3 g-4 ali-5"><div data-id="3" class="ft_column as-6 w-7 h-8 bgc-9"></div><div data-id="4" class="ft_column as-6 w-7 h-8 bgr-10 bgp-11 bgs-12 bgi-13"></div><div data-id="5" class="ft_column as-6 w-7 h-8 bgi-14"></div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.w-1 { width: 100%; }
+    .w-1 { width: 100%; }
 	.pt-2 { padding-top: 30px; }
 	.pb-3 { padding-bottom: 30px; }
 	.g-4 { gap: 10px; }

--- a/ftd/t/js/21-markdown.html
+++ b/ftd/t/js/21-markdown.html
@@ -10,8 +10,7 @@
 <body data-id="1"><div data-id="2"># Marked in the browser
 
 Rendered by **marked**.</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/22-document.html
+++ b/ftd/t/js/22-document.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column"><div data-id="3">This is document component</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/23-record-list.html
+++ b/ftd/t/js/23-record-list.html
@@ -8,9 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column"><comment data-id="3"></comment><div data-id="4" class="ft_row g-1"><div data-id="5" class="c-2">1</div><div data-id="6" class="c-3">Ritesh</div></div><div data-id="7" class="ft_row g-1"><div data-id="8" class="c-2">2</div><div data-id="9" class="c-3">Ajinosaurus</div></div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
-	.g-1 { gap: 5px; }
+    .g-1 { gap: 5px; }
 	.c-2 { color: green; }
 	.c-3 { color: blue; }
     </style>

--- a/ftd/t/js/23-record-list.html
+++ b/ftd/t/js/23-record-list.html
@@ -7,7 +7,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column"><div data-id="3"><div data-id="4" class="ft_row g-1"><div data-id="5" class="c-2">1</div><div data-id="6" class="c-3">Ritesh</div></div><div data-id="7" class="ft_row g-1"><div data-id="8" class="c-2">2</div><div data-id="9" class="c-3">Ajinosaurus</div></div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column"><comment data-id="3"></comment><div data-id="4" class="ft_row g-1"><div data-id="5" class="c-2">1</div><div data-id="6" class="c-3">Ritesh</div></div><div data-id="7" class="ft_row g-1"><div data-id="8" class="c-2">2</div><div data-id="9" class="c-3">Ajinosaurus</div></div></div></body><style id="styles">
     .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
 	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
 	.g-1 { gap: 5px; }

--- a/ftd/t/js/24-device.ftd
+++ b/ftd/t/js/24-device.ftd
@@ -1,0 +1,27 @@
+
+
+-- footer: Ritesh
+
+-- component footer:
+caption name:
+
+-- ftd.column:
+width: fill-container
+
+-- ftd.desktop:
+
+-- show-name: $footer.name
+
+-- end: ftd.desktop
+
+-- end: ftd.column
+
+-- end: footer
+
+
+-- component show-name:
+caption name:
+
+-- ftd.text: $show-name.name
+
+-- end: show-name

--- a/ftd/t/js/24-re-export.html
+++ b/ftd/t/js/24-re-export.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">FifthTry Click here</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/25-re-re-export.html
+++ b/ftd/t/js/25-re-re-export.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2">FifthTry Click here</div><div data-id="3">Arpita</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/26-re-export.html
+++ b/ftd/t/js/26-re-export.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column"><div data-id="3">Arpita</div><div data-id="4">Arpita</div></div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/loop.ftd
+++ b/ftd/t/js/loop.ftd
@@ -1,0 +1,10 @@
+-- string list names:
+
+-- string: Arpita
+-- string: Ayushi
+
+-- end: names
+
+
+-- ftd.text: $obj
+$loop$: $names as $obj

--- a/ftd/t/js/loop.html
+++ b/ftd/t/js/loop.html
@@ -8,8 +8,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><comment data-id="2"></comment><div data-id="3">Arpita</div><div data-id="4">Ayushi</div></body><style id="styles">
-    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
-	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    
     </style>
 <script>
     (function() {

--- a/ftd/t/js/loop.html
+++ b/ftd/t/js/loop.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+    <script src="fastn-js.js"></script>
+
+    <style>
+       
+    </style>
+</head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+<body data-id="1"><comment data-id="2"></comment><div data-id="3">Arpita</div><div data-id="4">Ayushi</div></body><style id="styles">
+    .ft_row {  display: flex; align-items: start; justify-content: start; flex-direction: row; }
+	.ft_column {  display: flex; align-items: start; justify-content: start; flex-direction: column; }
+    </style>
+<script>
+    (function() {
+        let global = {
+};
+let main = function (parent) {
+  fastn_utils.getter(global.foo__names).forLoop(parent, function (root, item, index) {
+    let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
+    rooti0.setProperty(fastn_dom.PropertyKind.StringValue, item, inherited);
+    return rooti0;
+  });
+}
+fastn_utils.createNestedObject(global, "foo__names", fastn.mutableList(["Arpita",
+"Ayushi"]));
+
+        fastn_virtual.hydrate(main);
+        ftd.post_init();
+    })();
+</script>
+</html>


### PR DESCRIPTION
- Remove wrapper
  - iterativeDOM
  - conditionalDOM
  - deviceDOM
- Fix `inherited` reference conversion to `ftd::interpreter::PropertyValue` in interpreter
- Fix CSS
  - Added `box-sizing: border-box;`
  - Remove `fastn_dom.common` css from `dom.js`