### PR TITLE
Added status codes, proper error handling in `pg` processor

### DIFF
--- a/fastn-core/src/library2022/processor/mod.rs
+++ b/fastn-core/src/library2022/processor/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod pg;
 pub(crate) mod query;
 pub(crate) mod request_data;
 pub(crate) mod sitemap;
-mod sql;
+pub mod sql;
 pub(crate) mod sqlite;
 pub(crate) mod toc;
 pub(crate) mod user_details;

--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -268,11 +268,8 @@ async fn execute_query(
     let (query, query_args) = super::sql::extract_arguments(query)?;
 
     let client = pool().await.as_ref().unwrap().get().await.unwrap();
-
     let stmt = client.prepare_cached(query.as_str()).await.unwrap();
-
     let args = prepare_args(query_args, stmt.params(), doc, line_number, headers)?;
-
     let rows = client.query(&stmt, &args.pg_args()).await.unwrap();
     let mut result: Vec<Vec<serde_json::Value>> = vec![];
 

--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -38,12 +38,20 @@ pub async fn process(
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
     let (headers, query) = super::sqlite::get_p1_data("pg", &value, doc.name)?;
 
-    super::sqlite::result_to_value(
-        execute_query(query.as_str(), doc, value.line_number(), headers).await?,
-        kind,
-        doc,
-        &value,
-    )
+    let query_response = execute_query(query.as_str(), doc, value.line_number(), headers).await;
+
+    match query_response {
+        Ok(result) => {
+            super::sqlite::result_to_value(Ok(result), kind, doc, &value, super::sql::STATUS_OK)
+        }
+        Err(e) => super::sqlite::result_to_value(
+            Err(e.to_string()),
+            kind,
+            doc,
+            &value,
+            super::sql::STATUS_ERROR,
+        ),
+    }
 }
 
 type PGData = dyn postgres_types::ToSql + Sync;
@@ -84,6 +92,9 @@ fn resolve_variable_from_doc(
 
     Ok(match (e, thing) {
         (&postgres_types::Type::TEXT, ftd::interpreter::Value::String { text, .. }) => {
+            Box::new(text)
+        }
+        (&postgres_types::Type::VARCHAR, ftd::interpreter::Value::String { text, .. }) => {
             Box::new(text)
         }
         (&postgres_types::Type::INT4, ftd::interpreter::Value::Integer { value, .. }) => {
@@ -153,6 +164,9 @@ fn resolve_variable_from_headers(
 
     Ok(match (e, &header.value) {
         (&postgres_types::Type::TEXT, ftd::ast::VariableValue::String { value, .. }) => {
+            Some(Box::new(value.to_string()))
+        }
+        (&postgres_types::Type::VARCHAR, ftd::ast::VariableValue::String { value, .. }) => {
             Some(Box::new(value.to_string()))
         }
         (&postgres_types::Type::INT4, ftd::ast::VariableValue::String { value, .. }) => {
@@ -252,9 +266,11 @@ async fn execute_query(
     headers: ftd::ast::HeaderValues,
 ) -> ftd::interpreter::Result<Vec<Vec<serde_json::Value>>> {
     let (query, query_args) = super::sql::extract_arguments(query)?;
+
     let client = pool().await.as_ref().unwrap().get().await.unwrap();
 
     let stmt = client.prepare_cached(query.as_str()).await.unwrap();
+
     let args = prepare_args(query_args, stmt.params(), doc, line_number, headers)?;
 
     let rows = client.query(&stmt, &args.pg_args()).await.unwrap();

--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -1,3 +1,7 @@
+pub const STATUS_OK: usize = 0;
+
+pub const STATUS_ERROR: usize = 1;
+
 const BACKSLASH: char = '\\';
 
 const SPECIAL_CHARS: [char; 9] = [BACKSLASH, '$', '/', ':', '"', ',', '\'', ';', ' '];

--- a/fastn-core/src/library2022/processor/sql.rs
+++ b/fastn-core/src/library2022/processor/sql.rs
@@ -1,9 +1,6 @@
 pub const STATUS_OK: usize = 0;
-
 pub const STATUS_ERROR: usize = 1;
-
 const BACKSLASH: char = '\\';
-
 const SPECIAL_CHARS: [char; 9] = [BACKSLASH, '$', '/', ':', '"', ',', '\'', ';', ' '];
 
 // TODO: Can improve the performance

--- a/fastn-core/src/library2022/processor/sqlite.rs
+++ b/fastn-core/src/library2022/processor/sqlite.rs
@@ -118,7 +118,7 @@ pub(crate) fn result_to_value(
                 value: status as i64,
             }),
             "string" => Ok(ftd::interpreter::Value::String { text: (e) }),
-            &_ => todo!(),
+            _ => unimplemented!(),
         },
     }
 }


### PR DESCRIPTION
Added status codes and proper error handling in `pg` processor.

Now, SQL queries which do not return any rows in result (eg. insert, delete, etc) can be executed properly, and they will return an status code or error message depending on the type of the `ftd` document they have been attached to.

Example:

```ftd
-- import: fastn/processors as pr
-- import: todo-app/api/models

-- string todo:
$processor$: pr.request-data

-- integer status:
$processor$: pr.pg
todo: $todo

INSERT INTO todos(todo, complete) VALUES ($todo::VARCHAR, false)

-- ftd.text: Success
text if { status == 1 }: Something went wrong
```