### PR TITLE
prevent undefined from getting printed in markdown text

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1883,7 +1883,9 @@ class Node2 {
                 staticValue = this.#node.innerHTML;
             }
             staticValue = fastn_utils.process_post_markdown(this.#node, staticValue);
-            this.#node.innerHTML = staticValue;
+            if(!fastn_utils.isNull(staticValue)) {
+                this.#node.innerHTML = staticValue;
+            }
         } else {
             throw ("invalid fastn_dom.PropertyKind: " + kind);
         }

--- a/ftd/t/js/21-markdown.ftd
+++ b/ftd/t/js/21-markdown.ftd
@@ -3,3 +3,16 @@
 # Marked in the browser
 
 Rendered by **marked**.
+
+-- component markdown:
+body string text:
+
+-- ftd.text:
+text: $markdown.text
+
+-- end: markdown
+
+-- markdown:
+
+;; COMMENT NEXT LINE
+;; Go to the [new page](/new-page/).

--- a/ftd/t/js/21-markdown.html
+++ b/ftd/t/js/21-markdown.html
@@ -17,7 +17,7 @@
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 <body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3"><h1 id="marked-in-the-browser">Marked in the browser</h1>
-Rendered by <strong>marked</strong>.</div></div></body><style id="styles">
+Rendered by <strong>marked</strong>.</div><div data-id="4"></div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
     </style>
@@ -31,11 +31,28 @@ let main = function (parent) {
   try {
     let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
     parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "# Marked in the browser\n\nRendered by **marked**.", inherited);
+    let parenti1 = foo__markdown(parent, inherited);
   } finally {
     __fastn_package_name__ = __fastn_super_package_name__;
   }
 }
 global["main"] = main;
+let foo__markdown = function (parent, inherited, args) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "foo";
+  try {
+    let __args__ = {
+    };
+    inherited = fastn_utils.getInheritedValues(__args__, inherited, args);
+    __args__ = fastn_utils.getArgs(__args__, args);
+    let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti0.setProperty(fastn_dom.PropertyKind.StringValue, __args__.text, inherited);
+    return parenti0;
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
+global["foo__markdown"] = foo__markdown;
 fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "../../theme_css/coldark-theme.dark.css";
 fastn_dom.codeData.availableThemes["coldark-theme.light"] = "../../theme_css/coldark-theme.light.css";
 fastn_dom.codeData.availableThemes["coy-theme"] = "../../theme_css/coy-theme.css";

--- a/ftd/t/js/63-external-js.html
+++ b/ftd/t/js/63-external-js.html
@@ -16,7 +16,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="__cur-3">Hello</div><div data-id="4">undefined</div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="__cur-3">Hello</div><div data-id="4"></div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
 	.__cur-3 { cursor: pointer; }


### PR DESCRIPTION
this fix should prevent undefined from getting printed in markdown text.

Issue: https://github.com/fastn-stack/fastn/issues/1361
