### PR TITLE
Fixed `poster` attribute of `ftd.video`

### DIFF
--- a/ftd/src/interpreter/things/default.rs
+++ b/ftd/src/interpreter/things/default.rs
@@ -9626,9 +9626,9 @@ pub fn video_function() -> ftd::interpreter::ComponentDefinition {
                 ),
                 ftd::interpreter::Argument::default(
                     "poster",
-                    ftd::interpreter::Kind::string()
-                        .into_kind_data()
-                        .into_optional(),
+                    ftd::interpreter::Kind::record(ftd::interpreter::FTD_IMAGE_SRC)
+                        .into_optional()
+                        .into_kind_data(),
                 ),
             ],
         ]

--- a/ftd/t/js/48-video.ftd
+++ b/ftd/t/js/48-video.ftd
@@ -1,8 +1,14 @@
--- import: video-player/assets
+-- ftd.video-src my-video:
+dark: https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4
+light: https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
 
+-- ftd.image-src my-video-poster:
+dark: https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerFun.jpg
+light: https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg
 
 -- ftd.video:
-src: https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
+src: $my-video
+poster: $my-video-poster
 autoplay: true
 loop: true
 muted: true

--- a/ftd/t/js/48-video.html
+++ b/ftd/t/js/48-video.html
@@ -16,7 +16,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><video data-id="3" src="https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" controls="true" autoplay="true" muted="true" loop="true"></video></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><video data-id="3" src="https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" controls="true" autoplay="true" muted="true" loop="true" poster="https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"></video></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
     </style>
@@ -29,19 +29,25 @@ let main = function (parent) {
   __fastn_package_name__ = "foo";
   try {
     let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Video);
-    parenti0.setProperty(fastn_dom.PropertyKind.VideoSrc, fastn.recordInstance({
-      dark: "https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
-      light: "https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-    }), inherited);
+    parenti0.setProperty(fastn_dom.PropertyKind.VideoSrc, global.foo__my_video, inherited);
     parenti0.setProperty(fastn_dom.PropertyKind.Controls, true, inherited);
     parenti0.setProperty(fastn_dom.PropertyKind.Autoplay, true, inherited);
     parenti0.setProperty(fastn_dom.PropertyKind.Muted, true, inherited);
     parenti0.setProperty(fastn_dom.PropertyKind.LoopVideo, true, inherited);
+    parenti0.setProperty(fastn_dom.PropertyKind.Poster, global.foo__my_video_poster, inherited);
   } finally {
     __fastn_package_name__ = __fastn_super_package_name__;
   }
 }
 global["main"] = main;
+fastn_utils.createNestedObject(global, "foo__my_video", fastn.recordInstance({
+  light: "https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+  dark: "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4"
+}));
+fastn_utils.createNestedObject(global, "foo__my_video_poster", fastn.recordInstance({
+  light: "https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg",
+  dark: "https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerFun.jpg"
+}));
 fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "../../theme_css/coldark-theme.dark.css";
 fastn_dom.codeData.availableThemes["coldark-theme.light"] = "../../theme_css/coldark-theme.light.css";
 fastn_dom.codeData.availableThemes["coy-theme"] = "../../theme_css/coy-theme.css";


### PR DESCRIPTION
Fixed `poster` attribute of `ftd.video`.

Example:
```ftd
-- ftd.video-src my-video:
dark: https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4
light: https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4

-- ftd.image-src my-video-poster:
dark: https://storage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerFun.jpg
light: https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg

-- ftd.video:
src: $my-video
poster: $my-video-poster
autoplay: true
loop: true
muted: true
controls: true
```