### PR TITLE
removed: check if doubleBuffering is true when attaching CSS/Javascript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "clap",
  "colored",

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1642,7 +1642,6 @@ class Node2 {
             ftd.breakpoint_width.set(fastn_utils.getStaticValue(staticValue));
         } else if (kind === fastn_dom.PropertyKind.Css) {
             let css_list = staticValue.map(obj => fastn_utils.getStaticValue(obj.item));
-            console.log(css_list);
             css_list.forEach((css) => {
                 this.attachExternalCss(css);
             });

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -1379,29 +1379,25 @@ class Node2 {
         }
     }
     attachExternalCss(css) {
-        if (doubleBuffering) {
-            let css_tag = document.createElement('link');
-            css_tag.rel = 'stylesheet';
-            css_tag.type = 'text/css';
-            css_tag.href = css;
+        let css_tag = document.createElement('link');
+        css_tag.rel = 'stylesheet';
+        css_tag.type = 'text/css';
+        css_tag.href = css;
 
-            let head = document.head || document.getElementsByTagName("head")[0];
-            if (!fastn_dom.externalCss.has(css)){
-                head.appendChild(css_tag);
-                fastn_dom.externalCss.add(css);
-            }
+        let head = document.head || document.getElementsByTagName("head")[0];
+        if (!fastn_dom.externalCss.has(css)){
+            head.appendChild(css_tag);
+            fastn_dom.externalCss.add(css);
         }
     }
     attachExternalJs(js) {
-        if (doubleBuffering) {
-            let js_tag = document.createElement('script');
-            js_tag.src = js;
+        let js_tag = document.createElement('script');
+        js_tag.src = js;
 
-            let head = document.head || document.getElementsByTagName("head")[0];
-            if (!fastn_dom.externalJs.has(js)){
-                head.appendChild(js_tag);
-                fastn_dom.externalCss.add(js);
-            }
+        let head = document.head || document.getElementsByTagName("head")[0];
+        if (!fastn_dom.externalJs.has(js)){
+            head.appendChild(js_tag);
+            fastn_dom.externalCss.add(js);
         }
     }
     attachColorCss(property, value, visited) {
@@ -1646,6 +1642,7 @@ class Node2 {
             ftd.breakpoint_width.set(fastn_utils.getStaticValue(staticValue));
         } else if (kind === fastn_dom.PropertyKind.Css) {
             let css_list = staticValue.map(obj => fastn_utils.getStaticValue(obj.item));
+            console.log(css_list);
             css_list.forEach((css) => {
                 this.attachExternalCss(css);
             });

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.26"
+version = "0.4.27"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Removed the check for doubleBuffering when attaching an external CSS/Javascript file. It was preventing components which were being dynamically rendered or which were not initially instantiated during the hydration phase from attaching the External CSS/JS files.