### PR TITLE
cookie support added with `ftd.cookie`

### DIFF
--- a/fastn-js/js/ftd.js
+++ b/fastn-js/js/ftd.js
@@ -273,15 +273,16 @@ ftd.cookie = {
         let cookieString = `${cookieKey}=${encodeURIComponent(cookieValue)}`;
 
         if (expires) {
-            cookieString += `; expires=${expires.toUTCString()}`;
+            cookieString += `; expires=${fastn_utils.getStaticValue(expires)}`;
+            // cookieString += `; expires=${fastn_utils.getStaticValue(expires).toUTCString()}`;
         }
         if (path) {
-            cookieString += `; path=${path}`;
+            cookieString += `; path=${fastn_utils.getStaticValue(path)}`;
         }
         if (domain) {
-            cookieString += `; domain=${domain}`;
+            cookieString += `; domain=${fastn_utils.getStaticValue(domain)}`;
         }
-        if (secure) {
+        if (secure && fastn_utils.getStaticValue(secure)) {
             cookieString += '; secure';
         }
 

--- a/ftd/src/interpreter/constants.rs
+++ b/ftd/src/interpreter/constants.rs
@@ -318,3 +318,5 @@ pub const FTD_LINK_REL: &str = "ftd#link-rel";
 pub const FTD_LINK_REL_NO_FOLLOW: &str = "ftd#link-rel.no-follow";
 pub const FTD_LINK_REL_SPONSORED: &str = "ftd#link-rel.sponsored";
 pub const FTD_LINK_REL_UGC: &str = "ftd#link-rel.ugc";
+
+pub const FTD_COOKIE: &str = "ftd#cookie";

--- a/ftd/src/interpreter/things/default.rs
+++ b/ftd/src/interpreter/things/default.rs
@@ -3556,6 +3556,65 @@ pub fn default_bag() -> indexmap::IndexMap<String, ftd::interpreter::Thing> {
                 line_number: 0,
             }),
         ),
