### PR TITLE
Prevent internal class names from being removed

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -2,6 +2,12 @@ let fastn_dom = {};
 
 fastn_dom.styleClasses = "";
 
+fastn_dom.InternalClass = {
+    FT_COLUMN: 'ft_column',
+    FT_ROW: 'ft_row',
+    FULL: "full",
+};
+
 fastn_dom.codeData = {
     availableThemes: {},
     addedCssFile: []

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -5,7 +5,7 @@ fastn_dom.styleClasses = "";
 fastn_dom.InternalClass = {
     FT_COLUMN: 'ft_column',
     FT_ROW: 'ft_row',
-    FULL: "full",
+    FT_FULL_SIZE: "ft_full_size",
 };
 
 fastn_dom.codeData = {

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -7,7 +7,7 @@ let fastn_utils = {
             css.push(fastn_dom.InternalClass.FT_COLUMN);
         } else if (kind === fastn_dom.ElementKind.Document) {
             css.push(fastn_dom.InternalClass.FT_COLUMN);
-            css.push(fastn_dom.InternalClass.FULL);
+            css.push(fastn_dom.InternalClass.FT_FULL_SIZE);
         } else if (kind === fastn_dom.ElementKind.Row) {
             css.push(fastn_dom.InternalClass.FT_ROW);
         } else if (kind === fastn_dom.ElementKind.IFrame) {

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -1,4 +1,5 @@
 let fastn_utils = {
+    ftClassNames: ["ft_column", "ft_row"],
     htmlNode(kind) {
         let node = "div";
         let css = [];
@@ -104,7 +105,8 @@ let fastn_utils = {
         const classesToRemove = [];
 
         for (const className of iterativeClassList) {
-            if (!className.startsWith('__') &&
+            if (!className.startsWith('__') && 
+                !this.ftClassNames.includes(className) &&
                 className !== extraCodeData?.language &&
                 className !== extraCodeData?.theme
             ) {

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -1,16 +1,15 @@
 let fastn_utils = {
-    ftClassNames: ["ft_column", "ft_row"],
     htmlNode(kind) {
         let node = "div";
         let css = [];
         let attributes = {};
         if (kind === fastn_dom.ElementKind.Column) {
-            css.push("ft_column");
+            css.push(fastn_dom.InternalClass.FT_COLUMN);
         } else if (kind === fastn_dom.ElementKind.Document) {
-            css.push("ft_column");
-            css.push("full");
+            css.push(fastn_dom.InternalClass.FT_COLUMN);
+            css.push(fastn_dom.InternalClass.FULL);
         } else if (kind === fastn_dom.ElementKind.Row) {
-            css.push("ft_row");
+            css.push(fastn_dom.InternalClass.FT_ROW);
         } else if (kind === fastn_dom.ElementKind.IFrame) {
             node = "iframe";
             // To allow fullscreen support
@@ -102,11 +101,12 @@ let fastn_utils = {
         if (ssr) {
             iterativeClassList = iterativeClassList.getClasses();
         }
+        const internalClassNames = Object.values(fastn_dom.InternalClass);
         const classesToRemove = [];
 
         for (const className of iterativeClassList) {
             if (!className.startsWith('__') && 
-                !this.ftClassNames.includes(className) &&
+                !internalClassNames.includes(className) &&
                 className !== extraCodeData?.language &&
                 className !== extraCodeData?.theme
             ) {

--- a/ftd/ftd-js.css
+++ b/ftd/ftd-js.css
@@ -132,7 +132,7 @@ pre code {
     justify-content: start
 }
 
-.full {
+.ft_full_size {
     width: 100%;
     height: 100%;
 }

--- a/ftd/t/js/22-document.html
+++ b/ftd/t/js/22-document.html
@@ -17,7 +17,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column full"><div data-id="4">This is document component</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column ft_full_size"><div data-id="4">This is document component</div></div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
     </style>

--- a/ftd/t/js/41-document-favicon.html
+++ b/ftd/t/js/41-document-favicon.html
@@ -17,7 +17,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column full"><div data-id="4" class="__m-3 __c-4">This is some text</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column ft_full_size"><div data-id="4" class="__m-3 __c-4">This is some text</div></div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
 	.__m-3 { margin: 20px; }

--- a/ftd/t/js/72-document-breakpoint.html
+++ b/ftd/t/js/72-document-breakpoint.html
@@ -17,7 +17,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column full"><div data-id="4" class="__c-3">Mobile text</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column ft_full_size"><div data-id="4" class="__c-3">Mobile text</div></div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
 	.__c-3 { color: red !important; }


### PR DESCRIPTION
## What's the Issue?

The issue is that when using the `classes` header to set custom CSS class names, the class names of the kernel elements are being removed.

## How to Replicate

fastn code:

```ftd
-- ftd.column:
css: styles.css
classes: red

-- ftd.text: Hello World

-- end: ftd.column
```

Expected Output:

```html
<div class="ft_column red"><div>Hello World</div></div>
```

Actual Output:

```html
<div class="red"><div>Hello World</div></div>
```

## Proposed Solution

In `fastn-js/js/dom.js`, we can create a map of class names called `fastn_dom.InternalClass` that will be used by kernel components. Then, in the `fastn_utils.removeNonFastnClasses` function, we can check if the className that is going to be removed is not one of those class names.