### PR TITLE
SQLite process read-write fix and param name support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ features = [
     # sqlite dynamic library is installed on everyone's machine. We can chose to give two
     # binaries, one with bundled, one without, but it is not worth the tradeoff right now.
     "bundled",
+    "column_decltype",
 ]
 
 


### PR DESCRIPTION
SQLite process read-write fix and param name support added. It was required for porting the `todo-app` from PostgreSQL to SQLite.

Param support is similar to what we had done with PostgreSQL processor:
```ftd
-- integer status:
$processor$: pr.package-query
db: db.sqlite
todo: $todo

INSERT INTO todos(todo, complete) VALUES (:todo::TEXT, 0)
```