### PR TITLE
Refactored `replace_markers_2023`

### DIFF
--- a/fastn-core/src/package/package_doc.rs
+++ b/fastn-core/src/package/package_doc.rs
@@ -515,7 +515,6 @@ pub(crate) async fn read_ftd_2023(
     );
 
     let file_content = fastn_core::utils::replace_markers_2023(
-        ftd::ftd_js_html(),
         js_document_script.as_str(),
         js_ast_data.scripts.join("").as_str(),
         ssr_body.as_str(),

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -741,9 +741,7 @@ pub fn get_fastn_package_data(package: &fastn_core::Package) -> String {
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn replace_markers_2023(
-    s: &str,
     js_script: &str,
     scripts: &str,
     ssr_body: &str,
@@ -752,60 +750,42 @@ pub fn replace_markers_2023(
     base_url: &str,
     config: &fastn_core::Config,
 ) -> String {
-    ftd::html::utils::trim_all_lines(
-        s.replace(
-            "__fastn_package__",
-            get_fastn_package_data(&config.package).as_str(),
+    format!(
+        include_str!("../../ftd/ftd-js.html"),
+        fastn_package = get_fastn_package_data(&config.package).as_str(),
+        base_url = base_url,
+        favicon_html_tag = resolve_favicon(
+            config.root.as_str(),
+            config.package.name.as_str(),
+            &config.package.favicon,
         )
-        .replace(
-            "__js_script__",
-            format!("{js_script}{}", fastn_core::utils::available_code_themes()).as_str(),
-        )
-        .replace(
-            "__html_body__",
-            format!("{}{}", ssr_body, font_style).as_str(),
-        )
-        .replace(
-            "__favicon_html_tag__",
-            resolve_favicon(
-                config.root.as_str(),
-                config.package.name.as_str(),
-                &config.package.favicon,
-            )
-            .unwrap_or_default()
-            .as_str(),
-        )
-        .replace(
-            "__script_file__",
-            format!(
-                r#"
-                    <script src="{}"></script>
-                    <script src="{}"></script>
-                    <script src="{}"></script>
-                    <link rel="stylesheet" href="{}">
-                    {}
-                "#,
-                hashed_markdown_js(),
-                hashed_prism_js(),
-                hashed_default_ftd_js(config.package.name.as_str()),
-                hashed_prism_css(),
-                scripts,
-            )
-            .as_str(),
-        )
-        .replace(
-            "__extra_js__",
-            get_extra_js(
-                config.ftd_external_js.as_slice(),
-                config.ftd_inline_js.as_slice(),
-                "",
-                "",
-            )
-            .as_str(),
-        )
-        .replace("__default_css__", default_css)
-        .replace("__base_url__", base_url)
+        .unwrap_or_default()
         .as_str(),
+        js_script = format!("{js_script}{}", fastn_core::utils::available_code_themes()).as_str(),
+        script_file = format!(
+            r#"
+                <script src="{}"></script>
+                <script src="{}"></script>
+                <script src="{}"></script>
+                <link rel="stylesheet" href="{}">
+                {}
+            "#,
+            hashed_markdown_js(),
+            hashed_prism_js(),
+            hashed_default_ftd_js(config.package.name.as_str()),
+            hashed_prism_css(),
+            scripts,
+        )
+        .as_str(),
+        extra_js = get_extra_js(
+            config.ftd_external_js.as_slice(),
+            config.ftd_inline_js.as_slice(),
+            "",
+            "",
+        )
+        .as_str(),
+        default_css = default_css,
+        html_body = format!("{}{}", ssr_body, font_style).as_str(),
     )
 }
 

--- a/ftd/ftd-js.html
+++ b/ftd/ftd-js.html
@@ -2,41 +2,41 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <base href="__base_url__">
+    <base href="{base_url}">
     <meta content="fastn" name="generator">
-    __favicon_html_tag__
+    {favicon_html_tag}
     
     <script>
-        __fastn_package__
+        {fastn_package}
     </script>
 
-    __script_file____extra_js__
+    {script_file}
+    {extra_js}
 
     <style>
-       __default_css__
+       {default_css}
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-__html_body__
+{html_body}
 <script>
-    (function() {
-        __js_script__
+    (function() {{
+        {js_script}
 
-        let main_wrapper = function (parent) {
+        let main_wrapper = function (parent) {{
             let parenti0 = fastn_dom.createKernel(parent, fastn_dom.ElementKind.Column);
             parenti0.setProperty(fastn_dom.PropertyKind.Width, fastn_dom.Resizing.FillContainer, inherited);
             parenti0.setProperty(fastn_dom.PropertyKind.Height, fastn_dom.Resizing.FillContainer, inherited);
             main(parenti0);
-        }
+        }}
         fastnVirtual.doubleBuffer(main_wrapper);
         ftd.post_init();
-    })();
+    }})();
 
-    window.onload = function() {
+    window.onload = function() {{
         fastn_utils.resetFullHeight();
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
-    };
-
+    }};
 </script>
 </html>

--- a/ftd/src/js/ftd_test_helpers.rs
+++ b/ftd/src/js/ftd_test_helpers.rs
@@ -128,52 +128,46 @@ fn p(s: &str, t: &str, fix: bool, manual: bool, script: bool, file_location: &st
                 format!("{js_ftd_script}\n{js_document_script}").as_str(),
             );
 
-            ftd::ftd_js_html()
-                .replace("__extra_js__", "")
-                .replace("__fastn_package__", dummy_package_data.as_str())
-                .replace(
-                    "__js_script__",
+            format!(
+                include_str!("../../ftd-js.html"),
+                fastn_package = dummy_package_data.as_str(),
+                js_script =
                     format!("{js_document_script}{}", test_available_code_themes()).as_str(),
-                )
-                .replace("__favicon_html_tag__", "")
-                .replace("__html_body__", ssr_body.as_str())
-                .replace("<base href=\"__base_url__\">", "")
-                .replace(
-                    "__script_file__",
-                    format!(
-                        "{}{}",
-                        js_ast_data.scripts.join(""),
-                        if manual {
-                            format!(
-                                r#"
-                            <script src="../../prism/prism.js"></script>
-                            <script src="../../prism/prism-line-highlight.js"></script>
-                            <script src="../../prism/prism-line-numbers.js"></script>
-                            <script src="../../prism/prism-rust.js"></script>
-                            <script src="../../prism/prism-json.js"></script>
-                            <script src="../../prism/prism-python.js"></script>
-                            <script src="../../prism/prism-markdown.js"></script>
-                            <script src="../../prism/prism-bash.js"></script>
-                            <script src="../../prism/prism-sql.js"></script>
-                            <script src="../../prism/prism-javascript.js"></script>
-                            <link rel="stylesheet" href="../../prism/prism-line-highlight.css">
-                            <link rel="stylesheet" href="../../prism/prism-line-numbers.css">
-                            <script>{}</script>
-                        "#,
-                                ftd::js::all_js_without_test("foo")
-                            )
-                        } else {
-                            "<script src=\"fastn-js.js\"></script>".to_string()
-                        }
-                    )
+                favicon_html_tag = "",
+                base_url = "",
+                extra_js = "",
+                default_css = (if manual { ftd::ftd_js_css() } else { "" })
+                    .to_string()
                     .as_str(),
+                html_body = ssr_body.as_str(),
+                script_file = format!(
+                    "{}{}",
+                    js_ast_data.scripts.join(""),
+                    if manual {
+                        format!(
+                            r#"
+                        <script src="../../prism/prism.js"></script>
+                        <script src="../../prism/prism-line-highlight.js"></script>
+                        <script src="../../prism/prism-line-numbers.js"></script>
+                        <script src="../../prism/prism-rust.js"></script>
+                        <script src="../../prism/prism-json.js"></script>
+                        <script src="../../prism/prism-python.js"></script>
+                        <script src="../../prism/prism-markdown.js"></script>
+                        <script src="../../prism/prism-bash.js"></script>
+                        <script src="../../prism/prism-sql.js"></script>
+                        <script src="../../prism/prism-javascript.js"></script>
+                        <link rel="stylesheet" href="../../prism/prism-line-highlight.css">
+                        <link rel="stylesheet" href="../../prism/prism-line-numbers.css">
+                        <script>{}</script>
+                    "#,
+                            ftd::js::all_js_without_test("foo")
+                        )
+                    } else {
+                        "<script src=\"fastn-js.js\"></script>".to_string()
+                    }
                 )
-                .replace(
-                    "__default_css__",
-                    (if manual { ftd::ftd_js_css() } else { "" })
-                        .to_string()
-                        .as_str(),
-                )
+                .as_str(),
+            )
         }
     };
     if fix || manual || script {

--- a/ftd/src/lib.rs
+++ b/ftd/src/lib.rs
@@ -56,10 +56,6 @@ pub fn theme_css() -> ftd::Map<String> {
     themes
 }
 
-pub fn ftd_js_html() -> &'static str {
-    include_str!("../ftd-js.html")
-}
-
 pub fn ftd_js_css() -> &'static str {
     include_str!("../ftd-js.css")
 }

--- a/ftd/t/js/01-basic-module.html
+++ b/ftd/t/js/01-basic-module.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -126,6 +127,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/01-basic.html
+++ b/ftd/t/js/01-basic.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -89,6 +90,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/02-property.html
+++ b/ftd/t/js/02-property.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -113,6 +114,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/03-common-properties.html
+++ b/ftd/t/js/03-common-properties.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -1864,6 +1865,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/04-variable.html
+++ b/ftd/t/js/04-variable.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -195,6 +196,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/05-dynamic-dom-list.html
+++ b/ftd/t/js/05-dynamic-dom-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -179,6 +180,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/06-dynamic-dom-list-2.html
+++ b/ftd/t/js/06-dynamic-dom-list-2.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -157,6 +158,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/07-dynamic-dom-record-list.html
+++ b/ftd/t/js/07-dynamic-dom-record-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -139,6 +140,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/08-inherited.html
+++ b/ftd/t/js/08-inherited.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -541,6 +542,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/09-text-properties.html
+++ b/ftd/t/js/09-text-properties.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -233,6 +234,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/10-color-test.html
+++ b/ftd/t/js/10-color-test.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -201,6 +202,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/11-device.html
+++ b/ftd/t/js/11-device.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -147,6 +148,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/12-children.html
+++ b/ftd/t/js/12-children.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -135,6 +136,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/13-non-style-properties.html
+++ b/ftd/t/js/13-non-style-properties.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -182,6 +183,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/14-code.html
+++ b/ftd/t/js/14-code.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -276,6 +277,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/15-function-call-in-property.html
+++ b/ftd/t/js/15-function-call-in-property.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -118,6 +119,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/16-container.html
+++ b/ftd/t/js/16-container.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -78,6 +79,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/17-clone.html
+++ b/ftd/t/js/17-clone.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -134,6 +135,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/17-events.html
+++ b/ftd/t/js/17-events.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -121,6 +122,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/18-rive.html
+++ b/ftd/t/js/18-rive.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="https://unpkg.com/@rive-app/canvas@1.0.98"></script><script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -246,6 +247,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/19-image.html
+++ b/ftd/t/js/19-image.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -82,6 +83,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/20-background-properties.html
+++ b/ftd/t/js/20-background-properties.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -169,6 +170,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/21-markdown.html
+++ b/ftd/t/js/21-markdown.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -92,6 +93,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/22-document.html
+++ b/ftd/t/js/22-document.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -96,6 +97,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/23-record-list.html
+++ b/ftd/t/js/23-record-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -176,6 +177,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/24-device.html
+++ b/ftd/t/js/24-device.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -127,6 +128,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/24-re-export.html
+++ b/ftd/t/js/24-re-export.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -135,6 +136,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/25-re-re-export.html
+++ b/ftd/t/js/25-re-re-export.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -166,6 +167,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/26-re-export.html
+++ b/ftd/t/js/26-re-export.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -100,6 +101,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/27-for-loop.html
+++ b/ftd/t/js/27-for-loop.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -109,6 +110,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/28-mutable-component-arguments.html
+++ b/ftd/t/js/28-mutable-component-arguments.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -116,6 +117,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/28-web-component.html
+++ b/ftd/t/js/28-web-component.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="ftd/ftd/t/assets/web_component.js" type="module"></script><script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -103,6 +104,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/29-dom-list.html
+++ b/ftd/t/js/29-dom-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -258,6 +259,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/30-web-component.html
+++ b/ftd/t/js/30-web-component.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="../../t/assets/todo.js" type="module"></script><script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -478,6 +479,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/31-advance-list.html
+++ b/ftd/t/js/31-advance-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -361,6 +362,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/31-ftd-len.html
+++ b/ftd/t/js/31-ftd-len.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -99,6 +100,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/32-ftd-len.html
+++ b/ftd/t/js/32-ftd-len.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -245,6 +246,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/33-list-indexing.html
+++ b/ftd/t/js/33-list-indexing.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -123,6 +124,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/34-ftd-ui.html
+++ b/ftd/t/js/34-ftd-ui.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -155,6 +156,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/36-single-ui.html
+++ b/ftd/t/js/36-single-ui.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -126,6 +127,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/37-expander.html
+++ b/ftd/t/js/37-expander.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -201,6 +202,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/38-background-image-properties.html
+++ b/ftd/t/js/38-background-image-properties.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -90,6 +91,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/40-code-themes.html
+++ b/ftd/t/js/40-code-themes.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -397,6 +398,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/41-document-favicon.html
+++ b/ftd/t/js/41-document-favicon.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -89,6 +90,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/42-links.html
+++ b/ftd/t/js/42-links.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -104,6 +105,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/43-image-object-fit.html
+++ b/ftd/t/js/43-image-object-fit.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -191,6 +192,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/44-local-storage.html
+++ b/ftd/t/js/44-local-storage.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -116,6 +117,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/44-module.html
+++ b/ftd/t/js/44-module.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -174,6 +175,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/45-re-module.html
+++ b/ftd/t/js/45-re-module.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -232,6 +233,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/45-re-re-module.html
+++ b/ftd/t/js/45-re-re-module.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -194,6 +195,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/46-code-languages.html
+++ b/ftd/t/js/46-code-languages.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -197,6 +198,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/47-ftd-code-syntax.html
+++ b/ftd/t/js/47-ftd-code-syntax.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -286,6 +287,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/48-video.html
+++ b/ftd/t/js/48-video.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -87,6 +88,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/49-align-content.html
+++ b/ftd/t/js/49-align-content.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -924,6 +925,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/50-iframe-fullscreen.html
+++ b/ftd/t/js/50-iframe-fullscreen.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -124,6 +125,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/51-markdown-table.html
+++ b/ftd/t/js/51-markdown-table.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -143,6 +144,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/52-events.html
+++ b/ftd/t/js/52-events.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -211,6 +212,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/53-link-color.html
+++ b/ftd/t/js/53-link-color.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -85,6 +86,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/54-class-fix.html
+++ b/ftd/t/js/54-class-fix.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -88,6 +89,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/56-title-fix.html
+++ b/ftd/t/js/56-title-fix.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -75,6 +76,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/57-code-dark-mode.html
+++ b/ftd/t/js/57-code-dark-mode.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -98,6 +99,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/59-text-shadow.html
+++ b/ftd/t/js/59-text-shadow.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -89,6 +90,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/60-conditional-module-headers.html
+++ b/ftd/t/js/60-conditional-module-headers.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -111,6 +112,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/61-functions.html
+++ b/ftd/t/js/61-functions.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -137,6 +138,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/62-fallback-fonts.html
+++ b/ftd/t/js/62-fallback-fonts.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -159,6 +160,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/63-external-js.html
+++ b/ftd/t/js/63-external-js.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="../../t/assets/test.js"></script><script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -140,6 +141,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/64-selectable.html
+++ b/ftd/t/js/64-selectable.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -78,6 +79,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/65-legacy.html
+++ b/ftd/t/js/65-legacy.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -114,6 +115,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/66-backdrop-filter.html
+++ b/ftd/t/js/66-backdrop-filter.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -144,6 +145,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/67-counter.html
+++ b/ftd/t/js/67-counter.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -148,6 +149,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/68-mask.html
+++ b/ftd/t/js/68-mask.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -676,6 +677,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/69-chained-dot-value-in-functions.html
+++ b/ftd/t/js/69-chained-dot-value-in-functions.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -155,6 +156,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/72-document-breakpoint.html
+++ b/ftd/t/js/72-document-breakpoint.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -98,6 +99,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/73-loops-inside-list.html
+++ b/ftd/t/js/73-loops-inside-list.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -190,6 +191,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/74-default-text-value.html
+++ b/ftd/t/js/74-default-text-value.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -88,6 +89,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/78-data-for-module.html
+++ b/ftd/t/js/78-data-for-module.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -72,6 +73,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/78-module-using-record.html
+++ b/ftd/t/js/78-module-using-record.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -105,6 +106,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>

--- a/ftd/t/js/loop.html
+++ b/ftd/t/js/loop.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    
+    <base href="">
     <meta content="fastn" name="generator">
     
     
@@ -11,6 +11,7 @@
     </script>
 
     <script src="fastn-js.js"></script>
+    
 
     <style>
        
@@ -79,6 +80,5 @@ fastn_dom.codeData.availableThemes["ztouch-theme"] = "../../theme_css/ztouch-the
         fastn_utils.setFullHeight();
         ftd.emit_on_load();
     };
-
 </script>
 </html>


### PR DESCRIPTION
Refactored the `replace_markers_2023` function and the `ftd/ftd-js.html` template. Instead of replacing our custom markers, we now utilize the `include_str!` macro along with the `format!` macro to naturally build the HTML string. This approach enhances error handling and overall code robustness.