### PR TITLE
selectable property added

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -277,6 +277,7 @@ fastn_dom.PropertyKind = {
     Muted: 115,
     LinkColor: 116,
     TextShadow: 117,
+    Selectable: 118,
 };
 
 
@@ -1560,6 +1561,12 @@ class Node2 {
             // overflow: auto, resize: staticValue
             this.attachCss("resize", staticValue);
             this.attachCss("overflow", "auto");
+        } else if (kind === fastn_dom.PropertyKind.Selectable) {
+            if(staticValue === false) {
+                this.attachCss("user-select", "none");
+            } else {
+                this.attachCss("user-select", null);
+            }
         } else if (kind === fastn_dom.PropertyKind.MinHeight) {
             this.attachCss("min-height", staticValue);
         } else if (kind === fastn_dom.PropertyKind.MaxHeight) {

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -425,6 +425,7 @@ pub enum PropertyKind {
     MetaTwitterImage,
     MetaThemeColor,
     Favicon,
+    Selectable,
 }
 
 impl PropertyKind {
@@ -562,6 +563,7 @@ impl PropertyKind {
                 "fastn_dom.PropertyKind.DocumentProperties.MetaThemeColor"
             }
             PropertyKind::Favicon => "fastn_dom.PropertyKind.Favicon",
+            PropertyKind::Selectable => "fastn_dom.PropertyKind.Selectable",
         }
     }
 }

--- a/ftd/src/interpreter/things/default.rs
+++ b/ftd/src/interpreter/things/default.rs
@@ -10725,6 +10725,12 @@ fn common_arguments() -> Vec<ftd::interpreter::Argument> {
                 .into_optional()
                 .into_kind_data(),
         ),
+        ftd::interpreter::Argument::default(
+            "selectable",
+            ftd::interpreter::Kind::boolean()
+                .into_optional()
+                .into_kind_data(),
+        ),
     ]
 }
 
@@ -10770,12 +10776,6 @@ fn text_arguments() -> Vec<ftd::interpreter::Argument> {
         ftd::interpreter::Argument::default(
             "text-shadow",
             ftd::interpreter::Kind::record(ftd::interpreter::FTD_SHADOW)
-                .into_optional()
-                .into_kind_data(),
-        ),
-        ftd::interpreter::Argument::default(
-            "selectable",
-            ftd::interpreter::Kind::boolean()
                 .into_optional()
                 .into_kind_data(),
         ),

--- a/ftd/src/interpreter/things/default.rs
+++ b/ftd/src/interpreter/things/default.rs
@@ -10773,6 +10773,12 @@ fn text_arguments() -> Vec<ftd::interpreter::Argument> {
                 .into_optional()
                 .into_kind_data(),
         ),
+        ftd::interpreter::Argument::default(
+            "selectable",
+            ftd::interpreter::Kind::boolean()
+                .into_optional()
+                .into_kind_data(),
+        ),
     ]
 }
 

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -2208,6 +2208,7 @@ pub struct Common {
     pub css: Option<ftd::js::Value>,
     pub js: Option<ftd::js::Value>,
     pub events: Vec<ftd::interpreter::Event>,
+    pub selectable: Option<ftd::js::Value>,
 }
 
 impl Common {
@@ -2423,6 +2424,7 @@ impl Common {
             whitespace: ftd::js::value::get_optional_js_value("white-space", properties, arguments),
             shadow: ftd::js::value::get_optional_js_value("shadow", properties, arguments),
             events: events.to_vec(),
+            selectable: ftd::js::value::get_optional_js_value("selectable", properties, arguments),
         }
     }
 
