### PR TITLE
add nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,34 @@ We also offer our own hosting solution for your static and dynamic sites. Using
 managed hosting solution, that a non programmers can use with ease.
 
 
+## Usage with Nix
+
+```sh
+nix run github:fastn-stack/fastn
+```
+
+In a `flake.nix` file:
+
+```Nix
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    fastn.url = "github:fastn-stack/fastn";
+  };
+
+  outputs = { self, flake-utils, nixpkgs, fastn }:
+    flake-utils.lib.eachDefaultSystem (system:
+      rec {
+        # nix develop
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = [ fastn ];
+        };
+      }
+    );
+}
+```
+
 
 ## Contributors
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1697664192,
+        "narHash": "sha256-nRTG3rYEGFV2+putRiC96+kNXDyKaPJgT6K/1FWN7yo=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "636a9b5dd7f2ad7d7c3af929ecf95e4d4fab9e97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683236849,
+        "narHash": "sha256-Y7PNBVLOBvZrmrFmHgXUBUA1lM72tl6JGIn1trOeuyE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "374ffe54403c3c42d97a513ac7a14ce1b5b86e30",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-mozilla": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695805681,
+        "narHash": "sha256-1ElPLD8eFfnuIk0G52HGGpRtQZ4QPCjChRlEOfkZ5ro=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "6eabade97bc28d707a8b9d82ad13ef143836736e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1697660476,
+        "narHash": "sha256-w5/4HKG6/TPOFUki4rYUbME8zC6+suT6hSunyFD4BlI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "964a525d67348323be4fa100345d37b361ebd36e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-mozilla": "nixpkgs-mozilla"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+
+    naersk.url = "github:nix-community/naersk";
+
+    nixpkgs-mozilla = {
+      url = "github:mozilla/nixpkgs-mozilla";
+      flake = false;
+    };
+
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  };
+
+  outputs = { self, flake-utils, nixpkgs, nixpkgs-mozilla, naersk }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) {
+          inherit system;
+
+          overlays = [
+            (import nixpkgs-mozilla)
+          ];
+        };
+
+        toolchain = (pkgs.rustChannelOf {
+          rustToolchain = ./rust-toolchain;
+          sha256 = "sha256-Q9UgzzvxLi4x9aWUJTn+/5EXekC98ODRU1TwhUs9RnY=";
+        }).rust;
+
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+
+        fastnp = naersk'.buildPackage {
+          name = "fastn";
+          version = "0.3.0";
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [ pkg-config openssl.dev ];
+        };
+      in
+      rec {
+        # For `nix build` & `nix run`:
+        defaultPackage = fastnp;
+
+        packages = {
+          fastn = fastnp;
+        };
+
+        # nix develop
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = [ toolchain pkgs.pkg-config pkgs.openssl.dev ];
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
         toolchain = (pkgs.rustChannelOf {
           rustToolchain = ./rust-toolchain;
-          sha256 = "sha256-Q9UgzzvxLi4x9aWUJTn+/5EXekC98ODRU1TwhUs9RnY=";
+          sha256 = "sha256-rLP8+fTxnPHoR96ZJiCa/5Ans1OojI7MLsmSqR2ip8o=";
         }).rust;
 
         naersk' = pkgs.callPackage naersk {


### PR DESCRIPTION
This adds an option for nix users to use `fastn` in their systems. Usage instructions is added in the README.md
This is not cached so it has to be built from source everytime someone wants to use it. Using [cachix](https://www.cachix.org/) can help in this.