### PR TITLE
serialising `pg` processor queries (to avoid connection/thread issue)

### DIFF
--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -26,9 +26,10 @@ async fn create_pool() -> Result<deadpool_postgres::Pool, deadpool_postgres::Cre
 static POOL_RESULT: tokio::sync::OnceCell<
     Result<deadpool_postgres::Pool, deadpool_postgres::CreatePoolError>,
 > = tokio::sync::OnceCell::const_new();
+
 static PREPARED_STATEMENT: once_cell::sync::Lazy<
-    tokio::sync::Mutex<std::collections::HashSet<String>>,
-> = once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
+    tokio::sync::RwLock<std::collections::HashSet<String>>,
+> = once_cell::sync::Lazy::new(|| tokio::sync::RwLock::new(std::collections::HashSet::new()));
 
 async fn pool() -> &'static Result<deadpool_postgres::Pool, deadpool_postgres::CreatePoolError> {
     POOL_RESULT.get_or_init(create_pool).await
@@ -269,17 +270,15 @@ async fn execute_query(
     headers: ftd::ast::HeaderValues,
 ) -> ftd::interpreter::Result<Vec<Vec<serde_json::Value>>> {
     let (query, query_args) = super::sql::extract_arguments(query)?;
-    let stmt_key = query.to_string();
     let client = pool().await.as_ref().unwrap().get().await.unwrap();
 
-    // Use a Mutex to ensure only one thread prepares the same statement
-    let mut prepared_statements = PREPARED_STATEMENT.lock().await;
-    let stmt = if !prepared_statements.contains(&stmt_key) {
-        let stmt = client.prepare_cached(query.as_str()).await.unwrap();
-        prepared_statements.insert(stmt_key);
-        stmt
-    } else {
+    let mut prepared_statements = PREPARED_STATEMENT.write().await;
+    let stmt = if prepared_statements.contains(&query) {
         client.prepare_cached(query.as_str()).await.unwrap()
+    } else {
+        let stmt = client.prepare_cached(query.as_str()).await.unwrap();
+        prepared_statements.insert(query);
+        stmt
     };
 
     let args = prepare_args(query_args, stmt.params(), doc, line_number, headers)?;

--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -262,22 +262,6 @@ fn prepare_args(
     Ok(QueryArgs { args })
 }
 
-async fn get_statemetn(query: &str) -> tokio_postgres::Statement {
-    if let Some(s) = PREPARED_STATEMENT.read().await.get(query) {
-        return s.clone();
-    }
-
-    let mut prepared_statements = PREPARED_STATEMENT.write().await;
-    let stmt = if prepared_statements.contains(&query) {
-        client.prepare_cached(query.as_str()).await.unwrap()
-    } else {
-        let stmt = client.prepare_cached(query.as_str()).await.unwrap();
-        prepared_statements.insert(query);
-        stmt
-    };
-    stmt
-}
-
 async fn execute_query(
     query: &str,
     doc: &ftd::interpreter::TDoc<'_>,

--- a/fastn-core/src/library2022/processor/pg.rs
+++ b/fastn-core/src/library2022/processor/pg.rs
@@ -23,8 +23,12 @@ async fn create_pool() -> Result<deadpool_postgres::Pool, deadpool_postgres::Cre
 // TODO: I am a little confused about the use of `tokio::sync` here, both sides are async, so why
 //       do we need to use `tokio::sync`? Am I doing something wrong? How do I prove/verify that
 //       this is correct?
-static POOL_RESULT: tokio::sync::OnceCell<Result<deadpool_postgres::Pool, deadpool_postgres::CreatePoolError>> = tokio::sync::OnceCell::const_new();
-static PREPARED_STATEMENT: once_cell::sync::Lazy<tokio::sync::Mutex<std::collections::HashSet<String>>> = once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
+static POOL_RESULT: tokio::sync::OnceCell<
+    Result<deadpool_postgres::Pool, deadpool_postgres::CreatePoolError>,
+> = tokio::sync::OnceCell::const_new();
+static PREPARED_STATEMENT: once_cell::sync::Lazy<
+    tokio::sync::Mutex<std::collections::HashSet<String>>,
+> = once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
 
 async fn pool() -> &'static Result<deadpool_postgres::Pool, deadpool_postgres::CreatePoolError> {
     POOL_RESULT.get_or_init(create_pool).await
@@ -267,7 +271,7 @@ async fn execute_query(
     let (query, query_args) = super::sql::extract_arguments(query)?;
     let stmt_key = query.to_string();
     let client = pool().await.as_ref().unwrap().get().await.unwrap();
-    
+
     // Use a Mutex to ensure only one thread prepares the same statement
     let mut prepared_statements = PREPARED_STATEMENT.lock().await;
     let stmt = if !prepared_statements.contains(&stmt_key) {


### PR DESCRIPTION
**Fixes:**

The problem was in the `execute_query` function. `fastn` sometimes makes multiple concurrent requests, which leads to attempt of creating multiple statements. since we are using a pool, where statements are pooled so that they can be reused later, it leads to errors like "statement s0 already exists".

We prevent this by using utilizing Mutex Lock, and HashSet, to keep track of already prepared statements and apply a lock when preparing a statement so that only one statement is prepared for these concurrent requests. It then release the lock once it is done.

@amitu 