### PR TITLE
statically link pq-sys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         continue-on-error: false
         with:
           args: cargo build --target $BUILD_TARGET --release
+      - name: run fastn
+        run: ./target/x86_64-unknown-linux-musl/release/${{ env.BINARY_NAME }}
       - uses: actions/upload-artifact@v2
         with:
           name: linux_musl_x86_64
@@ -59,6 +61,8 @@ jobs:
         with:
           command: build
           args: --release
+      - name: run fastn
+        run: ./target/release/${{ env.BINARY_NAME }}.exe
       - uses: actions/upload-artifact@v2
         with:
           name: windows_x64_latest
@@ -103,6 +107,8 @@ jobs:
         with:
           command: build
           args: --release
+      - name: run fastn
+        run: ./target/release/${{ env.BINARY_NAME }}
       - uses: actions/upload-artifact@v2
         with:
           name: macos_x64_latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,13 @@ features = [
     "column_decltype",
 ]
 
+[workspace.dependencies.pq-sys]
+version = "0.4.8"
+features = [
+    # see workspace.dependencies.rusqlite
+    "bundled"
+]
+
 
 [workspace.dependencies.web-sys]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ features = [
 ]
 
 [workspace.dependencies.pq-sys]
-version = "0.4.8"
+version = "0.4"
 features = [
     # see workspace.dependencies.rusqlite
     "bundled"


### PR DESCRIPTION
I don't know how to test this without running the actual CI flow. The local cargo build still produces a dynamically linked binary linked to my system libpq :(