### PR TITLE
Porting Vercel Remote Cache SDK to Rust

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./fastn-core/Cargo.toml"
+    ],
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./fastn-core/Cargo.toml"
-    ],
-    "rust-analyzer.showUnlinkedFileNotification": false
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1575,7 @@ dependencies = [
  "antidote",
  "async-lock",
  "async-recursion",
+ "atty",
  "camino",
  "clap",
  "colored",
@@ -2082,6 +2094,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -2378,7 +2399,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys",
 ]
@@ -2768,7 +2789,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ wgpu = "0.16"
 winit = "0.28"
 zip = "0.6"
 prettify-js = "0.1.0"
+atty = "0.2"
 indexmap = { version = "2", features = ["serde"] }
 
 [workspace.dependencies.rusqlite]

--- a/fastn-core/Cargo.toml
+++ b/fastn-core/Cargo.toml
@@ -76,6 +76,7 @@ url.workspace = true
 zip.workspace = true
 fastn-observer.workspace = true
 fastn-js.workspace = true
+atty.workspace = true
 
 [dev-dependencies]
 fbt-lib.workspace = true

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -32,6 +32,7 @@ mod translation;
 mod version;
 // mod wasm;
 mod library2022;
+pub mod vercel;
 mod workspace;
 
 pub(crate) use auto_import::AutoImport;

--- a/fastn-core/src/vercel/artifact.rs
+++ b/fastn-core/src/vercel/artifact.rs
@@ -1,0 +1,98 @@
+struct ArtifactBaseRequest {
+    token: String,
+    url: String,
+    user_agent: String,
+    options: Option<ArtifactOptions>,
+    response: Option<reqwest::Response>,
+}
+
+struct ArtifactOptions {
+    duration: Option<u64>,
+    tag: Option<String>,
+}
+
+impl ArtifactBaseRequest {
+    fn new(
+        token: String,
+        url: String,
+        user_agent: String,
+        options: Option<ArtifactOptions>,
+    ) -> Self {
+        ArtifactBaseRequest {
+            token,
+            url,
+            user_agent,
+            options,
+            response: None,
+        }
+    }
+
+    fn get_headers(&self, method: &str) -> reqwest::header::HeaderMap {
+        let mut headers = reqwest::header::HeaderMap::new();
+
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", self.token)).unwrap(),
+        );
+
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            reqwest::header::HeaderValue::from_str(&self.user_agent).unwrap(),
+        );
+
+        if method == "PUT" {
+            headers.insert(
+                reqwest::header::CONTENT_TYPE,
+                reqwest::header::HeaderValue::from_static("application/octet-stream"),
+            );
+
+            if let Some(options) = &self.options {
+                if let Some(duration) = options.duration {
+                    headers.insert(
+                        reqwest::header::HeaderName::from_static("x-artifact-duration"),
+                        reqwest::header::HeaderValue::from(duration),
+                    );
+                }
+
+                if let Some(tag) = &options.tag {
+                    headers.insert(
+                        reqwest::header::HeaderName::from_static("x-artifact-tag"),
+                        reqwest::header::HeaderValue::from_str(tag).unwrap(),
+                    );
+                }
+            }
+        }
+
+        if let Ok(ci_name) = std::env::var("CI") {
+            headers.insert(
+                reqwest::header::HeaderName::from_static("x-artifact-client-ci"),
+                reqwest::header::HeaderValue::from_str(&ci_name).unwrap(),
+            );
+        }
+
+        let is_tty = atty::is(atty::Stream::Stdout);
+        headers.insert(
+            reqwest::header::HeaderName::from_static("x-artifact-client-interactive"),
+            reqwest::header::HeaderValue::from_str(if is_tty { "1" } else { "0" }).unwrap(),
+        );
+
+        headers
+    }
+
+    async fn fetch(&mut self, method: &str) -> fastn_core::Result<()> {
+        let client = reqwest::Client::new();
+
+        let response = match method {
+            "GET" => client.get(&self.url),
+            "HEAD" => client.head(&self.url),
+            "PUT" => client.put(&self.url),
+            _ => todo!(),
+        }
+        .headers(self.get_headers(method))
+        .send()
+        .await?;
+
+        self.response = Some(response);
+        Ok(())
+    }
+}

--- a/fastn-core/src/vercel/constants.rs
+++ b/fastn-core/src/vercel/constants.rs
@@ -1,0 +1,1 @@
+pub const REMOTE_CACHE_ENDPOINT: &str = "https://vercel.com/api/v8/artifacts";

--- a/fastn-core/src/vercel/mod.rs
+++ b/fastn-core/src/vercel/mod.rs
@@ -1,0 +1,5 @@
+pub mod constants;
+
+mod artifact;
+pub mod remote_cache_client;
+mod utils;

--- a/fastn-core/src/vercel/mod.rs
+++ b/fastn-core/src/vercel/mod.rs
@@ -1,5 +1,5 @@
 pub mod constants;
 
-mod artifact;
+pub mod artifact;
 pub mod remote_cache_client;
 mod utils;

