### PR TITLE
Fix: Handle undefined/null values in the `value` property

### DIFF
--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -841,6 +841,10 @@ class Node2 {
         }
     }
     updateTextInputValue() {
+        if(fastn_utils.isNull(this.#rawInnerValue)) {
+            this.attachAttribute("value");
+            return;
+        }
         if (!ssr && this.#node.tagName.toLowerCase() === 'textarea') {
             this.#node.innerHTML = this.#rawInnerValue;
         } else {


### PR DESCRIPTION
This fix handles undefined/null values in the `value` property.