### PR TITLE
fixed permission issue while installing fastn

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ setup() {
 
     DESTINATION_PATH="/usr/local/bin"
 
-    if [ -d "$DESTINATION_PATH" ]; then
+    if [ -d "$DESTINATION_PATH" ] && [ -w "$DESTINATION_PATH" ]; then
         DESTINATION_PATH=$DESTINATION_PATH
     else
         DESTINATION_PATH="${HOME}/.fastn/bin"


### PR DESCRIPTION
#1121 

I was in Fastn Roadshow Delhi, and was facing some issues while installing fastn on my Linux machine (Fedora) . 

So I looked at the install script and fixed the issue. I can confirm that it is working on Linux completely fine. But I haven't tested on MacOS right now. 

The main issue was that the script was trying to write to /usr/local/bin even if it didn't had the permission to do so. 
