### PR TITLE
use quick-js on non windows platforms

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# editor and OS junk
+.idea
+**/.DS_Store
+
+ftd/t/js/**.manual.html
+ftd/t/js/**.script.html
+
+# nix symlink to the build output
+result
+
+.direnv
+.envrc
+
+# Rust stuff
+target
+**/*.rs.bk
+
+# fastn test
+fastn-core/tests/**/.build
+
+fastn-core/tests/**/.packages/fifthtry.github.io/package-info/
+
+/**/.packages
+/**/.remote-state
+
+
+docs
+.env
+.env.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "copy_dir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543d1dd138ef086e2ff05e3a48cf9da045da2033d16f8538fd76b86cd49b2ca3"
+dependencies = [
+ "walkdir",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1751,7 @@ dependencies = [
  "itertools 0.12.0",
  "prettify-js",
  "pretty",
+ "quick-js",
  "rquickjs",
 ]
 
@@ -2661,6 +2671,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
+name = "libquickjs-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0b24e9bd171b75ae0295bd428fb8fe58410fb23156e5f34a4657a70c3cee96"
+dependencies = [
+ "cc",
+ "copy_dir",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,6 +3557,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick-js"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19cb4cefcb00f4ab9b332664d06005a74f582ac16aa959c6ad5912957bd83e5f"
+dependencies = [
+ "libquickjs-sys",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ reqwest = { version = "0.11", features = ["json"] }
 rink = { git = "https://github.com/DioxusLabs/dioxus", rev = "fb52673433cc57a70c86185ffa7da5fa3a2394da" }
 ron = "0.8"
 rquickjs = { version = "0.4", features = ["macro"] }
+quick-js = "0.4"
 rustc-hash = "1"
 rusty-hook = "0.11"
 serde = { version = "1", features = ["derive"] }

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -30,7 +30,8 @@ pub async fn process(
     }
 
     let _ = req_config;
-    doc.from_json::<std::vec::Vec<UserDetails>>(&vec![], &kind, &value)
+    let ud: UserDetails = Default::default();
+    doc.from_json(&ud, &kind, &value)
 }
 
 #[derive(Debug, serde::Serialize, Default)]

--- a/fastn-js/Cargo.toml
+++ b/fastn-js/Cargo.toml
@@ -8,12 +8,18 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+#rquickjs = { workspace = true, optional = true }
 pretty.workspace = true
 itertools.workspace = true
 indoc.workspace = true
 fastn-grammar.workspace = true
 prettify-js.workspace = true
 camino.workspace = true
+
+[target.'cfg(not(windows))'.dependencies]
+quick-js.workspace = true
+
+[target.'cfg(windows)'.dependencies]
 rquickjs.workspace = true
 
 [dev-dependencies]

--- a/fastn-js/src/ssr.rs
+++ b/fastn-js/src/ssr.rs
@@ -1,16 +1,48 @@
 pub fn run_test(js: &str) -> Vec<bool> {
-    rquickjs::Context::full(&rquickjs::Runtime::new().unwrap())
-        .unwrap()
-        .with(|ctx| ctx.eval::<Vec<bool>, _>(js).unwrap())
+    #[cfg(target_os = "windows")]
+    {
+        rquickjs::Context::full(&rquickjs::Runtime::new().unwrap())
+            .unwrap()
+            .with(|ctx| ctx.eval::<Vec<bool>, _>(js).unwrap())
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Added logging support from console from within context
+        let context = quick_js::Context::builder()
+            .console(
+                |level: quick_js::console::Level, args: Vec<quick_js::JsValue>| {
+                    eprintln!("{}: {:?}", level, args);
+                },
+            )
+            .build()
+            .unwrap();
+        context.eval_as::<Vec<bool>>(js).unwrap()
+    }
 }
 
 pub fn ssr_str(js: &str) -> String {
     let all_js = fastn_js::all_js_with_test();
     let js = format!("{all_js}{js}");
 
-    rquickjs::Context::full(&rquickjs::Runtime::new().unwrap())
-        .unwrap()
-        .with(|ctx| ctx.eval::<String, _>(js).unwrap())
+    #[cfg(target_os = "windows")]
+    {
+        rquickjs::Context::full(&rquickjs::Runtime::new().unwrap())
+            .unwrap()
+            .with(|ctx| ctx.eval::<String, _>(js).unwrap())
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Added logging support from console from within context
+        let context = quick_js::Context::builder()
+            .console(
+                |level: quick_js::console::Level, args: Vec<quick_js::JsValue>| {
+                    eprintln!("{}: {:?}", level, args);
+                },
+            )
+            .build()
+            .unwrap();
+        context.eval_as::<String>(js.as_str()).unwrap()
+    }
 }
 
 pub fn ssr(ast: &[fastn_js::Ast]) -> String {

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.34"
+version = "0.4.35"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Building with `rquickjs` for linux and mac throws errors but this lib doesn't seem to work correctly at runtime. I have reverted the [changes to use `rquickjs`](https://github.com/fastn-stack/fastn/pull/1668) for now.

- `.dockerignore` to reduce docker image size