### PR TITLE
Resolve variables in `url` header

### DIFF
--- a/fastn-core/src/library2022/processor/http.rs
+++ b/fastn-core/src/library2022/processor/http.rs
@@ -48,7 +48,7 @@ pub async fn process(
                     }
                 };
 
-                thing.string(doc.name, line_number).unwrap()
+                thing.string(doc.name, line_number)?
             }
         }
         None => {

--- a/fastn-core/src/library2022/processor/http.rs
+++ b/fastn-core/src/library2022/processor/http.rs
@@ -24,7 +24,33 @@ pub async fn process(
     }
 
     let url = match headers.get_optional_string_by_key("url", doc.name, line_number)? {
-        Some(v) => v,
+        Some(v) => {
+            if !v.starts_with('$') {
+                v
+            } else {
+                let thing = match doc.get_thing(v.as_str(), line_number) {
+                    Ok(ftd::interpreter::Thing::Variable(v)) => {
+                        v.value.resolve(doc, line_number)?
+                    }
+                    Ok(v2) => {
+                        return ftd::interpreter::utils::e2(
+                            format!("{v} is not a variable, it's a {v2:?}"),
+                            doc.name,
+                            line_number,
+                        )
+                    }
+                    Err(e) => {
+                        return ftd::interpreter::utils::e2(
+                            format!("${v} not found in the document: {e:?}"),
+                            doc.name,
+                            line_number,
+                        )
+                    }
+                };
+
+                thing.string(doc.name, line_number).unwrap()
+            }
+        }
         None => {
             return ftd::interpreter::utils::e2(
                 format!(


### PR DESCRIPTION
Fixes:
- Resolves variables assigned to the `url` header of `http` processor. It resolves the url string assigned to the variables from the bag.