### PR TITLE
Create single .output dir for build and cache

### DIFF
--- a/fastn-core/src/apis/cache.rs
+++ b/fastn-core/src/apis/cache.rs
@@ -97,7 +97,7 @@ pub async fn clear_(
     for package in query.package.iter() {
         if package.eq("main") {
             // TODO: List directories and files other than main
-            fastn_core::utils::remove_except(&config.root, &[".packages", ".build"]).await?;
+            fastn_core::utils::remove_except(&config.root, &[".packages", ".output"]).await?;
         } else {
             let path = tokio::fs::canonicalize(config.packages_root.join(package)).await?;
             if path.starts_with(&config.packages_root) {

--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -11,7 +11,7 @@ pub async fn build(
 
     // Default css and js
     default_build_files(
-        config.root.join(".build"),
+        config.output_dir.join("build"),
         &config.ftd_edition,
         &config.package.name,
     )
@@ -49,7 +49,7 @@ pub async fn build(
                 format!("{}/index.html", redirect_from.trim_matches('/'))
             };
 
-            let save_path = config.root.join(".build").join(save_file.as_str());
+            let save_path = config.output_dir.join("build").join(save_file.as_str());
             fastn_core::utils::update(save_path, content.as_bytes())
                 .await
                 .ok();
@@ -70,9 +70,11 @@ mod build_dir {
     {
         let mut b = std::collections::BTreeMap::new();
 
-        for f in find_all_files_recursively(".build") {
+        for f in find_all_files_recursively(".output/build") {
             b.insert(
-                f.to_string_lossy().to_string().replacen(".build/", "", 1),
+                f.to_string_lossy()
+                    .to_string()
+                    .replacen(".output/build/", "", 1),
                 fastn_core::utils::generate_hash(std::fs::read(&f)?),
             );
         }
@@ -597,7 +599,7 @@ async fn handle_file_(
 
             fastn_core::utils::copy(
                 config.root.join(doc.id.as_str()),
-                config.root.join(".build").join(doc.id.as_str()),
+                config.output_dir.join("build").join(doc.id.as_str()),
             )
             .await
             .ok();
@@ -797,7 +799,8 @@ async fn process_static(
         package: &fastn_core::Package,
     ) -> fastn_core::Result<()> {
         let build_path = base_path
-            .join(".build")
+            .join(".output")
+            .join("build")
             .join("-")
             .join(package.name.as_str());
 
@@ -818,14 +821,14 @@ async fn process_static(
 
         {
             // TODO: need to remove this once download_base_url is removed
-            std::fs::create_dir_all(base_path.join(".build"))?;
+            std::fs::create_dir_all(base_path.join(".output").join("build"))?;
             if let Some((dir, _)) = sa.id.rsplit_once(std::path::MAIN_SEPARATOR) {
-                std::fs::create_dir_all(base_path.join(".build").join(dir))?;
+                std::fs::create_dir_all(base_path.join(".output").join("build").join(dir))?;
             }
 
             std::fs::copy(
                 sa.base_path.join(sa.id.as_str()),
-                base_path.join(".build").join(sa.id.as_str()),
+                base_path.join(".output").join("build").join(sa.id.as_str()),
             )?;
         }
         Ok(())

--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -1,9 +1,9 @@
 pub const INDEX_FILE: &str = "index.html";
-pub const BUILD_FOLDER: &str = ".build";
+pub const BUILD_FOLDER: &str = "build";
 pub const IGNORED_DIRECTORIES: [&str; 4] = ["-", "images", "static", "assets"];
 
 pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result<()> {
-    let build_path = config.root.join(BUILD_FOLDER);
+    let build_path = config.output_dir.join(BUILD_FOLDER);
     let build_directory = build_path.as_str().to_string();
     println!("Post build index assertion started ...");
 

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -31,6 +31,7 @@ pub struct Config {
     // Global Information
     pub package: fastn_core::Package,
     pub root: camino::Utf8PathBuf,
+    pub output_dir: camino::Utf8PathBuf,
     pub packages_root: camino::Utf8PathBuf,
     pub original_directory: camino::Utf8PathBuf,
     pub all_packages: std::cell::RefCell<std::collections::BTreeMap<String, fastn_core::Package>>,
@@ -52,7 +53,7 @@ impl Config {
     /// `build_dir` is where the static built files are stored. `fastn build` command creates this
     /// folder and stores its output here.
     pub fn build_dir(&self) -> camino::Utf8PathBuf {
-        self.root.join(".build")
+        self.output_dir.join("build")
     }
 
     pub fn clone_dir(&self) -> camino::Utf8PathBuf {
@@ -1273,12 +1274,14 @@ impl Config {
                 )
             }
         };
+        let output_dir = root.join(".output");
         let fastn_doc = utils::fastn_doc(&root.join("FASTN.ftd")).await?;
         let package = fastn_core::Package::from_fastn_doc(&root, &fastn_doc)?;
         let mut config = Config {
             package: package.clone(),
             packages_root: root.clone().join(".packages"),
             root,
+            output_dir,
             original_directory,
             current_document: None,
             all_packages: Default::default(),

--- a/fastn-core/src/file.rs
+++ b/fastn-core/src/file.rs
@@ -152,7 +152,7 @@ pub fn package_ignores(
     overrides.add("!.tracks")?;
     overrides.add("!fastn")?;
     overrides.add("!rust-toolchain")?;
-    overrides.add("!.build")?;
+    overrides.add("!.output")?;
     for ignored_path in &package.ignored_paths {
         overrides.add(format!("!{}", ignored_path).as_str())?;
     }
@@ -166,7 +166,7 @@ pub fn ignore_path(
 ) -> Result<ignore::overrides::Override, ignore::Error> {
     let mut overrides = ignore::overrides::OverrideBuilder::new(root_path);
     overrides.add("!.packages")?;
-    overrides.add("!.build")?;
+    overrides.add("!.output")?;
     for ignored_path in &package.ignored_paths {
         overrides.add(format!("!{}", ignored_path).as_str())?;
     }

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -43,25 +43,18 @@ pub fn get_ftd_hash(path: &str) -> fastn_core::Result<String> {
 }
 
 pub fn get_cache_file(id: &str) -> Option<std::path::PathBuf> {
-    let cache_dir = dirs::cache_dir()?;
-    let base_path = cache_dir.join("fastn.com");
+    let current_dir = std::env::current_dir().expect("cant read current dir");
+    let output_dir = current_dir.join(".output");
+    let cache_dir = output_dir.join("cache");
 
-    if !base_path.exists() {
-        if let Err(err) = std::fs::create_dir_all(&base_path) {
+    if !cache_dir.exists() {
+        if let Err(err) = std::fs::create_dir_all(&cache_dir) {
             eprintln!("Failed to create cache directory: {}", err);
             return None;
         }
     }
 
-    Some(
-        base_path
-            .join(id_to_cache_key(
-                &std::env::current_dir()
-                    .expect("cant read current dir")
-                    .to_string_lossy(),
-            ))
-            .join(id_to_cache_key(id)),
-    )
+    Some(cache_dir.join(id_to_cache_key(id)))
 }
 
 pub fn get_cached<T>(id: &str) -> Option<T>

--- a/fastn-core/src/version.rs
+++ b/fastn-core/src/version.rs
@@ -108,7 +108,7 @@ pub(crate) async fn build_version(
                         )
                     };
                     let original_file_path =
-                        config.root.join(".build").join(original_file_rel_path);
+                        config.output_dir.join("build").join(original_file_rel_path);
                     let file_rel_path = if new_id.contains("index.ftd") {
                         new_id.replace("index.ftd", "index.html")
                     } else {
@@ -117,7 +117,7 @@ pub(crate) async fn build_version(
                             format!("{}index.html", std::path::MAIN_SEPARATOR).as_str(),
                         )
                     };
-                    let new_file_path = config.root.join(".build").join(file_rel_path);
+                    let new_file_path = config.output_dir.join("build").join(file_rel_path);
                     let original_content = std::fs::read_to_string(&original_file_path)?;
                     std::fs::create_dir_all(&new_file_path.as_str().replace("index.html", ""))?;
                     let mut f = std::fs::File::create(&new_file_path)?;


### PR DESCRIPTION
Create single .output dir for build and cache. This way they can be packed into a single artifact and only one http request will be required to upload/retrieve it.