### PR TITLE
NULL anchor fix

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1663,6 +1663,9 @@ class Node2 {
         } else if (kind === fastn_dom.PropertyKind.Link) {
             // Changing node type to `a` for link
             // todo: needs fix for image links
+            if(fastn_utils.isNull(staticValue)) {
+                return;
+            }
             this.updateToAnchor(staticValue);
         } else if (kind === fastn_dom.PropertyKind.LinkRel) {
             if (fastn_utils.isNull(staticValue)) {

--- a/ftd/t/js/42-links.ftd
+++ b/ftd/t/js/42-links.ftd
@@ -8,3 +8,8 @@ if: { ftd.device == "mobile" }
 link: fastn.com
 background.solid: yellow
 if: { ftd.device == "desktop" }
+
+;; Should not update element to anchor if link is null
+
+-- ftd.text: Link
+link: NULL


### PR DESCRIPTION
Fixes the issue where an element gets updated to an anchor even when the value of `link`is null.

Example:

```ftd 
;; Update element to anchor

-- ftd.text: Link
link: https://example.com

;; Should not update element to anchor if link is null

-- ftd.text: Link
link: NULL
```