### PR TITLE
feat: add github user email

### DIFF
--- a/fastn-core/src/auth/github/apis.rs
+++ b/fastn-core/src/auth/github/apis.rs
@@ -18,7 +18,8 @@ pub struct User {
 pub struct GhUserDetails {
     pub login: String,
     pub id: usize,
-    pub name: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
 }
 
 // TODO: API to starred a repo on behalf of the user

--- a/fastn-core/src/auth/github/mod.rs
+++ b/fastn-core/src/auth/github/mod.rs
@@ -6,8 +6,7 @@ pub use apis::*;
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct UserDetail {
     pub access_token: String,
-    pub username: String,
-    pub name: String,
+    pub user: GhUserDetails,
 }
 
 pub async fn login(
@@ -58,8 +57,7 @@ pub async fn callback(
     let gh_user = fastn_core::auth::github::apis::user_details(access_token.as_str()).await?;
 
     let ud = UserDetail {
-        username: gh_user.login,
-        name: gh_user.name,
+        user: gh_user,
         access_token,
     };
 
@@ -233,7 +231,7 @@ pub async fn matched_contributed_repos(
             fastn_core::auth::github::apis::repo_contributors(ud.access_token.as_str(), repo)
                 .await?;
 
-        if repo_contributors.contains(&ud.username) {
+        if repo_contributors.contains(&ud.user.login) {
             matched_repo_contributors_list.push(String::from(repo.to_owned()));
         }
     }
@@ -273,7 +271,7 @@ pub async fn matched_collaborated_repos(
             fastn_core::auth::github::apis::repo_collaborators(ud.access_token.as_str(), repo)
                 .await?;
 
-        if repo_collaborator.contains(&ud.username) {
+        if repo_collaborator.contains(&ud.user.login) {
             matched_repo_collaborator_list.push(String::from(repo.to_owned()));
         }
     }
@@ -317,7 +315,7 @@ pub async fn matched_org_teams(
                 team_name,
             )
             .await?;
-            if team_members.contains(&ud.username) {
+            if team_members.contains(&ud.user.login) {
                 matched_org_teams.push(org_team.to_string());
             }
         }
@@ -359,7 +357,7 @@ pub async fn matched_sponsored_org(
     for sponsor in sponsors_list.iter() {
         if fastn_core::auth::github::apis::is_user_sponsored(
             ud.access_token.as_str(),
-            ud.username.as_str(),
+            ud.user.login.as_str(),
             sponsor.to_owned(),
         )
         .await?

--- a/fastn-core/src/auth/mod.rs
+++ b/fastn-core/src/auth/mod.rs
@@ -60,7 +60,9 @@ pub async fn get_user_data_from_cookies(
                         let github_ud: github::UserDetail =
                             serde_json::from_str(ud_decrypted.as_str())?;
                         match requested_field {
-                            "username" | "user_name" | "user-name" => Ok(Some(github_ud.username)),
+                            "username" | "user_name" | "user-name" => {
+                                Ok(Some(github_ud.user.login))
+                            }
                             "token" => Ok(Some(github_ud.access_token)),
                             _ => Err(fastn_core::Error::GenericError(format!(
                                 "invalid field {} requested for platform {}",

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -18,14 +18,9 @@ pub async fn process(
                 .map_err(|e| tracing::info!("[user-details]: Serde deserialization failed {e}:"))
             })
         {
-            match fastn_core::auth::github::user_details(user_detail.access_token.as_str()).await {
-                Ok(user) => {
-                    ud = UserDetails {
-                        is_logged_in: true,
-                        user: Some(user),
-                    }
-                }
-                Err(e) => tracing::info!("[user-details]: Failed to get github user: {e}"),
+            ud = UserDetails {
+                is_logged_in: true,
+                user: Some(user_detail.user),
             }
         }
     }


### PR DESCRIPTION
It'd be nice to have user email too. This can be used in Django's default [User](https://docs.djangoproject.com/en/4.2/ref/contrib/auth/) model.

fix: gh email and user's name can be `null`
    eg. [api.github.com/users/Vishvajeet590](https://api.github.com/users/Vishvajeet590)