### PR TITLE
Fix: module vs package

### DIFF
--- a/fastn-core/src/library2022/mod.rs
+++ b/fastn-core/src/library2022/mod.rs
@@ -154,7 +154,8 @@ impl Library2022 {
             let packages = lib.config.all_packages.borrow();
             let package = packages.get(package.name.as_str()).unwrap_or(package);
             // Explicit check for the current package.
-            if !name.starts_with(package.name.as_str()) {
+            let name = format!("{}/", name.trim_end_matches('/'));
+            if !name.starts_with(format!("{}/", package.name.as_str()).as_str()) {
                 return None;
             }
             let new_name = name.replacen(package.name.as_str(), "", 1);
@@ -166,7 +167,8 @@ impl Library2022 {
                 return None;
             }
             String::from_utf8(data).ok().map(|body| {
-                let body_with_prefix = package.get_prefixed_body(body.as_str(), name, true);
+                let body_with_prefix =
+                    package.get_prefixed_body(body.as_str(), name.as_str(), true);
                 let line_number = body_with_prefix.split('\n').count() - body.split('\n').count();
                 (body_with_prefix, line_number)
             })

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1069,6 +1069,7 @@ class Node2 {
     attachAlignContent(value, node_kind) {
         if (fastn_utils.isNull(value)) {
             this.attachCss('align-items', value);
+            this.attachCss("justify-content", value);
             return;
         }
         if (node_kind === fastn_dom.ElementKind.Row) {
@@ -1746,20 +1747,17 @@ class ForLoop {
         this.#nodes.splice(index, 0, node);
         return node;
     }
-
     createAllNode() {
         this.deleteAllNode();
         for (let idx in this.#list.getList()) {
             this.createNode(idx);
         }
     }
-
     deleteAllNode() {
         while (this.#nodes.length > 0) {
             this.#nodes.pop().destroy();
         }
     }
-
     getWrapper() {
         return this.#wrapper;
     }
@@ -1767,7 +1765,6 @@ class ForLoop {
        let node = this.#nodes.splice(index, 1)[0];
         node.destroy();
     }
-
     getParent() {
         return this.#parent;
     }


### PR DESCRIPTION
If there's a package or dependencies which has same prefix then `fastn` hits wrong http request to fetch the file.

Example:

For a package with the following `FASTN.ftd`:

```ftd
-- fastn.dependency: fastn-community.github.io/midnight-storm
-- fastn.dependency: fastn-community.github.io/midnight-storm-cs
```

When there's a request for `fastn-community.github.io/midnight-storm-cs`, there's a chances for `fastn` to hit to a request for `https://fastn-community.github.io/midnight-storm/-cs` which is because the prefix for both dependencies matches.
