### PR TITLE
fixed `getInheritedValues` not assigning default values of inherited variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "clap",
  "colored",

--- a/fastn-js/js/fastn.js
+++ b/fastn-js/js/fastn.js
@@ -337,6 +337,21 @@
         getAllFields() {
             return this.#fields;
         }
+        getClonedFields() {
+            let clonedFields = {};
+            for (let key in this.#fields) {
+                let field_value = this.#fields[key];
+                if (field_value instanceof fastn.recordInstanceClass
+                    || field_value instanceof fastn.mutableClass
+                    || field_value instanceof fastn.mutableListClass) {
+                    clonedFields[key] = this.#fields[key].getClone();
+                }
+                else {
+                    clonedFields[key] = this.#fields[key];
+                }
+            }
+            return clonedFields;
+        }
         addClosure(closure) {
             this.#closures.push(closure);
         }

--- a/fastn-js/js/utils.js
+++ b/fastn-js/js/utils.js
@@ -74,17 +74,17 @@ let fastn_utils = {
     },
     getInheritedValues(default_args, inherited, function_args) {
         let record_fields = {
-            "colors": ftd.default_colors.getClone().setAndReturn("is-root", true),
-            "types": ftd.default_types.getClone().setAndReturn("is-root", true)
+            "colors": ftd.default_colors.getClone().setAndReturn("is_root", true),
+            "types": ftd.default_types.getClone().setAndReturn("is_root", true)
         }
         Object.assign(record_fields, default_args);
         let fields = {};
         if (inherited instanceof fastn.recordInstanceClass) {
-            fields = inherited.getAllFields();
-            if (fields["colors"].get("is-root")) {
+            fields = inherited.getClonedFields();
+            if (fastn_utils.getStaticValue(fields["colors"].get("is_root"))) {
                delete fields.colors;
             }
-            if (fields["types"].get("is-root")) {
+            if (fastn_utils.getStaticValue(fields["types"].get("is_root"))) {
                delete fields.types;
             }
         }

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.12"
+version = "0.4.13"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ftd/src/js/mod.rs
+++ b/ftd/src/js/mod.rs
@@ -55,7 +55,7 @@ pub fn default_bag_into_js_ast() -> Vec<fastn_js::Ast> {
                     "colors".to_string(),
                     fastn_js::SetPropertyValue::Reference(
                         "ftd#default-colors__DOT__getClone()__DOT__setAndReturn\
-                        (\"is-root\"__COMMA__\
+                        (\"is_root\"__COMMA__\
                          true)"
                             .to_string(),
                     ),
@@ -64,7 +64,7 @@ pub fn default_bag_into_js_ast() -> Vec<fastn_js::Ast> {
                     "types".to_string(),
                     fastn_js::SetPropertyValue::Reference(
                         "ftd#default-types__DOT__getClone()__DOT__setAndReturn\
-                        (\"is-root\"__COMMA__\
+                        (\"is_root\"__COMMA__\
                          true)"
                             .to_string(),
                     ),


### PR DESCRIPTION
fixed an issue with the `getInheritedValues` function where default values of inherited variables was not being applied.