### PR TITLE
.env support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1633,7 @@ version = "0.3.78"
 dependencies = [
  "clap",
  "colored",
+ "dotenvy",
  "fastn-cloud",
  "fastn-core",
  "fastn-observer",

--- a/fastn-core/src/commands/create_package.rs
+++ b/fastn-core/src/commands/create_package.rs
@@ -1,7 +1,7 @@
 async fn template_contents(
     project_name: &str,
     download_base_url: Option<&str>,
-) -> (String, String) {
+) -> (String, String, String) {
     let ftd = format!(
         r#"-- import: fastn
 
@@ -14,8 +14,12 @@ async fn template_contents(
             .unwrap_or_default()
     );
     let index = "-- ftd.text: Hello world".to_string();
+    let gitignore = r#".build/
+.env
+    "#
+    .to_string();
 
-    (ftd, index)
+    (ftd, index, gitignore)
 }
 
 pub async fn create_package(
@@ -53,12 +57,11 @@ pub async fn create_package(
     // Create all directories if not present
     tokio::fs::create_dir_all(final_dir.as_str()).await?;
 
-    let tmp_contents = template_contents(name, download_base_url).await;
-    let tmp_fastn = tmp_contents.0;
-    let tmp_index = tmp_contents.1;
+    let (tmp_fastn, tmp_index, tmp_gitignore) = template_contents(name, download_base_url).await;
 
     fastn_core::utils::update(&final_dir.join("FASTN.ftd"), tmp_fastn.as_bytes()).await?;
     fastn_core::utils::update(&final_dir.join("index.ftd"), tmp_index.as_bytes()).await?;
+    fastn_core::utils::update(&final_dir.join(".gitignore"), tmp_gitignore.as_bytes()).await?;
 
     // Note: Not required for now
     // let sync_message = "Initial sync".to_string();

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -20,3 +20,4 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+dotenvy = "0.15.7"

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -578,9 +578,16 @@ Remove it from your version control system or run fastn again with
 FASTN_DANGER_ACCEPT_CHECKED_IN_ENV set"
         );
         std::process::exit(1);
-    }
+    } else {
+        if checked_in && ignore {
+            println!(
+                "WARN: your .env file has been detected in the version control system! This poses a
+significant security risk in case the source code becomes public."
+            );
+        }
 
-    if dotenvy::dotenv().is_ok() {
-        println!("INFO: loaded environment variables from .env file.");
+        if dotenvy::dotenv().is_ok() {
+            println!("INFO: loaded environment variables from .env file.");
+        }
     }
 }

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -547,7 +547,7 @@ pub fn version() -> &'static str {
     }
 }
 
-fn set_env_vars() -> () {
+fn set_env_vars() {
     let checked_in = {
         if let Ok(status) = std::process::Command::new("git")
             .arg("ls-files")
@@ -580,7 +580,7 @@ FASTN_DANGER_ACCEPT_CHECKED_IN_ENV set"
         std::process::exit(1);
     }
 
-    if let Ok(_) = dotenvy::dotenv() {
+    if dotenvy::dotenv().is_ok() {
         println!("INFO: loaded environment variables from .env file.");
     }
 }


### PR DESCRIPTION
closes #1424 

- if there's a .env file in CWD, parse it and set env vars from it
- create-package should generate a .gitignore file that contains .env
  file
- check if the .env file is checked in, panic and proceed only when
  FASTN_DANGER_ACCEPT_CHECKED_IN_ENV is set
