### PR TITLE
cargo publish during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,3 +148,29 @@ jobs:
           tag: ${{ github.event.inputs.releaseTag }}
           prerelease: ${{ github.event.inputs.productionRelease && github.event.inputs.productionRelease == 'false' }}
           bodyFile: .github/RELEASE_TEMPLATE.md
+  publish-crate:
+    name: Publish our crate on crates.io
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            ftd/target
+            fifthtry_content/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Publish
+        uses: gmiam/rust-musl-action@9e6a37bf27ecfffb6b92240ea276bea5487fa15d
+        continue-on-error: false
+        with:
+          args: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,5 +172,7 @@ jobs:
       - name: Publish
         uses: gmiam/rust-musl-action@9e6a37bf27ecfffb6b92240ea276bea5487fa15d
         continue-on-error: false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
-          args: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+          args: cargo publish


### PR DESCRIPTION
In this PR I am trying to enable cargo publish command on each release so people can install `fastn` using `cargo install fastn` as well. 

We probably do not recommend that (as it recompiles everything, and is slower), but it would be good to have our package history on crates.io, and some people are more trusting of `cargo install` way than running shell scripts to install things.

References: 
- [CARGO_REGISTRY_TOKEN docs](https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials)
- [Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)