### PR TITLE
added fastn check to assert index files (post build) + other minor fixes

### DIFF
--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -1,0 +1,47 @@
+pub const INDEX_FILE: &str = "index.html";
+pub const BUILD_FOLDER: &str = ".build";
+
+pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result<()> {
+    let build_path = config.root.join(BUILD_FOLDER);
+
+    if build_path.is_dir() {
+        if !build_path.join(INDEX_FILE).exists() {
+            return Err(fastn_core::Error::NotFound(format!(
+                "Couldn't find {} in package root folder",
+                INDEX_FILE
+            )));
+        }
+        check_index_in_folders(build_path)
+            .await
+            .map_err(|e| fastn_core::Error::GenericError(e.to_string()))?;
+    }
+
+    Ok(())
+}
+
+#[async_recursion::async_recursion]
+async fn check_index_in_folders(folder: camino::Utf8PathBuf) -> Result<(), fastn_core::Error> {
+    use colored::Colorize;
+
+    if folder.is_dir() {
+        let mut entries = tokio::fs::read_dir(folder).await?;
+        while let Some(current_entry) = entries.next_entry().await? {
+            let entry_path = camino::Utf8PathBuf::from_path_buf(current_entry.path())
+                .expect(format!("failed to read path: {:?}", current_entry.path()).as_str());
+
+            if entry_path.is_dir() {
+                let index_html_path = entry_path.join(INDEX_FILE);
+                if !index_html_path.exists() {
+                    let warning_msg = format!(
+                        "Warning: Folder {:?} does not have an index.html file.",
+                        entry_path
+                    );
+                    println!("{}", warning_msg.yellow());
+                }
+
+                check_index_in_folders(entry_path).await?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -36,7 +36,7 @@ async fn check_index_in_folders(
         while let Some(current_entry) = entries.next_entry().await? {
             let current_entry_path = current_entry.path();
             let entry_path = camino::Utf8PathBuf::from_path_buf(current_entry_path)
-                .expect(format!("failed to read path: {:?}", current_entry.path()).as_str());
+                .unwrap_or_else(|_| panic!("failed to read path: {:?}", current_entry.path()));
 
             let is_ignored_directory = entry_path.is_dir() && is_ignored_directory(&entry_path);
 

--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -1,8 +1,11 @@
 pub const INDEX_FILE: &str = "index.html";
 pub const BUILD_FOLDER: &str = ".build";
+pub const IGNORED_DIRECTORIES: [&str; 3] = ["-", "images", "static"];
 
 pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result<()> {
     let build_path = config.root.join(BUILD_FOLDER);
+    let build_directory = build_path.as_str().to_string();
+    println!("Post build index assertion started ...");
 
     if build_path.is_dir() {
         if !build_path.join(INDEX_FILE).exists() {
@@ -11,7 +14,7 @@ pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result
                 INDEX_FILE
             )));
         }
-        check_index_in_folders(build_path)
+        check_index_in_folders(build_path, build_directory.as_str())
             .await
             .map_err(|e| fastn_core::Error::GenericError(e.to_string()))?;
     }
@@ -20,28 +23,52 @@ pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result
 }
 
 #[async_recursion::async_recursion]
-async fn check_index_in_folders(folder: camino::Utf8PathBuf) -> Result<(), fastn_core::Error> {
+async fn check_index_in_folders(
+    folder: camino::Utf8PathBuf,
+    build_path: &str,
+) -> Result<(), fastn_core::Error> {
     use colored::Colorize;
+    let mut file_count = 0;
+    let mut has_ignored_directory = false;
 
     if folder.is_dir() {
-        let mut entries = tokio::fs::read_dir(folder).await?;
+        let mut entries = tokio::fs::read_dir(&folder).await?;
         while let Some(current_entry) = entries.next_entry().await? {
-            let entry_path = camino::Utf8PathBuf::from_path_buf(current_entry.path())
+            let current_entry_path = current_entry.path();
+            let entry_path = camino::Utf8PathBuf::from_path_buf(current_entry_path)
                 .expect(format!("failed to read path: {:?}", current_entry.path()).as_str());
 
-            if entry_path.is_dir() {
-                let index_html_path = entry_path.join(INDEX_FILE);
-                if !index_html_path.exists() {
-                    let warning_msg = format!(
-                        "Warning: Folder {:?} does not have an index.html file.",
-                        entry_path
-                    );
-                    println!("{}", warning_msg.yellow());
-                }
+            let is_ignored_directory = entry_path.is_dir() && is_ignored_directory(&entry_path);
 
-                check_index_in_folders(entry_path).await?;
+            if !has_ignored_directory {
+                has_ignored_directory = is_ignored_directory;
+            }
+            if entry_path.is_file() {
+                file_count += 1;
+            }
+            if entry_path.is_dir() && !is_ignored_directory {
+                check_index_in_folders(entry_path, build_path).await?;
+            }
+        }
+        if file_count > 0 || !has_ignored_directory {
+            let index_html_path = folder.join(INDEX_FILE);
+            if !index_html_path.exists() {
+                let warning_msg = format!(
+                    "Warning: Directory {:?} does not have an index.html file.",
+                    folder.as_str().trim_start_matches(build_path)
+                );
+                println!("{}", warning_msg.yellow());
             }
         }
     }
     Ok(())
+}
+
+fn is_ignored_directory(path: &camino::Utf8PathBuf) -> bool {
+    for dir in IGNORED_DIRECTORIES {
+        if path.ends_with(dir) {
+            return true;
+        }
+    }
+    false
 }

--- a/fastn-core/src/commands/mod.rs
+++ b/fastn-core/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod abort_merge;
 pub mod add;
 pub mod build;
+pub mod check;
 pub mod clone;
 pub mod close_cr;
 pub mod create_cr;

--- a/fastn-core/src/error.rs
+++ b/fastn-core/src/error.rs
@@ -60,6 +60,9 @@ pub enum Error {
     #[error("APIResponseError: {}", _0)]
     APIResponseError(String),
 
+    #[error("NotFoundError: {}", _0)]
+    NotFound(String),
+
     #[error("PackageError: {message}")]
     PackageError { message: String },
 

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -36,10 +36,10 @@ mod workspace;
 
 pub(crate) use auto_import::AutoImport;
 pub use commands::{
-    abort_merge::abort_merge, add::add, build::build, clone::clone, close_cr::close_cr,
-    create_cr::create_cr, create_package::create_package, diff::diff, edit::edit,
-    mark_resolved::mark_resolved, mark_upto_date::mark_upto_date, merge::merge, query::query,
-    resolve_conflict::resolve_conflict, revert::revert, rm::rm, serve::listen,
+    abort_merge::abort_merge, add::add, build::build, check::post_build_check, clone::clone,
+    close_cr::close_cr, create_cr::create_cr, create_package::create_package, diff::diff,
+    edit::edit, mark_resolved::mark_resolved, mark_upto_date::mark_upto_date, merge::merge,
+    query::query, resolve_conflict::resolve_conflict, revert::revert, rm::rm, serve::listen,
     start_tracking::start_tracking, status::status, sync2::sync2,
     translation_status::translation_status, update::update,
 };

--- a/fastn-js/js/ftd.js
+++ b/fastn-js/js/ftd.js
@@ -20,6 +20,7 @@ let ftd = {
 
     copy_to_clipboard(args) {
         let text = args.a;
+        if (text instanceof fastn.mutableClass) text = text.get();
         if (text.startsWith("\\", 0)) {
             text = text.substring(1);
         }

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -234,6 +234,10 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
         return fastn_core::mark_upto_date(&config, source, target).await;
     }
 
+    if matches.subcommand_matches("check").is_some() {
+        return fastn_core::post_build_check(&config).await;
+    }
+
     unreachable!("No subcommand matched");
 }
 

--- a/ftd/ftd-js.css
+++ b/ftd/ftd-js.css
@@ -278,6 +278,6 @@ p {
     margin-block-end: 1em;
 }
 
-h1 {
+h1:only-child {
     margin-block-end: 0.67em
 }


### PR DESCRIPTION
fastn check (will assert `.build` index files)
- [x] will throw an error if package root `index.html` is not created after fastn build
- [x] will show warnings if any valid URL folder doesn't contain index.html (it could be intentional so avoiding throwing error in this case)
