### PR TITLE
Some fixes in fastn 0.4

### DIFF
--- a/fastn-core/src/package/package_doc.rs
+++ b/fastn-core/src/package/package_doc.rs
@@ -512,6 +512,7 @@ pub(crate) async fn read_ftd_2023(
     let js_ast_data = ftd::js::document_into_js_ast(main_ftd_doc);
     let js_document_script = fastn_js::to_js(js_ast_data.asts.as_slice(), true);
     let js_ftd_script = fastn_js::to_js(ftd::js::default_bag_into_js_ast().as_slice(), false);
+    dbg!(&main.id);
     let ssr_body =
         fastn_js::ssr_with_js_string(format!("{js_ftd_script}\n{js_document_script}").as_str());
 

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1430,7 +1430,7 @@ class Node2 {
                 this.attachAttribute("target", staticValue);
             }
         } else if (kind === fastn_dom.PropertyKind.TextStyle) {
-            let styles = staticValue.map(obj => fastn_utils.getStaticValue(obj.item));
+            let styles = staticValue?.map(obj => fastn_utils.getStaticValue(obj.item));
             this.attachTextStyles(styles);
         } else if (kind === fastn_dom.PropertyKind.Region) {
             this.updateTagName(staticValue);

--- a/fastn-js/src/to_js.rs
+++ b/fastn-js/src/to_js.rs
@@ -192,8 +192,12 @@ impl fastn_js::ElementKind {
 impl fastn_js::ComponentStatement {
     pub fn to_js(&self) -> pretty::RcDoc<'static> {
         match self {
-            fastn_js::ComponentStatement::StaticVariable(f) => f.to_js(),
-            fastn_js::ComponentStatement::MutableVariable(f) => f.to_js(),
+            fastn_js::ComponentStatement::StaticVariable(static_variable) => {
+                static_variable.to_js()
+            }
+            fastn_js::ComponentStatement::MutableVariable(mutable_variable) => {
+                mutable_variable.to_js()
+            }
             fastn_js::ComponentStatement::CreateKernel(kernel) => kernel.to_js(),
             fastn_js::ComponentStatement::SetProperty(set_property) => set_property.to_js(),
             fastn_js::ComponentStatement::InstantiateComponent(i) => i.to_js(),

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -894,9 +894,8 @@ impl InheritedProperties {
         }
 
         if !inherited_fields.is_empty() {
-            dbg!(&rdata.inherited_variable_name);
             Some(fastn_js::StaticVariable {
-                name: dbg!(format!("{}{}", fastn_js::INHERITED_PREFIX, component_name)),
+                name: format!("{}{}", fastn_js::INHERITED_PREFIX, component_name),
                 value: fastn_js::SetPropertyValue::Value(fastn_js::Value::Record {
                     fields: inherited_fields,
                     other_references: vec![rdata.inherited_variable_name.to_string()],

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -894,10 +894,12 @@ impl InheritedProperties {
         }
 
         if !inherited_fields.is_empty() {
+            dbg!(&rdata.inherited_variable_name);
             Some(fastn_js::StaticVariable {
-                name: format!("{}{}", fastn_js::INHERITED_PREFIX, component_name),
+                name: dbg!(format!("{}{}", fastn_js::INHERITED_PREFIX, component_name)),
                 value: fastn_js::SetPropertyValue::Value(fastn_js::Value::Record {
                     fields: inherited_fields,
+                    other_references: vec![rdata.inherited_variable_name.to_string()],
                 }),
                 prefix: None,
             })

--- a/ftd/src/js/mod.rs
+++ b/ftd/src/js/mod.rs
@@ -63,6 +63,7 @@ pub fn default_bag_into_js_ast() -> Vec<fastn_js::Ast> {
                     ),
                 ),
             ],
+            other_references: vec![],
         }),
         prefix: None,
     }));
@@ -203,7 +204,10 @@ impl ftd::interpreter::Variable {
                 }
                 return fastn_js::Ast::RecordInstance(fastn_js::RecordInstance {
                     name: self.name.to_string(),
-                    fields: fastn_js::SetPropertyValue::Value(fastn_js::Value::Record { fields }),
+                    fields: fastn_js::SetPropertyValue::Value(fastn_js::Value::Record {
+                        fields,
+                        other_references: vec![],
+                    }),
                     prefix,
                 });
             } else if self.kind.is_list() {

--- a/ftd/src/js/value.rs
+++ b/ftd/src/js/value.rs
@@ -384,6 +384,7 @@ impl ftd::interpreter::Value {
                             )
                         })
                         .collect_vec(),
+                    other_references: vec![],
                 })
             }
             ftd::interpreter::Value::UI { component, .. } => {

--- a/ftd/t/js/08-inherited.html
+++ b/ftd/t/js/08-inherited.html
@@ -45,6 +45,7 @@ let main = function (parent) {
   parenti2.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
   parenti2.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.Fixed(fastn_dom.Length.Px(200)), inherited);
   let __$$inherited$$__parenti2 = fastn.recordInstance({
+    ...inherited.getAllFields(),
     colors: global.foo__colors
   });
   parenti2.setProperty(fastn_dom.PropertyKind.Children, fastn.mutableList([function (root, inherited) {


### PR DESCRIPTION
- Fix: fastn_dom.PropertyKind.TextStyle to accept undefined value
- Fix: inherited variables to use spread operator for old inherited