+        // key, value, expires, path, domain, secure
+        (
+            ftd::interpreter::FTD_COOKIE.to_string(),
+            ftd::interpreter::Thing::Record(ftd::interpreter::Record {
+                name: ftd::interpreter::FTD_COOKIE.to_string(),
+                fields: std::iter::IntoIterator::into_iter([
+                    ftd::interpreter::Field {
+                        name: "key".to_string(),
+                        kind: ftd::interpreter::Kind::string().into_kind_data().caption(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                    ftd::interpreter::Field {
+                        name: "value".to_string(),
+                        kind: ftd::interpreter::Kind::string().into_kind_data(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                    ftd::interpreter::Field {
+                        name: "expires".to_string(),
+                        kind: ftd::interpreter::Kind::string().into_kind_data().into_optional(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                    ftd::interpreter::Field {
+                        name: "path".to_string(),
+                        kind: ftd::interpreter::Kind::string().into_kind_data().into_optional(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                    ftd::interpreter::Field {
+                        name: "domain".to_string(),
+                        kind: ftd::interpreter::Kind::string().into_kind_data().into_optional(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                    ftd::interpreter::Field {
+                        name: "secure".to_string(),
+                        kind: ftd::interpreter::Kind::boolean().into_kind_data().into_optional(),
+                        mutable: false,
+                        value: None,
+                        access_modifier: Default::default(),
+                        line_number: 0,
+                    },
+                ])
+                .collect(),
+                line_number: 0,
+            }),
+        ),
         (
             "ftd#dark-mode".to_string(),
             ftd::interpreter::Thing::Variable(ftd::interpreter::Variable {

--- a/ftd/t/js/55-cookie.ftd
+++ b/ftd/t/js/55-cookie.ftd
@@ -1,0 +1,30 @@
+-- ftd.cookie user: user-name
+value: Harsh Singh
+secure: true
+
+-- ftd.cookie user-2: user-name
+value: Rithik Seth
+secure: true
+
+-- string $user-name: *$user.value
+
+-- ftd.text: $user-name
+
+-- ftd.text: Save User Cookie
+$on-click$: $save-user(a = $user)
+
+-- ftd.text: Update User Cookie
+$on-click$: $save-user(a = $user-2)
+
+-- ftd.text: Get User
+$on-click$: $get-user($a = $user-name)
+
+-- void save-user(a):
+ftd.cookie a:
+
+ftd.cookie.set(a)
+
+-- void get-user(a):
+string $a:
+
+__args__.a.set(ftd.cookie.get("user-name"))

--- a/ftd/t/js/55-cookie.html
+++ b/ftd/t/js/55-cookie.html
@@ -1,0 +1,144 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <meta content="fastn" name="generator">
+    
+    
+    <script>
+        let __fastn_package_name__ = "foo";
+    </script>
+
+    <script src="fastn-js.js"></script>
+
+    <style>
+       
+    </style>
+</head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3">Harsh Singh</div><div data-id="4" class="__cur-3">Save User Cookie</div><div data-id="5" class="__cur-4">Update User Cookie</div><div data-id="6" class="__cur-5">Get User</div></div></body><style id="styles">
+    .__w-1 { width: 100%; }
+	.__h-2 { height: 100%; }
+	.__cur-3 { cursor: pointer; }
+	.__cur-4 { cursor: pointer; }
+	.__cur-5 { cursor: pointer; }
+    </style>
+<script>
+    (function() {
+        let global = {
+};
+let main = function (parent) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "foo";
+  try {
+    let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti0.setProperty(fastn_dom.PropertyKind.StringValue, global.foo__user_name, inherited);
+    let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "Save User Cookie", inherited);
+    parenti1.addEventHandler(fastn_dom.Event.Click, function () {
+      foo__save_user({
+        a: global.foo__user,
+      }, parenti1);
+    });
+    let parenti2 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti2.setProperty(fastn_dom.PropertyKind.StringValue, "Update User Cookie", inherited);
+    parenti2.addEventHandler(fastn_dom.Event.Click, function () {
+      foo__save_user({
+        a: global.foo__user_2,
+      }, parenti2);
+    });
+    let parenti3 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti3.setProperty(fastn_dom.PropertyKind.StringValue, "Get User", inherited);
+    parenti3.addEventHandler(fastn_dom.Event.Click, function () {
+      foo__get_user({
+        a: global.foo__user_name,
+      }, parenti3);
+    });
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
+global["main"] = main;
+fastn_utils.createNestedObject(global, "foo__user", fastn.recordInstance({
+  key: "user-name",
+  value: "Harsh Singh",
+  expires: null,
+  path: null,
+  domain: null,
+  secure: true
+}));
+fastn_utils.createNestedObject(global, "foo__user_name", fastn_utils.clone(global.foo__user.get("value")));
+let foo__save_user = function (args)
+{
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "foo";
+  try {
+    let __args__ = args;
+    return (ftd.cookie.set(__args__.a));
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
+global["foo__save_user"] = foo__save_user;
+fastn_utils.createNestedObject(global, "foo__user_2", fastn.recordInstance({
+  key: "user-name",
+  value: "Rithik Seth",
+  expires: null,
+  path: null,
+  domain: null,
+  secure: true
+}));
+let foo__get_user = function (args)
+{
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "foo";
+  try {
+    let __args__ = args;
+    return (__args__.a.set(ftd.cookie.get("user-name")));
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
+global["foo__get_user"] = foo__get_user;
+fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "../../theme_css/coldark-theme.dark.css";
+fastn_dom.codeData.availableThemes["coldark-theme.light"] = "../../theme_css/coldark-theme.light.css";
+fastn_dom.codeData.availableThemes["coy-theme"] = "../../theme_css/coy-theme.css";
+fastn_dom.codeData.availableThemes["dracula-theme"] = "../../theme_css/dracula-theme.css";
+fastn_dom.codeData.availableThemes["duotone-theme.dark"] = "../../theme_css/duotone-theme.dark.css";
+fastn_dom.codeData.availableThemes["duotone-theme.earth"] = "../../theme_css/duotone-theme.earth.css";
+fastn_dom.codeData.availableThemes["duotone-theme.forest"] = "../../theme_css/duotone-theme.forest.css";
+fastn_dom.codeData.availableThemes["duotone-theme.light"] = "../../theme_css/duotone-theme.light.css";
+fastn_dom.codeData.availableThemes["duotone-theme.sea"] = "../../theme_css/duotone-theme.sea.css";
+fastn_dom.codeData.availableThemes["duotone-theme.space"] = "../../theme_css/duotone-theme.space.css";
+fastn_dom.codeData.availableThemes["fastn-theme.dark"] = "../../theme_css/fastn-theme.dark.css";
+fastn_dom.codeData.availableThemes["fastn-theme.light"] = "../../theme_css/fastn-theme.light.css";
+fastn_dom.codeData.availableThemes["fire.light"] = "../../theme_css/fire.light.css";
+fastn_dom.codeData.availableThemes["gruvbox-theme.dark"] = "../../theme_css/gruvbox-theme.dark.css";
+fastn_dom.codeData.availableThemes["gruvbox-theme.light"] = "../../theme_css/gruvbox-theme.light.css";
+fastn_dom.codeData.availableThemes["laserwave-theme"] = "../../theme_css/laserwave-theme.css";
+fastn_dom.codeData.availableThemes["material-theme.dark"] = "../../theme_css/material-theme.dark.css";
+fastn_dom.codeData.availableThemes["material-theme.light"] = "../../theme_css/material-theme.light.css";
+fastn_dom.codeData.availableThemes["nightowl-theme"] = "../../theme_css/nightowl-theme.css";
+fastn_dom.codeData.availableThemes["one-theme.dark"] = "../../theme_css/one-theme.dark.css";
+fastn_dom.codeData.availableThemes["one-theme.light"] = "../../theme_css/one-theme.light.css";
+fastn_dom.codeData.availableThemes["vs-theme.dark"] = "../../theme_css/vs-theme.dark.css";
+fastn_dom.codeData.availableThemes["vs-theme.light"] = "../../theme_css/vs-theme.light.css";
+fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-theme.css";
+
+        let main_wrapper = function (parent) {
+            let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Column);
+            parenti0.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
+            parenti0.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.FillContainer, inherited);
+            main(parenti0);
+        }
+        fastn_virtual.hydrate(main_wrapper);
+        ftd.post_init();
+    })();
+
+    window.onload = function() {
+        fastn_utils.resetFullHeight();
+        fastn_utils.setFullHeight();
+    };
+
+</script>
+</html>


### PR DESCRIPTION
A new internal `ftd.cookie` record and library function with the same name has been added to enable cookie support in fastn.

Example:
```ftd
-- ftd.cookie user: user-name
value: Harsh Singh
secure: true

-- ftd.cookie user-2: user-name
value: Rithik Seth
secure: true

-- string $user-name: *$user.value

-- ftd.text: $user-name

-- ftd.text: Save User Cookie
$on-click$: $save-user(a = $user)

-- ftd.text: Update User Cookie
$on-click$: $save-user(a = $user-2)

-- ftd.text: Get User
$on-click$: $get-user($a = $user-name)

-- void save-user(a):
ftd.cookie a:

ftd.cookie.set(a)

-- void get-user(a):
string $a:

__args__.a.set(ftd.cookie.get("user-name"))
```