--- a/fastn-core/src/vercel/remote_cache_client.rs
+++ b/fastn-core/src/vercel/remote_cache_client.rs
@@ -1,0 +1,34 @@
+pub(crate) struct RemoteClient {
+    token: String,
+    team_id: Option<String>,
+    user_agent: String,
+}
+
+impl RemoteClient {
+    fn new(token: String, team_id: Option<String>, product: String) -> RemoteClient {
+        RemoteClient {
+            token,
+            team_id,
+            user_agent: super::utils::get_user_agent(product.as_str()),
+        }
+    }
+
+    fn get_endpoint_url(self, hash: String) -> fastn_core::Result<String> {
+        if hash.contains('/') {
+            return Err(fastn_core::error::Error::GenericError(
+                "Invalid hash: Cannot contain '/'".to_string(),
+            ));
+        }
+        let params = if let Some(team_id) = &self.team_id {
+            format!("?teamId={}", team_id)
+        } else {
+            "".to_string()
+        };
+        Ok(format!(
+            "{}/{}{}",
+            super::constants::REMOTE_CACHE_ENDPOINT,
+            hash,
+            params
+        ))
+    }
+}

--- a/fastn-core/src/vercel/remote_cache_client.rs
+++ b/fastn-core/src/vercel/remote_cache_client.rs
@@ -1,19 +1,21 @@
+#[derive(Debug)]
 pub(crate) struct RemoteClient {
     token: String,
     team_id: Option<String>,
     user_agent: String,
 }
 
+#[allow(dead_code)]
 impl RemoteClient {
-    fn new(token: String, team_id: Option<String>, product: String) -> RemoteClient {
+    pub fn new(token: String, team_id: Option<String>, product: String) -> RemoteClient {
         RemoteClient {
             token,
             team_id,
-            user_agent: super::utils::get_user_agent(product.as_str()),
+            user_agent: fastn_core::vercel::utils::get_user_agent(product.as_str()),
         }
     }
 
-    fn get_endpoint_url(self, hash: String) -> fastn_core::Result<String> {
+    fn get_endpoint_url(&self, hash: String) -> fastn_core::Result<String> {
         if hash.contains('/') {
             return Err(fastn_core::error::Error::GenericError(
                 "Invalid hash: Cannot contain '/'".to_string(),
@@ -29,6 +31,51 @@ impl RemoteClient {
             super::constants::REMOTE_CACHE_ENDPOINT,
             hash,
             params
+        ))
+    }
+
+    pub fn get(
+        &self,
+        hash: String,
+        options: Option<fastn_core::vercel::artifact::ArtifactOptions>,
+    ) -> fastn_core::Result<fastn_core::vercel::artifact::ArtifactGetRequest> {
+        Ok(fastn_core::vercel::artifact::ArtifactGetRequest(
+            fastn_core::vercel::artifact::ArtifactBaseRequest::new(
+                self.token.to_string(),
+                self.get_endpoint_url(hash)?.clone(),
+                self.user_agent.to_string(),
+                options,
+            ),
+        ))
+    }
+
+    pub fn put(
+        &self,
+        hash: String,
+        options: Option<fastn_core::vercel::artifact::ArtifactOptions>,
+    ) -> fastn_core::Result<fastn_core::vercel::artifact::ArtifactPutRequest> {
+        Ok(fastn_core::vercel::artifact::ArtifactPutRequest(
+            fastn_core::vercel::artifact::ArtifactBaseRequest::new(
+                self.token.to_string(),
+                self.get_endpoint_url(hash)?.clone(),
+                self.user_agent.to_string(),
+                options,
+            ),
+        ))
+    }
+
+    pub fn exists(
+        &self,
+        hash: String,
+        options: Option<fastn_core::vercel::artifact::ArtifactOptions>,
+    ) -> fastn_core::Result<fastn_core::vercel::artifact::ArtifactExistsRequest> {
+        Ok(fastn_core::vercel::artifact::ArtifactExistsRequest(
+            fastn_core::vercel::artifact::ArtifactBaseRequest::new(
+                self.token.to_string(),
+                self.get_endpoint_url(hash)?.clone(),
+                self.user_agent.to_string(),
+                options,
+            ),
         ))
     }
 }

--- a/fastn-core/src/vercel/utils.rs
+++ b/fastn-core/src/vercel/utils.rs
@@ -1,0 +1,13 @@
+pub fn get_user_agent(product: &str) -> String {
+    let cargo_version = env!("CARGO_PKG_VERSION");
+    let target_os = std::env::consts::OS;
+    let target_arch = std::env::consts::ARCH;
+    format!(
+        "vercel/remote {} {} {} {} ({})",
+        cargo_version,
+        product,
+        env!("CARGO_PKG_VERSION"),
+        target_os,
+        target_arch
+    )
+}


### PR DESCRIPTION
Porting Vercel Remote Cache SDK to Rust for uploading and retrieving cache artifacts.

Github repository of Vercel Remote Cache SDK: https://github.com/vercel/remote-cache
Docs: https://vercel.com/docs/monorepos/remote-caching