@@ -3003,6 +3005,16 @@ impl Common {
             component_statements.push(fastn_js::ComponentStatement::SetProperty(
                 open_in_new_tab.to_set_property(
                     fastn_js::PropertyKind::OpenInNewTab,
+                    doc,
+                    element_name,
+                    rdata,
+                ),
+            ));
+        }
+        if let Some(ref selectable) = self.selectable {
+            component_statements.push(fastn_js::ComponentStatement::SetProperty(
+                selectable.to_set_property(
+                    fastn_js::PropertyKind::Selectable,
                     doc,
                     element_name,
                     rdata,

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -3013,12 +3013,7 @@ impl Common {
         }
         if let Some(ref selectable) = self.selectable {
             component_statements.push(fastn_js::ComponentStatement::SetProperty(
-                selectable.to_set_property(
-                    fastn_js::PropertyKind::Selectable,
-                    doc,
-                    element_name,
-                    rdata,
-                ),
+                selectable.to_set_property(fastn_js::PropertyKind::Selectable, doc, element_name, rdata),
             ));
         }
         component_statements

--- a/ftd/src/js/element.rs
+++ b/ftd/src/js/element.rs
@@ -3013,7 +3013,12 @@ impl Common {
         }
         if let Some(ref selectable) = self.selectable {
             component_statements.push(fastn_js::ComponentStatement::SetProperty(
-                selectable.to_set_property(fastn_js::PropertyKind::Selectable, doc, element_name, rdata),
+                selectable.to_set_property(
+                    fastn_js::PropertyKind::Selectable,
+                    doc,
+                    element_name,
+                    rdata,
+                ),
             ));
         }
         component_statements

--- a/ftd/t/js/64-selectable.ftd
+++ b/ftd/t/js/64-selectable.ftd
@@ -1,0 +1,4 @@
+-- ftd.text: You can select this value
+
+-- ftd.text: You cannot select this value
+selectable: false

--- a/ftd/t/js/64-selectable.html
+++ b/ftd/t/js/64-selectable.html
@@ -1,0 +1,83 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <meta content="fastn" name="generator">
+    
+    
+    <script>
+        let __fastn_package_name__ = "foo";
+    </script>
+
+    <script src="fastn-js.js"></script>
+
+    <style>
+       
+    </style>
+</head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3">You can select this value</div><div data-id="4" class="__user-select-3">You cannot select this value</div></div></body><style id="styles">
+    .__w-1 { width: 100%; }
+	.__h-2 { height: 100%; }
+	.__user-select-3 { user-select: none; }
+    </style>
+<script>
+    (function() {
+        let global = {
+};
+let main = function (parent) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "foo";
+  try {
+    let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti0.setProperty(fastn_dom.PropertyKind.StringValue, "You can select this value", inherited);
+    let parenti1 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Text);
+    parenti1.setProperty(fastn_dom.PropertyKind.StringValue, "You cannot select this value", inherited);
+    parenti1.setProperty(fastn_dom.PropertyKind.Selectable, false, inherited);
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
+global["main"] = main;
+fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "../../theme_css/coldark-theme.dark.css";
+fastn_dom.codeData.availableThemes["coldark-theme.light"] = "../../theme_css/coldark-theme.light.css";
+fastn_dom.codeData.availableThemes["coy-theme"] = "../../theme_css/coy-theme.css";
+fastn_dom.codeData.availableThemes["dracula-theme"] = "../../theme_css/dracula-theme.css";
+fastn_dom.codeData.availableThemes["duotone-theme.dark"] = "../../theme_css/duotone-theme.dark.css";
+fastn_dom.codeData.availableThemes["duotone-theme.earth"] = "../../theme_css/duotone-theme.earth.css";
+fastn_dom.codeData.availableThemes["duotone-theme.forest"] = "../../theme_css/duotone-theme.forest.css";
+fastn_dom.codeData.availableThemes["duotone-theme.light"] = "../../theme_css/duotone-theme.light.css";
+fastn_dom.codeData.availableThemes["duotone-theme.sea"] = "../../theme_css/duotone-theme.sea.css";
+fastn_dom.codeData.availableThemes["duotone-theme.space"] = "../../theme_css/duotone-theme.space.css";
+fastn_dom.codeData.availableThemes["fastn-theme.dark"] = "../../theme_css/fastn-theme.dark.css";
+fastn_dom.codeData.availableThemes["fastn-theme.light"] = "../../theme_css/fastn-theme.light.css";
+fastn_dom.codeData.availableThemes["fire.light"] = "../../theme_css/fire.light.css";
+fastn_dom.codeData.availableThemes["gruvbox-theme.dark"] = "../../theme_css/gruvbox-theme.dark.css";
+fastn_dom.codeData.availableThemes["gruvbox-theme.light"] = "../../theme_css/gruvbox-theme.light.css";
+fastn_dom.codeData.availableThemes["laserwave-theme"] = "../../theme_css/laserwave-theme.css";
+fastn_dom.codeData.availableThemes["material-theme.dark"] = "../../theme_css/material-theme.dark.css";
+fastn_dom.codeData.availableThemes["material-theme.light"] = "../../theme_css/material-theme.light.css";
+fastn_dom.codeData.availableThemes["nightowl-theme"] = "../../theme_css/nightowl-theme.css";
+fastn_dom.codeData.availableThemes["one-theme.dark"] = "../../theme_css/one-theme.dark.css";
+fastn_dom.codeData.availableThemes["one-theme.light"] = "../../theme_css/one-theme.light.css";
+fastn_dom.codeData.availableThemes["vs-theme.dark"] = "../../theme_css/vs-theme.dark.css";
+fastn_dom.codeData.availableThemes["vs-theme.light"] = "../../theme_css/vs-theme.light.css";
+fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-theme.css";
+
+        let main_wrapper = function (parent) {
+            let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Column);
+            parenti0.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
+            parenti0.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.FillContainer, inherited);
+            main(parenti0);
+        }
+        fastn_virtual.hydrate(main_wrapper);
+        ftd.post_init();
+    })();
+
+    window.onload = function() {
+        fastn_utils.resetFullHeight();
+        fastn_utils.setFullHeight();
+    };
+
+</script>
+</html>


### PR DESCRIPTION
Added a new property called `selectable` (`boolean`) which is same as setting `user-select: none` in CSS. it is required for styling native-looking buttons, image galleries, etc.

Example:
```ftd
-- ftd.text: You can select this value

-- ftd.text: You cannot select this value
selectable: false
```