### PR TITLE
import fbt, not yet compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,24 +775,6 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf1e432b302dc6236dd0db580d182ce520bb24af82d6462e2d7a5e0a31c50d"
-dependencies = [
- "entities",
- "lazy_static 1.4.0",
- "memchr",
- "pest",
- "pest_derive",
- "regex",
- "shell-words",
- "typed-arena 1.7.0",
- "unicode_categories",
- "xdg",
-]
-
-[[package]]
-name = "comrak"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c995deda3bfdebd07d0e2af79e9da13e4b1be652b21a746f3f5b24bf0a49ef"
@@ -803,7 +785,7 @@ dependencies = [
  "once_cell",
  "regex",
  "slug",
- "typed-arena 2.0.2",
+ "typed-arena",
  "unicode_categories",
 ]
 
@@ -1634,13 +1616,13 @@ dependencies = [
  "fastn-package",
  "fbt-lib",
  "fluent",
- "ftd 0.3.0",
+ "ftd",
  "futures",
  "futures-core",
  "futures-util",
  "hyper 1.0.1",
  "ignore",
- "indoc 2.0.4",
+ "indoc",
  "intl-memoizer",
  "itertools 0.12.0",
  "magic-crypt",
@@ -1683,7 +1665,7 @@ dependencies = [
 name = "fastn-issues"
 version = "0.1.0"
 dependencies = [
- "ftd 0.3.0",
+ "ftd",
  "rusqlite",
  "thiserror",
 ]
@@ -1693,7 +1675,7 @@ name = "fastn-js"
 version = "0.1.0"
 dependencies = [
  "fastn-grammar",
- "indoc 2.0.4",
+ "indoc",
  "itertools 0.12.0",
  "prettify-js",
  "pretty",
@@ -1721,7 +1703,7 @@ dependencies = [
  "async-trait",
  "camino",
  "fastn-issues",
- "ftd 0.3.0",
+ "ftd",
  "futures",
  "rusqlite",
  "serde",
@@ -1735,13 +1717,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fbt"
+version = "0.1.18"
+dependencies = [
+ "fbt-lib",
+]
+
+[[package]]
 name = "fbt-lib"
 version = "0.1.18"
-source = "git+https://github.com/FifthTry/fbt?rev=ea0ee98#ea0ee9832ab515c8acf7f0a1f4d89f2d4e6671eb"
 dependencies = [
  "colored",
  "diffy",
- "ftd 0.2.0",
+ "ftd",
  "rand",
  "sha2 0.10.8",
  "walkdir",
@@ -1873,30 +1861,10 @@ checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
 name = "ftd"
-version = "0.2.0"
-source = "git+https://github.com/FifthTry/ftd?rev=b698bd6#b698bd6acf4b6dfc1557976ef63f378c473e8432"
-dependencies = [
- "comrak 0.14.0",
- "css-color-parser",
- "format_num",
- "include_dir",
- "indoc 1.0.9",
- "itertools 0.10.5",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "slug",
- "syntect",
- "thiserror",
-]
-
-[[package]]
-name = "ftd"
 version = "0.3.0"
 dependencies = [
  "colored",
- "comrak 0.19.0",
+ "comrak",
  "crossterm 0.27.0",
  "css-color-parser",
  "diffy",
@@ -1909,7 +1877,7 @@ dependencies = [
  "futures",
  "include_dir",
  "indexmap 2.1.0",
- "indoc 2.0.4",
+ "indoc",
  "itertools 0.12.0",
  "once_cell",
  "pretty_assertions",
@@ -2401,12 +2369,6 @@ dependencies = [
  "hashbrown 0.14.3",
  "serde",
 ]
-
-[[package]]
-name = "indoc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "indoc"
@@ -3136,51 +3098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
-dependencies = [
- "once_cell",
- "pest",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3373,7 +3290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec 0.5.2",
- "typed-arena 2.0.2",
+ "typed-arena",
  "unicode-width",
 ]
 
@@ -4132,12 +4049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "shipyard"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,12 +4646,6 @@ dependencies = [
 
 [[package]]
 name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
-
-[[package]]
-name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
@@ -4750,12 +4655,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unic-langid"
@@ -5211,12 +5110,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "fastn-js",
     "fastn-grammar",
     "foo",
+    "fbt_lib",
+    "fbt",
     # "fastn-wasm",
     # "fastn-runtime",
 ]
@@ -79,6 +81,7 @@ dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus", rev =
 dotenvy = "0.15"
 edit = "0.1"
 env_logger = "0.10"
+fbt-lib = { path = "fbt_lib" }
 fastn-cloud = { path = "fastn-cloud" }
 fastn-core = { path = "fastn-core" }
 fastn-issues = { path = "fastn-issues" }
@@ -179,10 +182,6 @@ features = ["http1", "server"]
 version = "6"
 default-features = false
 features=["macos_kqueue"]
-
-[workspace.dependencies.fbt-lib]
-git = "https://github.com/FifthTry/fbt"
-rev = "ea0ee98"
 
 [workspace.dependencies.syntect]
 # We use syntect for syntax highlighting feature in ftd.code.

--- a/fbt/Cargo.toml
+++ b/fbt/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fbt"
+version = "0.1.18"
+authors = [
+    "Amit Upadhyay <upadhyay@gmail.com>",
+    "Shobhit Sharma <shobhit@fifthtry.com>",
+    "Sitesh <siteshpattanaik001@gmail.com>",
+]
+edition = "2021"
+description = "folder based testing tool (library)"
+license = "BSD-2-Clause"
+homepage = "https://www.fifthtry.com/fifthtry/fbt/"
+
+[dependencies]
+fbt-lib = { path = "../fbt_lib", version = "0.1.18" }

--- a/fbt/src/main.rs
+++ b/fbt/src/main.rs
@@ -1,0 +1,19 @@
+fn main() {
+    if version_asked() {
+        println!("fbt: {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
+    let mut args = std::env::args();
+    args.next(); // get rid of first element (name of binary)
+    let to_fix = args.any(|v| v == "--fix" || v == "-f");
+    let args: Vec<_> = args.filter(|v| !v.starts_with('-')).collect();
+
+    if let Some(code) = fbt_lib::main_with_filters(&args, to_fix, None) {
+        std::process::exit(code)
+    }
+}
+
+fn version_asked() -> bool {
+    std::env::args().any(|e| e == "--version" || e == "-v")
+}

--- a/fbt_lib/Cargo.toml
+++ b/fbt_lib/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fbt-lib"
+version = "0.1.18"
+authors = [
+    "Amit Upadhyay <upadhyay@gmail.com>",
+    "Shobhit Sharma <shobhit@fifthtry.com>",
+    "Sitesh <siteshpattanaik001@gmail.com>",
+]
+edition = "2021"
+description = "folder based testing tool (library)"
+license = "BSD-2-Clause"
+homepage = "https://www.fifthtry.com/fifthtry/fbt/"
+
+[dependencies]
+walkdir.workspace = true
+rand.workspace = true
+colored.workspace = true
+diffy.workspace = true
+sha2.workspace = true
+ftd.workspace = true
+

--- a/fbt_lib/src/copy_dir.rs
+++ b/fbt_lib/src/copy_dir.rs
@@ -1,0 +1,16 @@
+use std::{fs, io, path::Path};
+
+// stackoverflow.com/questions/26958489/how-to-copy-a-folder-recursively-in-rust
+pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}

--- a/fbt_lib/src/dir_diff.rs
+++ b/fbt_lib/src/dir_diff.rs
@@ -1,0 +1,193 @@
+// Source: https://github.com/assert-rs/dir-diff (Apache/MIT)
+// Need to modify it so including it, will send PR and try to get it included
+// upstream.
+
+/// The various errors that can happen when diffing two directories
+#[derive(Debug)]
+pub enum DirDiffError {
+    Io(std::io::Error),
+    StripPrefix(std::path::StripPrefixError),
+    WalkDir(walkdir::Error),
+    UTF8Parsing(std::string::FromUtf8Error),
+}
+
+#[derive(Debug)]
+pub enum DirDiff {
+    ExpectedFileMissing {
+        expected: std::path::PathBuf,
+    },
+    ExpectedFolderMissing {
+        expected: std::path::PathBuf,
+    },
+    UnexpectedFileFound {
+        found: std::path::PathBuf,
+    },
+    UnexpectedFolderFound {
+        found: std::path::PathBuf,
+    },
+    FileTypeMismatch {
+        file: std::path::PathBuf,
+        expected: String,
+        found: String,
+    },
+    ContentMismatch {
+        file: std::path::PathBuf,
+        expected: String,
+        found: String,
+    },
+    NonContentFileMismatch {
+        file: std::path::PathBuf,
+    },
+}
+
+pub(crate) fn diff<A: AsRef<std::path::Path>, B: AsRef<std::path::Path>>(
+    a_base: A,
+    b_base: B,
+) -> Result<Option<DirDiff>, DirDiffError> {
+    use sha2::Digest;
+    let mut a_walker = walk_dir(a_base)?;
+    let mut b_walker = walk_dir(b_base)?;
+
+    loop {
+        match (a_walker.next(), b_walker.next()) {
+            (Some(a), Some(b)) => {
+                // first lets check the depth:
+                // a > b: UnexpectedFileFound or UnexpectedFolderFound else
+                // b > a: ExpectedFileMissing or ExpectedFolderMissing
+
+                // if file names dont match how to find if we got a new entry
+                // on left or extra entry on right? how do people actually
+                // calculate diff?
+
+                // then check file type
+
+                // finally check file content if its a file
+
+                // TODO: this is dummy code to test stuff
+                let a = a?;
+                let b = b?;
+                if a.metadata()
+                    .expect("Unable to retrieve metadata for found file/folder")
+                    .is_dir()
+                    && b.metadata()
+                        .expect("Unable to retrieve metadata for found file/folder")
+                        .is_dir()
+                {
+                    // Recursively check for the files in the directory
+                    return diff(a.path(), b.path());
+                }
+
+                let found: std::path::PathBuf = b.path().into();
+
+                if a.file_name() != b.file_name() {
+                    return Ok(Some(if found.is_dir() {
+                        DirDiff::UnexpectedFolderFound { found }
+                    } else {
+                        DirDiff::UnexpectedFileFound { found }
+                    }));
+                }
+                if let (Ok(a_content), Ok(b_content)) = (
+                    std::fs::read_to_string(a.path()),
+                    std::fs::read_to_string(b.path()),
+                ) {
+                    if a_content != b_content {
+                        return Ok(Some(DirDiff::ContentMismatch {
+                            expected: b_content,
+                            found: a_content,
+                            file: found,
+                        }));
+                    }
+                } else if let (Ok(a_content), Ok(b_content)) =
+                    (std::fs::read(a.path()), std::fs::read(b.path()))
+                {
+                    if !sha2::Sha256::digest(a_content).eq(&sha2::Sha256::digest(b_content)) {
+                        return Ok(Some(DirDiff::NonContentFileMismatch { file: found }));
+                    }
+                }
+            }
+            (None, Some(b)) => {
+                // we have something in b, but a is done, lets iterate over all
+                // entries in b, and put them in UnexpectedFileFound and
+                // UnexpectedFolderFound
+                let expected: std::path::PathBuf = b?.path().into();
+                return Ok(Some(if expected.is_dir() {
+                    DirDiff::ExpectedFolderMissing { expected }
+                } else {
+                    DirDiff::ExpectedFileMissing { expected }
+                }));
+            }
+            (Some(a), None) => {
+                // we have something in a, but b is done, lets iterate over all
+                // entries in a, and put them in ExpectedFileMissing and
+                // ExpectedFolderMissing
+                let found: std::path::PathBuf = a?.path().into();
+                return Ok(Some(if found.is_dir() {
+                    DirDiff::UnexpectedFolderFound { found }
+                } else {
+                    DirDiff::UnexpectedFileFound { found }
+                }));
+            }
+            (None, None) => break,
+        }
+    }
+
+    Ok(None)
+}
+
+pub(crate) fn fix<A: AsRef<std::path::Path>, B: AsRef<std::path::Path>>(
+    a_base: A,
+    b_base: B,
+) -> Result<(), DirDiffError> {
+    fix_(a_base, b_base)?;
+    Ok(())
+}
+
+fn fix_(src: impl AsRef<std::path::Path>, dst: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+    if dst.as_ref().exists() {
+        std::fs::remove_dir_all(&dst)?;
+    }
+    std::fs::create_dir_all(&dst)?;
+    let dir = std::fs::read_dir(src)?;
+    for child in dir {
+        let child = child?;
+        if child.metadata()?.is_dir() {
+            fix_(child.path(), dst.as_ref().join(child.file_name()))?;
+        } else {
+            std::fs::copy(child.path(), dst.as_ref().join(child.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+fn walk_dir<P: AsRef<std::path::Path>>(path: P) -> Result<walkdir::IntoIter, std::io::Error> {
+    let mut walkdir = walkdir::WalkDir::new(path)
+        .sort_by(compare_by_file_name)
+        .into_iter();
+    if let Some(Err(e)) = walkdir.next() {
+        Err(e.into())
+    } else {
+        Ok(walkdir)
+    }
+}
+
+fn compare_by_file_name(a: &walkdir::DirEntry, b: &walkdir::DirEntry) -> std::cmp::Ordering {
+    a.file_name().cmp(b.file_name())
+}
+
+impl From<std::io::Error> for DirDiffError {
+    fn from(e: std::io::Error) -> DirDiffError {
+        DirDiffError::Io(e)
+    }
+}
+
+impl From<std::path::StripPrefixError> for DirDiffError {
+    fn from(e: std::path::StripPrefixError) -> DirDiffError {
+        DirDiffError::StripPrefix(e)
+    }
+}
+
+impl From<walkdir::Error> for DirDiffError {
+    fn from(e: walkdir::Error) -> DirDiffError {
+        DirDiffError::WalkDir(e)
+    }
+}

--- a/fbt_lib/src/lib.rs
+++ b/fbt_lib/src/lib.rs
@@ -1,0 +1,8 @@
+mod copy_dir;
+mod dir_diff;
+mod run;
+mod types;
+
+pub use dir_diff::{DirDiff, DirDiffError};
+pub use run::{main, main_with_filters, main_with_test_folder, test_all};
+pub use types::*;

--- a/fbt_lib/src/run.rs
+++ b/fbt_lib/src/run.rs
@@ -1,0 +1,455 @@
+pub fn main() -> Option<i32> {
+    main_with_filters(&[], false, None)
+}
+
+pub fn main_with_test_folder(folder: &str) -> Option<i32> {
+    main_with_filters(&[], false, Some(folder.to_string()))
+}
+
+pub fn main_with_filters(filters: &[String], to_fix: bool, folder: Option<String>) -> Option<i32> {
+    use colored::Colorize;
+
+    let cases = match test_all(filters, to_fix, folder) {
+        Ok(tr) => tr,
+        Err(crate::Error::TestsFolderMissing) => {
+            eprintln!("{}", "Tests folder is missing".red());
+            return Some(1);
+        }
+        Err(crate::Error::TestsFolderNotReadable(e)) => {
+            eprintln!("{}", format!("Tests folder is unreadable: {:?}", e).red());
+            return Some(1);
+        }
+        Err(crate::Error::CantReadConfig(e)) => {
+            eprintln!("{}", format!("Cant read config file: {:?}", e).red());
+            return Some(1);
+        }
+        Err(crate::Error::InvalidConfig(e)) => {
+            eprintln!("{}", format!("Cant parse config file: {:?}", e).red());
+            return Some(1);
+        }
+        Err(crate::Error::BuildFailedToLaunch(e)) => {
+            eprintln!(
+                "{}",
+                format!("Build command failed to launch: {:?}", e).red()
+            );
+            return Some(1);
+        }
+        Err(crate::Error::BuildFailed(e)) => {
+            eprintln!("{}", format!("Build failed: {:?}", e).red());
+            return Some(1);
+        }
+    };
+
+    let mut any_failed = false;
+    for case in cases.iter() {
+        let duration = if is_test() {
+            "".to_string()
+        } else {
+            format!(" in {}", format!("{:?}", &case.duration).yellow())
+        };
+
+        match &case.result {
+            Ok(status) => {
+                if *status {
+                    println!("{}: {}{}", case.id.blue(), "PASSED".green(), duration);
+                } else {
+                    println!("{}: {}", case.id.blue(), "SKIPPED".magenta(),);
+                }
+            }
+            Err(crate::Failure::Skipped { reason }) => {
+                println!("{}: {} ({})", case.id.blue(), "SKIPPED".yellow(), reason,);
+            }
+            Err(crate::Failure::UnexpectedStatusCode { expected, output }) => {
+                any_failed = true;
+                println!(
+                    "{}: {}{} (exit code mismatch, expected={}, found={:?})",
+                    case.id.blue(),
+                    "FAILED".red(),
+                    duration,
+                    expected,
+                    output.exit_code
+                );
+                println!("stdout:\n{}\n", &output.stdout);
+                println!("stderr:\n{}\n", &output.stderr);
+            }
+            Err(crate::Failure::StdoutMismatch { expected, output }) => {
+                any_failed = true;
+                println!(
+                    "{}: {}{} (stdout mismatch)",
+                    case.id.blue(),
+                    "FAILED".red(),
+                    duration,
+                );
+                println!("stdout:\n\n{}\n", &output.stdout);
+                println!(
+                    "diff:\n\n{}\n",
+                    diffy::create_patch(
+                        (expected.to_owned() + "\n").as_str(),
+                        (output.stdout.clone() + "\n").as_str()
+                    )
+                );
+            }
+            Err(crate::Failure::StderrMismatch { expected, output }) => {
+                any_failed = true;
+                println!(
+                    "{}: {}{} (stderr mismatch)",
+                    case.id.blue(),
+                    "FAILED".red(),
+                    duration,
+                );
+                println!("stderr:\n\n{}\n", &output.stderr);
+                println!(
+                    "diff:\n\n{}\n",
+                    diffy::create_patch(
+                        (expected.to_owned() + "\n").as_str(),
+                        (output.stderr.clone() + "\n").as_str()
+                    )
+                );
+            }
+            Err(crate::Failure::OutputMismatch { diff }) => {
+                any_failed = true;
+                match diff {
+                    crate::DirDiff::ContentMismatch {
+                        found,
+                        expected,
+                        file,
+                    } => {
+                        println!(
+                            "{}: {}{} (output content mismatch: {})",
+                            case.id.blue(),
+                            "FAILED".red(),
+                            duration,
+                            file.to_str().unwrap_or("cant-read-filename"),
+                        );
+                        println!("found:\n\n{}\n", found.as_str());
+                        println!(
+                            "diff:\n\n{}\n",
+                            diffy::create_patch(
+                                (expected.to_owned() + "\n").as_str(),
+                                (found.to_owned() + "\n").as_str()
+                            )
+                        );
+                    }
+                    crate::DirDiff::UnexpectedFileFound { found } => {
+                        println!(
+                            "{}: {}{} (extra file found: {})",
+                            case.id.blue(),
+                            "FAILED".red(),
+                            duration,
+                            found.to_str().unwrap_or("cant-read-filename"),
+                        );
+                    }
+                    _ => {
+                        println!(
+                            "{}: {}{} (output mismatch: {:?})",
+                            case.id.blue(),
+                            "FAILED".red(),
+                            duration,
+                            diff
+                        );
+                    }
+                }
+            }
+            Err(crate::Failure::FixMismatch) => {
+                println!("{}: {}{}", case.id.blue(), "FIXED".purple(), duration,);
+            }
+            Err(e) => {
+                any_failed = true;
+                println!(
+                    "{}: {}{} ({:?})",
+                    case.id.blue(),
+                    "FAILED".red(),
+                    duration,
+                    e
+                );
+            }
+        }
+    }
+
+    if any_failed {
+        return Some(2);
+    }
+
+    None
+}
+
+pub fn test_all(
+    filters: &[String],
+    to_fix: bool,
+    folder: Option<String>,
+) -> Result<Vec<crate::Case>, crate::Error> {
+    let mut results = vec![];
+
+    let test_folder = folder
+        .map(|v| v.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| "./tests".to_string());
+    let config = match std::fs::read_to_string(format!("{}/fbt.p1", test_folder).as_str()) {
+        Ok(v) => match crate::Config::parse(v.as_str(), format!("{}/fbt.p1", test_folder).as_str())
+        {
+            Ok(config) => {
+                if let Some(ref b) = config.build {
+                    match if cfg!(target_os = "windows") {
+                        let mut c = std::process::Command::new("cmd");
+                        c.args(&["/C", b.as_str()]);
+                        c
+                    } else {
+                        let mut c = std::process::Command::new("sh");
+                        c.args(&["-c", b.as_str()]);
+                        c
+                    }
+                    .output()
+                    {
+                        Ok(v) => {
+                            if !v.status.success() {
+                                return Err(crate::Error::BuildFailed(v));
+                            }
+                        }
+                        Err(e) => return Err(crate::Error::BuildFailedToLaunch(e)),
+                    }
+                }
+                config
+            }
+            Err(e) => return Err(crate::Error::InvalidConfig(e)),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => crate::Config::default(),
+        Err(e) => return Err(crate::Error::CantReadConfig(e)),
+    };
+
+    let dirs = {
+        let mut dirs: Vec<_> = match {
+            match std::fs::read_dir(test_folder.as_str()) {
+                Ok(dirs) => dirs,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(crate::Error::TestsFolderMissing)
+                }
+                Err(e) => return Err(crate::Error::TestsFolderNotReadable(e)),
+            }
+        }
+        .map(|res| res.map(|e| e.path()))
+        .collect::<Result<Vec<_>, std::io::Error>>()
+        {
+            Ok(dirs) => dirs,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(crate::Error::TestsFolderMissing)
+            }
+            Err(e) => return Err(crate::Error::TestsFolderNotReadable(e)),
+        };
+        dirs.sort();
+        dirs
+    };
+
+    for dir in dirs {
+        if !dir.is_dir() {
+            continue;
+        }
+
+        let dir_name = dir
+            .file_name()
+            .map(|v| v.to_str())
+            .unwrap_or(None)
+            .unwrap_or("");
+
+        if dir_name.starts_with('.') {
+            continue;
+        }
+
+        // see if filter matches, else continue
+        let start = std::time::Instant::now();
+
+        let filter_is_not_empty = !filters.is_empty();
+        let something_matches = !filters
+            .iter()
+            .any(|v| dir_name.to_lowercase().contains(&v.to_lowercase()));
+
+        if filter_is_not_empty && something_matches {
+            results.push(crate::Case {
+                id: dir_name.to_string(),
+                result: Ok(false),
+                duration: std::time::Instant::now().duration_since(start),
+            });
+            continue;
+        }
+
+        results.push(test_one(&config, dir, start, to_fix));
+    }
+
+    Ok(results)
+}
+
+fn test_one(
+    global: &crate::Config,
+    entry: std::path::PathBuf,
+    start: std::time::Instant,
+    to_fix: bool,
+) -> crate::Case {
+    use std::{borrow::BorrowMut, io::Write};
+
+    let id = entry
+        .file_name()
+        .map(|v| v.to_str())
+        .unwrap_or(None)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("{:?}", entry.file_name()));
+
+    let id_ = id.as_str();
+    let err = |e: crate::Failure| crate::Case {
+        id: id_.to_string(),
+        result: Err(e),
+        duration: std::time::Instant::now().duration_since(start),
+    };
+
+    let config = match std::fs::read_to_string(entry.join("cmd.p1")) {
+        Ok(c) => {
+            match crate::TestConfig::parse(c.as_str(), format!("{}/cmd.p1", id).as_str(), global) {
+                Ok(c) => c,
+                Err(e) => return err(crate::Failure::CmdFileInvalid { error: e }),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return err(crate::Failure::CmdFileMissing)
+        }
+        Err(e) => return err(crate::Failure::CantReadCmdFile { error: e }),
+    };
+
+    if let Some(reason) = config.skip {
+        return err(crate::Failure::Skipped { reason });
+    };
+
+    let fbt = {
+        let fbt = std::env::temp_dir().join(format!("fbt/{}", rand::random::<i64>()));
+        if fbt.exists() {
+            // if we are not getting a unique directory from temp_dir and its
+            // returning some standard path like /tmp, this fmt may contain the
+            // output of last run, so we must empty it.
+            if let Err(e) = std::fs::remove_dir_all(&fbt) {
+                return err(crate::Failure::Other { io: e });
+            }
+        }
+        if let Err(e) = std::fs::create_dir_all(&fbt) {
+            return err(crate::Failure::Other { io: e });
+        }
+        fbt
+    };
+
+    let input = entry.join("input");
+
+    // if input folder exists, we copy it into tmp and run our command from
+    // inside that folder, else we run it from tmp
+    let dir = if input.exists() {
+        let dir = fbt.join("input");
+        if !input.is_dir() {
+            return err(crate::Failure::InputIsNotDir);
+        }
+        if let Err(e) = crate::copy_dir::copy_dir_all(&input, &dir) {
+            return err(crate::Failure::Other { io: e });
+        }
+        dir
+    } else {
+        fbt
+    };
+
+    // eprintln!("executing '{}' in {:?}", &config.cmd, &dir);
+    let mut child = match config.cmd().current_dir(&dir).spawn() {
+        Ok(c) => c,
+        Err(io) => {
+            return err(crate::Failure::CommandFailed {
+                io,
+                reason: "cant fork process",
+            });
+        }
+    };
+
+    if let (Some(ref stdin), Some(cstdin)) = (config.stdin, &mut child.stdin) {
+        if let Err(io) = cstdin.borrow_mut().write_all(stdin.as_bytes()) {
+            return err(crate::Failure::CommandFailed {
+                io,
+                reason: "cant write to stdin",
+            });
+        }
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(io) => {
+            return err(crate::Failure::CommandFailed {
+                io,
+                reason: "cant wait",
+            })
+        }
+    };
+
+    let output = match crate::Output::try_from(&output) {
+        Ok(o) => o.replace(dir.to_string_lossy().to_string()),
+        Err(reason) => {
+            return err(crate::Failure::CantReadOutput { reason, output });
+        }
+    };
+
+    if output.exit_code != config.exit_code {
+        return err(crate::Failure::UnexpectedStatusCode {
+            expected: config.exit_code,
+            output,
+        });
+    }
+
+    if let Some(ref stdout) = config.stdout {
+        if output.stdout != stdout.trim() {
+            return err(crate::Failure::StdoutMismatch {
+                output,
+                expected: stdout.trim().to_string(),
+            });
+        }
+    }
+
+    if let Some(ref stderr) = config.stderr {
+        if output.stderr != stderr.trim() {
+            return err(crate::Failure::StderrMismatch {
+                output,
+                expected: stderr.trim().to_string(),
+            });
+        }
+    }
+
+    // if there is `output` folder we will check if `dir` is equal to `output`.
+    // if `config` has a `output key` set, then instead of the entire `dir`, we
+    // will check for the folder named `output key`, which is resolved with
+    // respect to `dir`
+
+    let reference = entry.join("output");
+
+    if !reference.exists() {
+        return crate::Case {
+            id,
+            result: Ok(true),
+            duration: std::time::Instant::now().duration_since(start),
+        };
+    }
+
+    let output = match config.output {
+        Some(v) => dir.join(v),
+        None => dir,
+    };
+
+    if to_fix {
+        return match crate::dir_diff::fix(output, reference) {
+            Ok(()) => err(crate::Failure::FixMismatch),
+            Err(e) => err(crate::Failure::DirDiffError { error: e }),
+        };
+    }
+
+    crate::Case {
+        id: id.clone(),
+        result: match crate::dir_diff::diff(output, reference) {
+            Ok(Some(diff)) => {
+                return err(crate::Failure::OutputMismatch { diff });
+            }
+            Ok(None) => Ok(true),
+            Err(e) => return err(crate::Failure::DirDiffError { error: e }),
+        },
+        duration: std::time::Instant::now().duration_since(start),
+    }
+}
+
+fn is_test() -> bool {
+    std::env::args().any(|e| e == "--test")
+}

--- a/fbt_lib/src/types.rs
+++ b/fbt_lib/src/types.rs
@@ -1,0 +1,389 @@
+use std::convert::TryFrom;
+
+#[derive(Debug, Default)]
+pub(crate) struct Config {
+    pub build: Option<String>,
+    cmd: Option<String>,
+    env: Option<std::collections::HashMap<String, String>>,
+    clear_env: bool,
+    output: Option<String>,
+    exit_code: Option<i32>,
+}
+
+impl Config {
+    pub fn parse(s: &str, doc_id: &str) -> ftd::p1::Result<Config> {
+        let parsed = ftd::p1::parse(s, doc_id)?;
+        let mut iter = parsed.iter();
+        let mut c = match iter.next() {
+            Some(p1) => {
+                if p1.name != "fbt" {
+                    return Err(ftd::p1::Error::ParseError {
+                        message: "first section's name is not 'fbt'".to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number: p1.line_number,
+                    });
+                }
+
+                Config {
+                    build: p1
+                        .headers
+                        .string_optional(doc_id, p1.line_number, "build")?,
+                    cmd: p1.header.string_optional(doc_id, p1.line_number, "cmd")?,
+                    exit_code: p1
+                        .header
+                        .i32_optional(doc_id, p1.line_number, "exit-code")?,
+                    env: None,
+                    clear_env: p1.header.bool_with_default(
+                        doc_id,
+                        p1.line_number,
+                        "clear-env",
+                        false,
+                    )?,
+                    output: p1
+                        .header
+                        .string_optional(doc_id, p1.line_number, "output")?,
+                }
+            }
+            None => {
+                return Err(ftd::p1::Error::ParseError {
+                    message: "no sections found".to_string(),
+                    doc_id: doc_id.to_string(),
+                    line_number: 0,
+                });
+            }
+        };
+
+        for s in iter {
+            match s.name.as_str() {
+                "env" => {
+                    if c.env.is_some() {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "env provided more than once".to_string(),
+                            doc_id: doc_id.to_string(),
+                            line_number: s.line_number,
+                        });
+                    }
+                    c.env = read_env(doc_id, &s.body)?;
+                }
+                _ => {
+                    return Err(ftd::p1::Error::ParseError {
+                        message: "unknown section".to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number: s.line_number,
+                    });
+                }
+            }
+        }
+
+        Ok(c)
+    }
+}
+
+fn read_env(
+    doc_id: &str,
+    body: &Option<(usize, String)>,
+) -> ftd::p1::Result<Option<std::collections::HashMap<String, String>>> {
+    Ok(match body {
+        Some((line_number, v)) => {
+            let mut m = std::collections::HashMap::new();
+            for line in v.split('\n') {
+                let mut parts = line.splitn(2, '=');
+                match (parts.next(), parts.next()) {
+                    (Some(k), Some(v)) => {
+                        m.insert(k.to_string(), v.to_string());
+                    }
+                    _ => {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "invalid line in env".to_string(),
+                            doc_id: doc_id.to_string(),
+                            line_number: *line_number,
+                        });
+                    }
+                }
+            }
+            Some(m)
+        }
+        None => None,
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct TestConfig {
+    pub cmd: String,
+    env: Option<std::collections::HashMap<String, String>>,
+    clear_env: bool,
+    pub skip: Option<String>,
+    pub output: Option<String>,
+    pub stdin: Option<String>,
+    pub exit_code: i32,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+impl TestConfig {
+    pub fn cmd(&self) -> std::process::Command {
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut c = std::process::Command::new("cmd");
+            c.args(&["/C", self.cmd.as_str()]);
+            c
+        } else {
+            let mut c = std::process::Command::new("sh");
+            c.args(&["-c", self.cmd.as_str()]);
+            c
+        };
+
+        if self.clear_env {
+            cmd.env_clear();
+        }
+
+        if let Some(ref env) = self.env {
+            cmd.envs(env.iter());
+        }
+        cmd.env(
+            "FBT_CWD",
+            std::env::current_dir()
+                .map(|v| v.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "".into()),
+        );
+
+        if self.stdin.is_some() {
+            cmd.stdin(std::process::Stdio::piped());
+        }
+
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        cmd
+    }
+
+    pub fn parse(s: &str, doc_id: &str, config: &Config) -> ftd::p1::Result<Self> {
+        let parsed = ftd::p1::parse(s, doc_id)?;
+        let mut iter = parsed.iter();
+        let mut c = match iter.next() {
+            Some(p1) => {
+                if p1.name != "fbt" {
+                    return Err(ftd::p1::Error::ParseError {
+                        message: "first section's name is not 'fbt'".to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number: p1.line_number,
+                    });
+                }
+
+                TestConfig {
+                    cmd: match p1
+                        .header
+                        .string_optional(doc_id, p1.line_number, "cmd")?
+                        .or_else(|| config.cmd.clone())
+                    {
+                        Some(v) => v,
+                        None => {
+                            return Err(ftd::p1::Error::ParseError {
+                                message: "cmd not found".to_string(),
+                                doc_id: doc_id.to_string(),
+                                line_number: p1.line_number,
+                            })
+                        }
+                    },
+                    skip: p1.header.string_optional(doc_id, p1.line_number, "skip")?,
+                    exit_code: p1
+                        .header
+                        .i32_optional(doc_id, p1.line_number, "exit-code")?
+                        .or(config.exit_code)
+                        .unwrap_or(0),
+                    stdin: None,
+                    stdout: None,
+                    stderr: None,
+                    env: config.env.clone(),
+                    clear_env: p1.header.bool_with_default(
+                        doc_id,
+                        p1.line_number,
+                        "clear-env",
+                        config.clear_env,
+                    )?,
+                    output: p1
+                        .header
+                        .string_optional(doc_id, p1.line_number, "output")?
+                        .or_else(|| config.output.clone()),
+                }
+            }
+            None => {
+                return Err(ftd::p1::Error::ParseError {
+                    message: "no sections found".to_string(),
+                    doc_id: doc_id.to_string(),
+                    line_number: 0,
+                });
+            }
+        };
+
+        for s in iter {
+            match s.name.as_str() {
+                "stdin" => {
+                    if c.stdin.is_some() {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "stdin provided more than once".to_string(),
+                            doc_id: doc_id.to_string(),
+                            line_number: s.line_number,
+                        });
+                    }
+                    c.stdin = s.body.as_ref().map(|(_, v)| v.clone());
+                }
+                "stdout" => {
+                    if c.stdout.is_some() {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "stdout provided more than once".to_string(),
+                            doc_id: doc_id.to_string(),
+                            line_number: s.line_number,
+                        });
+                    }
+                    c.stdout = s.body.as_ref().map(|(_, v)| v.clone());
+                }
+                "stderr" => {
+                    if c.stderr.is_some() {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "stderr provided more than once".to_string(),
+                            doc_id: doc_id.to_string(),
+                            line_number: s.line_number,
+                        });
+                    }
+                    c.stderr = s.body.as_ref().map(|(_, v)| v.clone());
+                }
+                "env" => {
+                    c.env = match (read_env(doc_id, &s.body)?, &c.env) {
+                        (Some(v), Some(e)) => {
+                            let mut e = e.clone();
+                            e.extend(v.into_iter());
+                            Some(e)
+                        }
+                        (Some(v), None) => Some(v),
+                        (None, v) => v.clone(),
+                    };
+                }
+                _ => {
+                    return Err(ftd::p1::Error::ParseError {
+                        message: "unknown section".to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number: s.line_number,
+                    });
+                }
+            }
+        }
+
+        Ok(c)
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    TestsFolderMissing,
+    CantReadConfig(std::io::Error),
+    InvalidConfig(ftd::p1::Error),
+    BuildFailedToLaunch(std::io::Error),
+    BuildFailed(std::process::Output),
+    TestsFolderNotReadable(std::io::Error),
+}
+
+#[derive(Debug)]
+pub struct Case {
+    pub id: String, // 01_basic
+    // if Ok(true) => test passed
+    // if Ok(false) => test skipped
+    // if Err(Failure) => test failed
+    pub result: Result<bool, crate::Failure>,
+    pub duration: std::time::Duration,
+}
+
+#[derive(Debug)]
+pub struct Output {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Output {
+    pub fn replace(mut self, v: String) -> Self {
+        // on mac /private is added to temp folders
+        // amitu@MacBook-Pro fbt % ls /var/folders/kf/jfmbkscj7757mmr29mn3rksm0000gn/T/fbt/874862845293569866/input
+        // one
+        // amitu@MacBook-Pro fbt % ls /private/var/folders/kf/jfmbkscj7757mmr29mn3rksm0000gn/T/fbt/874862845293569866/input
+        // one
+        // both of them are the same folder, and we see the former path, but the lauched processes see the later
+
+        let private_v = format!("/private{}", v.as_str());
+        self.stdout = self.stdout.replace(private_v.as_str(), "<cwd>");
+        self.stderr = self.stderr.replace(private_v.as_str(), "<cwd>");
+        self.stdout = self.stdout.replace(v.as_str(), "<cwd>");
+        self.stderr = self.stderr.replace(v.as_str(), "<cwd>");
+
+        self
+    }
+}
+
+impl TryFrom<&std::process::Output> for Output {
+    type Error = &'static str;
+
+    fn try_from(o: &std::process::Output) -> std::result::Result<Self, Self::Error> {
+        Ok(Output {
+            exit_code: match o.status.code() {
+                Some(code) => code,
+                None => return Err("cant read exit_code"),
+            },
+            stdout: {
+                std::str::from_utf8(&o.stdout)
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            },
+            stderr: {
+                std::str::from_utf8(&o.stderr)
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            },
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum Failure {
+    Skipped {
+        reason: String,
+    },
+    CmdFileMissing,
+    CmdFileInvalid {
+        error: ftd::p1::Error,
+    },
+    CantReadCmdFile {
+        error: std::io::Error,
+    },
+    InputIsNotDir,
+    Other {
+        io: std::io::Error,
+    },
+    CommandFailed {
+        io: std::io::Error,
+        reason: &'static str,
+    },
+    UnexpectedStatusCode {
+        expected: i32,
+        output: Output,
+    },
+    CantReadOutput {
+        output: std::process::Output,
+        reason: &'static str,
+    },
+    StdoutMismatch {
+        expected: String,
+        output: Output,
+    },
+    StderrMismatch {
+        expected: String,
+        output: Output,
+    },
+    DirDiffError {
+        error: crate::DirDiffError,
+    },
+    OutputMismatch {
+        diff: crate::DirDiff,
+    },
+    FixMismatch,
+}


### PR DESCRIPTION
Motivation:

```txt
fastn on  main took 1s688ms ➜ cargo test 
   Compiling serde_json v1.0.108
   Compiling zerocopy v0.7.28
   Compiling tracing v0.1.40
   Compiling tokio v1.34.0
   Compiling rustix v0.38.26
   Compiling time v0.3.30
   Compiling comrak v0.19.0
   Compiling ring v0.17.6
^C  Building [=========>               ] 195/485: zerocopy, tokio, ring, rustix, comrak, serde_json, time, tracing                                                     
fastn on  main took 1s154ms ➜ git checkout -   
Switched to branch 'pulling_fbt_in'
fastn on  pulling_fbt_in took 125ms ➜ cargo test
   Compiling tracing v0.1.40
   Compiling serde_json v1.0.108
   Compiling zerocopy v0.7.28
   Compiling rustix v0.38.26
   Compiling tokio v1.34.0
   Compiling time v0.3.30
   Compiling comrak v0.19.0
   Compiling ring v0.17.6
^C  Building [=========>               ] 195/475: comrak, serde_json, ring, tokio, zerocopy, tracing, time, rustix                 
```

Number of dependencies during test goes down from 485 to 475.

```txt
fastn on  pulling_fbt_in took 3s433ms ➜ cargo check
    Checking fastn-core v0.1.0 (/Users/amitu/Projects/fastn/fastn-core)
    Checking fbt-lib v0.1.18 (/Users/amitu/Projects/fastn/fbt_lib)
^C  Building [=======================> ] 448/453: fbt-lib, fastn-core                                                                                                  
fastn on  pulling_fbt_in took 1s533ms ➜ git checkout main   
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
fastn on  main took 107ms ➜ cargo check
    Checking fastn-core v0.1.0 (/Users/amitu/Projects/fastn/fastn-core)
^C  Building [=======================> ] 448/451: fastn-core                         
```

Number of dependencies during regular build goes up from 451 to 453.

Not convinced it's a great idea yet. 