### PR TITLE
`fastn_ds` Fix: `fastn_ds::Path` `strip_prefix` function

### DIFF
--- a/fastn-cloud/src/lib.rs
+++ b/fastn-cloud/src/lib.rs
@@ -34,14 +34,14 @@ pub async fn upload() -> Result<(), UploadError> {
     let current_dir: camino::Utf8PathBuf = std::env::current_dir()?.canonicalize()?.try_into()?;
     let ds = fastn_ds::DocumentStore::new(current_dir);
     let build_dir = fastn_cloud::utils::build_dir(&ds);
-    if !build_dir.exists() {
+    if !ds.exists(&build_dir) {
         return Err(UploadError::BuildDirNotFound(
             "Run `fastn build` to create a .build directory before running this".to_string(),
         ));
     }
 
     let cw_id_path = fastn_cloud::utils::cw_id(&ds);
-    if !cw_id_path.exists() {
+    if !ds.exists(&cw_id_path) {
         return Err(UploadError::CwIdNotFound);
     }
     let _cw_id = ds
@@ -50,7 +50,7 @@ pub async fn upload() -> Result<(), UploadError> {
         .map_err(|_e| UploadError::CwIdReadError)?;
 
     let sid_path = fastn_cloud::utils::sid(&ds);
-    if !sid_path.exists() {
+    if !ds.exists(&sid_path) {
         return Err(UploadError::SidNotFound);
     }
 

--- a/fastn-core/src/apis/cache.rs
+++ b/fastn-core/src/apis/cache.rs
@@ -79,14 +79,14 @@ pub async fn clear_(
     for file in query.file.iter() {
         let main_file_path = config.ds.root().join(file.as_str());
         let package_file_path = config.packages_root.join(file.as_str());
-        if main_file_path.exists() {
+        if config.ds.exists(&main_file_path) {
             if main_file_path
                 .to_string()
                 .starts_with(&config.ds.root().to_string())
             {
                 config.ds.remove(&main_file_path).await?;
             }
-        } else if package_file_path.exists() {
+        } else if config.ds.exists(&package_file_path) {
             if package_file_path
                 .to_string()
                 .starts_with(&config.ds.root().to_string())
@@ -124,7 +124,7 @@ pub async fn clear_(
     }
 
     // Download FASTN.ftd again after removing all the content
-    if !config.ds.root().join("FASTN.ftd").exists() {
+    if !config.ds.exists(&config.ds.root().join("FASTN.ftd")) {
         fastn_core::commands::serve::download_init_package(&config.package.download_base_url)
             .await?;
     }

--- a/fastn-core/src/apis/clone.rs
+++ b/fastn-core/src/apis/clone.rs
@@ -32,7 +32,7 @@ async fn clone_worker(config: &fastn_core::Config) -> fastn_core::Result<CloneRe
                     ds.read_content(&x)
                         .await
                         .map_err(|e| e.into())
-                        .map(|v| (x.strip_prefix(&root).unwrap_or_else(|| x).to_string(), v))
+                        .map(|v| (x.strip_prefix(&root).unwrap_or(x).to_string(), v))
                 })
             })
             .collect::<Vec<tokio::task::JoinHandle<fastn_core::Result<(String, Vec<u8>)>>>>(),

--- a/fastn-core/src/apis/clone.rs
+++ b/fastn-core/src/apis/clone.rs
@@ -32,7 +32,7 @@ async fn clone_worker(config: &fastn_core::Config) -> fastn_core::Result<CloneRe
                     ds.read_content(&x)
                         .await
                         .map_err(|e| e.into())
-                        .map(|v| (x.strip_prefix(&root).to_string(), v))
+                        .map(|v| (x.strip_prefix(&root).unwrap_or_else(|| x).to_string(), v))
                 })
             })
             .collect::<Vec<tokio::task::JoinHandle<fastn_core::Result<(String, Vec<u8>)>>>>(),

--- a/fastn-core/src/apis/sync.rs
+++ b/fastn-core/src/apis/sync.rs
@@ -134,9 +134,7 @@ pub(crate) async fn sync_worker(
                 } else {
                     // else: both should have same version,
                     // client version(timestamp) can never be greater than server's version
-                    if config.ds.root().join(path).exists() {
-                        config.ds.remove(&config.ds.root().join(path)).await?;
-                    }
+                    config.ds.remove(&config.ds.root().join(path)).await?;
                     snapshots.remove(path);
                 }
             }

--- a/fastn-core/src/apis/sync2.rs
+++ b/fastn-core/src/apis/sync2.rs
@@ -297,9 +297,7 @@ pub(crate) async fn do_sync(
                         },
                     );
                 } else {
-                    if config.ds.root().join(path).exists() {
-                        config.ds.remove(&config.ds.root().join(path)).await?;
-                    }
+                    config.ds.remove(&config.ds.root().join(path)).await?;
                     to_be_in_history.insert(
                         path.to_string(),
                         fastn_core::history::FileEditTemp {

--- a/fastn-core/src/commands/abort_merge.rs
+++ b/fastn-core/src/commands/abort_merge.rs
@@ -7,9 +7,7 @@ pub async fn abort_merge(config: &fastn_core::Config, path: &str) -> fastn_core:
             .workspace
             .eq(&fastn_core::snapshot::WorkspaceType::CloneDeletedRemoteEdited)
         {
-            if config.ds.root().join(path).exists() {
-                config.ds.remove(&config.ds.root().join(path)).await?;
-            }
+            config.ds.remove(&config.ds.root().join(path)).await?;
         } else {
             config
                 .ds

--- a/fastn-core/src/commands/add.rs
+++ b/fastn-core/src/commands/add.rs
@@ -22,7 +22,7 @@ async fn simple_add(config: &fastn_core::Config, file: &str) -> fastn_core::Resu
         });
     }
 
-    if !config.ds.root().join(file).exists() {
+    if !config.ds.exists(&config.ds.root().join(file)) {
         return Err(fastn_core::Error::UsageError {
             message: format!("{} doesn't exists", file),
         });
@@ -80,7 +80,7 @@ async fn cr_add(config: &fastn_core::Config, file: &str, cr: usize) -> fastn_cor
 
     let file_path = config.ds.root().join(file);
 
-    if file_path.exists() {
+    if config.ds.exists(&file_path) {
         fastn_core::utils::copy(&file_path, &cr_file_path, &config.ds).await?;
     } else {
         fastn_core::utils::update(&cr_file_path, vec![].as_slice(), &config.ds).await?;

--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -256,10 +256,7 @@ async fn remove_deleted_documents(
         let folder_parent = folder_path.parent();
         let file_path = &folder_path.with_extension("ftd");
 
-        if file_path.exists() {
-            config.ds.remove(file_path).await?;
-        }
-
+        config.ds.remove(file_path).await?;
         config.ds.remove(&folder_path).await?;
 
         // If the parent folder of the file's output folder is also empty, delete it as well.

--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -7,7 +7,7 @@ pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result
     println!("Post build index assertion started ...");
 
     // if build_path.is_dir() {
-    if !build_path.join(INDEX_FILE).exists() {
+    if !config.ds.exists(&build_path.join(INDEX_FILE)) {
         return Err(fastn_core::Error::NotFound(format!(
             "Couldn't find {} in package root folder",
             INDEX_FILE

--- a/fastn-core/src/commands/edit.rs
+++ b/fastn-core/src/commands/edit.rs
@@ -9,7 +9,7 @@ pub async fn edit(config: &fastn_core::Config, file: &str, cr: &str) -> fastn_co
 
     let cr_track_path = config.cr_track_path(&config.ds.root().join(file), cr);
     let cr_file_path = config.cr_path(cr).join(file);
-    if cr_track_path.exists() && cr_file_path.exists() {
+    if config.ds.exists(&cr_track_path) && config.ds.exists(&cr_file_path) {
         return fastn_core::usage_error(format!("{} is already tracked in cr {}", file, cr));
     }
 
@@ -28,13 +28,13 @@ pub async fn edit(config: &fastn_core::Config, file: &str, cr: &str) -> fastn_co
     // copy file to cr directory
     let file_path = config.history_path(file, file_edit.version);
 
-    if cr_file_path.exists() {
+    if config.ds.exists(&cr_file_path) {
         return Err(fastn_core::Error::UsageError {
             message: format!("{} is already exists", cr_file_path),
         });
     }
 
-    if file_path.exists() {
+    if config.ds.exists(&file_path) {
         let content = config.ds.read_content(&file_path).await?;
         fastn_core::utils::update(&cr_file_path, content.as_slice(), &config.ds).await?;
     } else {

--- a/fastn-core/src/commands/mark_resolved.rs
+++ b/fastn-core/src/commands/mark_resolved.rs
@@ -11,11 +11,9 @@ pub async fn mark_resolved(config: &fastn_core::Config, path: &str) -> fastn_cor
     .await?;
     // TODO: Check workspace value and then delete it
     // This is certainly bad idea
-    if config.conflicted_dir().join(path).exists() {
-        config
-            .ds
-            .remove(&config.conflicted_dir().join(path))
-            .await?;
-    }
+    config
+        .ds
+        .remove(&config.conflicted_dir().join(path))
+        .await?;
     Ok(())
 }

--- a/fastn-core/src/commands/resolve_conflict.rs
+++ b/fastn-core/src/commands/resolve_conflict.rs
@@ -71,9 +71,7 @@ pub async fn resolve_conflict(
         if !(conflicted_data.ours.deleted() || conflicted_data.theirs.deleted()) {
             return fastn_core::usage_error(format!("{} is not in `delete-edit-conflict`", path));
         }
-        if config.ds.root().join(path).exists() {
-            config.ds.remove(&config.ds.root().join(path)).await?;
-        }
+        config.ds.remove(&config.ds.root().join(path)).await?;
     } else if print {
         let content = conflicted_data
             .marker

--- a/fastn-core/src/commands/rm.rs
+++ b/fastn-core/src/commands/rm.rs
@@ -30,9 +30,7 @@ async fn simple_rm(config: &fastn_core::Config, file: &str) -> fastn_core::Resul
     if let Some(workspace_entry) = workspace.get_mut(file) {
         workspace_entry.set_deleted();
         let path = config.ds.root().join(&workspace_entry.filename);
-        if path.exists() {
-            config.ds.remove(&path).await?;
-        }
+        config.ds.remove(&path).await?;
     } else {
         return Err(fastn_core::Error::UsageError {
             message: format!("{} is not present in workspace", file),

--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -217,7 +217,7 @@ async fn serve_fastn_file(config: &fastn_core::Config) -> fastn_core::http::Resp
 
 async fn favicon(config: &fastn_core::Config) -> fastn_core::Result<fastn_core::http::Response> {
     let mut path = fastn_ds::Path::new("favicon.ico");
-    if !path.exists() {
+    if !config.ds.exists(&path) {
         path = fastn_ds::Path::new("static/favicon.ico");
     }
     Ok(static_file(config, path).await)
@@ -228,7 +228,7 @@ async fn static_file(
     config: &fastn_core::Config,
     file_path: fastn_ds::Path,
 ) -> fastn_core::http::Response {
-    if !file_path.exists() {
+    if !config.ds.exists(&file_path) {
         tracing::error!(
             msg = "no such static file ({})",
             path = file_path.to_string()

--- a/fastn-core/src/commands/start_tracking.rs
+++ b/fastn-core/src/commands/start_tracking.rs
@@ -61,7 +61,7 @@ async fn write(
     timestamp: u128,
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<()> {
-    let string = if config.ds.exists(&path) {
+    let string = if config.ds.exists(path) {
         let existing_doc = config.ds.read_to_string(path).await?;
         format!(
             "{}\n\n-- fastn.track: {}\nself-timestamp: {}",

--- a/fastn-core/src/commands/start_tracking.rs
+++ b/fastn-core/src/commands/start_tracking.rs
@@ -61,7 +61,7 @@ async fn write(
     timestamp: u128,
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<()> {
-    let string = if path.exists() {
+    let string = if config.ds.exists(&path) {
         let existing_doc = config.ds.read_to_string(path).await?;
         format!(
             "{}\n\n-- fastn.track: {}\nself-timestamp: {}",

--- a/fastn-core/src/commands/status.rs
+++ b/fastn-core/src/commands/status.rs
@@ -29,7 +29,7 @@ async fn file_status(
     workspaces: &std::collections::BTreeMap<String, fastn_core::snapshot::Workspace>,
 ) -> fastn_core::Result<()> {
     let path = base_path.join(source);
-    if !path.exists() {
+    if !config.ds.exists(&path) {
         if snapshots.contains_key(source) {
             println!("{:?}: {}", FileStatus::Deleted, source);
         } else {
@@ -151,7 +151,7 @@ async fn get_track_status(
 ) -> fastn_core::Result<std::collections::BTreeMap<String, TrackStatus>> {
     let path = fastn_core::utils::track_path(doc.get_id(), doc.get_base_path());
     let mut track_list = std::collections::BTreeMap::new();
-    if !path.exists() {
+    if !config.ds.exists(&path) {
         return Ok(track_list);
     }
     let tracks = fastn_core::tracker::get_tracks(config, base_path, &path).await?;

--- a/fastn-core/src/commands/sync.rs
+++ b/fastn-core/src/commands/sync.rs
@@ -255,9 +255,7 @@ async fn update_current_directory(
                 fastn_core::utils::update1(config.ds.root(), path, content, &config.ds).await?;
             }
             fastn_core::apis::sync::SyncResponseFile::Delete { path, .. } => {
-                if config.ds.root().join(path).exists() {
-                    config.ds.remove(&config.ds.root().join(path)).await?;
-                }
+                config.ds.remove(&config.ds.root().join(path)).await?;
             }
         }
     }

--- a/fastn-core/src/commands/sync2.rs
+++ b/fastn-core/src/commands/sync2.rs
@@ -171,9 +171,7 @@ async fn update_current_directory(
                 }
             }
             fastn_core::apis::sync2::SyncResponseFile::Delete { path, .. } => {
-                if config.ds.root().join(path).exists() {
-                    config.ds.remove(&config.ds.root().join(path)).await?;
-                }
+                config.ds.remove(&config.ds.root().join(path)).await?;
             }
         }
     }

--- a/fastn-core/src/commands/translation_status.rs
+++ b/fastn-core/src/commands/translation_status.rs
@@ -40,12 +40,12 @@ pub(crate) async fn get_translation_status(
 ) -> fastn_core::Result<std::collections::BTreeMap<String, TranslationStatus>> {
     let mut translation_status = std::collections::BTreeMap::new();
     for (file, timestamp) in snapshots {
-        if !path.join(file).exists() {
+        if !config.ds.exists(&path.join(file)) {
             translation_status.insert(file.clone(), TranslationStatus::Missing);
             continue;
         }
         let track_path = fastn_core::utils::track_path(file.as_str(), path);
-        if !track_path.exists() {
+        if !config.ds.exists(&track_path) {
             translation_status.insert(file.clone(), TranslationStatus::NeverMarked);
             continue;
         }

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -898,7 +898,7 @@ impl Config {
     ) -> fastn_core::Result<fastn_core::Package> {
         let fastn_path = &self.packages_root.join(&package.name).join("FASTN.ftd");
 
-        if !self.ds.exists(&fastn_path) {
+        if !self.ds.exists(fastn_path) {
             let package = self.resolve_package(package).await?;
             self.add_package(&package);
         }

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -788,7 +788,7 @@ impl Config {
         id: &str,
         package: &fastn_core::Package,
     ) -> fastn_core::Result<fastn_core::File> {
-        let file_name = fastn_core::Config::get_file_name(self.ds.root(), id)?;
+        let file_name = fastn_core::Config::get_file_name(self.ds.root(), id, &self.ds)?;
         self.get_files(package)
             .await?
             .into_iter()
@@ -898,7 +898,7 @@ impl Config {
     ) -> fastn_core::Result<fastn_core::Package> {
         let fastn_path = &self.packages_root.join(&package.name).join("FASTN.ftd");
 
-        if !fastn_path.exists() {
+        if !self.ds.exists(&fastn_path) {
             let package = self.resolve_package(package).await?;
             self.add_package(&package);
         }
@@ -1120,7 +1120,7 @@ impl Config {
         }
 
         if let Some(package_root) =
-            utils::find_root_for_file(&self.packages_root.join(id), "FASTN.ftd")
+            utils::find_root_for_file(&self.packages_root.join(id), "FASTN.ftd", &self.ds)
         {
             let mut package = fastn_core::Package::new("unknown-package");
             package
@@ -1225,7 +1225,11 @@ impl Config {
         })
     }
 
-    pub(crate) fn get_file_name(root: &fastn_ds::Path, id: &str) -> fastn_core::Result<String> {
+    pub(crate) fn get_file_name(
+        root: &fastn_ds::Path,
+        id: &str,
+        ds: &fastn_ds::DocumentStore,
+    ) -> fastn_core::Result<String> {
         let mut id = id.to_string();
         let mut add_packages = "".to_string();
         if let Some(new_id) = id.strip_prefix("-/") {
@@ -1240,10 +1244,10 @@ impl Config {
             .replace("/index.html", "/")
             .replace("index.html", "/");
         if id.eq("/") {
-            if root.join(format!("{}index.ftd", add_packages)).exists() {
+            if ds.exists(&root.join(format!("{}index.ftd", add_packages))) {
                 return Ok(format!("{}index.ftd", add_packages));
             }
-            if root.join(format!("{}README.md", add_packages)).exists() {
+            if ds.exists(&root.join(format!("{}README.md", add_packages))) {
                 return Ok(format!("{}README.md", add_packages));
             }
             return Err(fastn_core::Error::UsageError {
@@ -1251,22 +1255,16 @@ impl Config {
             });
         }
         id = id.trim_matches('/').to_string();
-        if root.join(format!("{}{}.ftd", add_packages, id)).exists() {
+        if ds.exists(&root.join(format!("{}{}.ftd", add_packages, id))) {
             return Ok(format!("{}{}.ftd", add_packages, id));
         }
-        if root
-            .join(format!("{}{}/index.ftd", add_packages, id))
-            .exists()
-        {
+        if ds.exists(&root.join(format!("{}{}/index.ftd", add_packages, id))) {
             return Ok(format!("{}{}/index.ftd", add_packages, id));
         }
-        if root.join(format!("{}{}.md", add_packages, id)).exists() {
+        if ds.exists(&root.join(format!("{}{}.md", add_packages, id))) {
             return Ok(format!("{}{}.md", add_packages, id));
         }
-        if root
-            .join(format!("{}{}/README.md", add_packages, id))
-            .exists()
-        {
+        if ds.exists(&root.join(format!("{}{}/README.md", add_packages, id))) {
             return Ok(format!("{}{}/README.md", add_packages, id));
         }
         Err(fastn_core::Error::UsageError {
@@ -1279,18 +1277,20 @@ impl Config {
         directory: &fastn_ds::Path,
         ds: &fastn_ds::DocumentStore,
     ) -> fastn_core::Result<fastn_ds::Path> {
-        if let Some(fastn_ftd_root) = utils::find_root_for_file(directory, "FASTN.ftd") {
+        if let Some(fastn_ftd_root) = utils::find_root_for_file(directory, "FASTN.ftd", ds) {
             return Ok(fastn_ftd_root);
         }
-        let fastn_manifest_path = match utils::find_root_for_file(directory, "fastn.manifest.ftd") {
-            Some(fastn_manifest_path) => fastn_manifest_path,
-            None => {
-                return Err(fastn_core::Error::UsageError {
-                    message: "FASTN.ftd or fastn.manifest.ftd not found in any parent directory"
-                        .to_string(),
-                });
-            }
-        };
+        let fastn_manifest_path =
+            match utils::find_root_for_file(directory, "fastn.manifest.ftd", ds) {
+                Some(fastn_manifest_path) => fastn_manifest_path,
+                None => {
+                    return Err(fastn_core::Error::UsageError {
+                        message:
+                            "FASTN.ftd or fastn.manifest.ftd not found in any parent directory"
+                                .to_string(),
+                    });
+                }
+            };
 
         let doc = ds
             .read_to_string(&fastn_manifest_path.join("fastn.manifest.ftd"))
@@ -1314,7 +1314,7 @@ impl Config {
                 accumulator.join(part)
             });
 
-        if new_package_root.join("FASTN.ftd").exists() {
+        if ds.exists(&new_package_root.join("FASTN.ftd")) {
             Ok(new_package_root)
         } else {
             Err(fastn_core::Error::PackageError {

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -329,7 +329,12 @@ impl Config {
     }
 
     pub fn path_without_root(&self, path: &fastn_ds::Path) -> fastn_core::Result<String> {
-        Ok(path.strip_prefix(self.ds.root()).to_string())
+        Ok(path
+            .strip_prefix(self.ds.root())
+            .ok_or(fastn_core::Error::UsageError {
+                message: format!("Can't find prefix `{}` in `{}`", self.ds.root(), path),
+            })?
+            .to_string())
     }
 
     pub fn cr_deleted_file_path(&self, cr_number: usize) -> fastn_ds::Path {

--- a/fastn-core/src/config/utils.rs
+++ b/fastn-core/src/config/utils.rs
@@ -1,12 +1,16 @@
 /// `find_root_for_file()` starts with the given path, which is the current directory where the
 /// application started in, and goes up till it finds a folder that contains `FASTN.ftd` file.
 /// TODO: make async
-pub(crate) fn find_root_for_file(dir: &fastn_ds::Path, file_name: &str) -> Option<fastn_ds::Path> {
-    if dir.join(file_name).exists() {
+pub(crate) fn find_root_for_file(
+    dir: &fastn_ds::Path,
+    file_name: &str,
+    ds: &fastn_ds::DocumentStore,
+) -> Option<fastn_ds::Path> {
+    if ds.exists(&dir.join(file_name)) {
         Some(dir.clone())
     } else {
         if let Some(p) = dir.parent() {
-            return find_root_for_file(&p, file_name);
+            return find_root_for_file(&p, file_name, ds);
         };
         None
     }

--- a/fastn-core/src/cr.rs
+++ b/fastn-core/src/cr.rs
@@ -21,7 +21,7 @@ pub(crate) async fn get_cr_meta(
     cr_number: usize,
 ) -> fastn_core::Result<fastn_core::cr::CRMeta> {
     let cr_meta_path = config.cr_meta_path(cr_number);
-    if !cr_meta_path.exists() {
+    if !config.ds.exists(&cr_meta_path) {
         return fastn_core::usage_error(format!("CR#{} doesn't exist", cr_number));
     }
 
@@ -142,11 +142,11 @@ pub(crate) async fn get_deleted_files(
     config: &fastn_core::Config,
     cr_number: usize,
 ) -> fastn_core::Result<Vec<CRDeleted>> {
-    if !config.cr_path(cr_number).exists() {
+    if !config.ds.exists(&config.cr_path(cr_number)) {
         return fastn_core::usage_error(format!("CR#{} doesn't exist", cr_number));
     }
     let deleted_files_path = config.cr_deleted_file_path(cr_number);
-    if !deleted_files_path.exists() {
+    if !config.ds.exists(&deleted_files_path) {
         return Ok(vec![]);
     }
     let deleted_files_content = config.ds.read_to_string(&deleted_files_path).await?;

--- a/fastn-core/src/cr.rs
+++ b/fastn-core/src/cr.rs
@@ -220,7 +220,15 @@ impl fastn_core::Config {
         let mut tracking_info_list = vec![];
 
         for cr_track_path in cr_track_paths {
-            let tracked_file = cr_track_path.strip_prefix(&self.track_dir());
+            let tracked_file = cr_track_path.strip_prefix(&self.track_dir()).ok_or(
+                fastn_core::Error::UsageError {
+                    message: format!(
+                        "Can't find prefix `{}` in `{}`",
+                        self.track_dir(),
+                        cr_track_path
+                    ),
+                },
+            )?;
             let tracked_file_str = fastn_core::cr::cr_path_to_file_name(cr_number, &tracked_file)?;
             if let Some(info) = fastn_core::track::get_tracking_info_(self, &cr_track_path)
                 .await?

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -103,7 +103,7 @@ fn fastn_lib_ftd() -> &'static str {
 
 async fn package_info_about(config: &fastn_core::Config) -> fastn_core::Result<String> {
     let path = config.ds.root().join("fastn").join("cr.ftd");
-    Ok(if path.exists() {
+    Ok(if config.ds.exists(&path) {
         config.ds.read_to_string(&path).await?
     } else {
         let body_prefix = match config.package.generate_prefix_string(false) {
@@ -214,7 +214,7 @@ async fn original_package_status(config: &fastn_core::Config) -> fastn_core::Res
         .join("fastn")
         .join("translation")
         .join("original-status.ftd");
-    Ok(if path.exists() {
+    Ok(if config.ds.exists(&path) {
         config.ds.read_to_string(&path).await?
     } else {
         let body_prefix = match config.package.generate_prefix_string(false) {
@@ -237,7 +237,7 @@ async fn translation_package_status(config: &fastn_core::Config) -> fastn_core::
         .join("fastn")
         .join("translation")
         .join("translation-status.ftd");
-    Ok(if path.exists() {
+    Ok(if config.ds.exists(&path) {
         config.ds.read_to_string(&path).await?
     } else {
         let body_prefix = match config.package.generate_prefix_string(false) {
@@ -259,7 +259,7 @@ async fn get_messages(
     Ok(match status {
         TranslatedDocument::Missing { .. } => {
             let path = config.ds.root().join("fastn/translation/missing.ftd");
-            if path.exists() {
+            if config.ds.exists(&path) {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/missing.ftd").to_string()
@@ -267,7 +267,7 @@ async fn get_messages(
         }
         TranslatedDocument::NeverMarked { .. } => {
             let path = config.ds.root().join("fastn/translation/never-marked.ftd");
-            if path.exists() {
+            if config.ds.exists(&path) {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/never-marked.ftd").to_string()
@@ -275,7 +275,7 @@ async fn get_messages(
         }
         TranslatedDocument::Outdated { .. } => {
             let path = config.ds.root().join("fastn/translation/out-of-date.ftd");
-            if path.exists() {
+            if config.ds.exists(&path) {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/out-of-date.ftd").to_string()
@@ -283,7 +283,7 @@ async fn get_messages(
         }
         TranslatedDocument::UptoDate { .. } => {
             let path = config.ds.root().join("fastn/translation/upto-date.ftd");
-            if path.exists() {
+            if config.ds.exists(&path) {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/upto-date.ftd").to_string()

--- a/fastn-core/src/library2022/processor/package_query.rs
+++ b/fastn-core/src/library2022/processor/package_query.rs
@@ -23,7 +23,7 @@ pub async fn process(
 
     let sqlite_database_path = req_config.config.ds.root().join(sqlite_database.as_str());
 
-    if !sqlite_database_path.exists() {
+    if !req_config.config.ds.exists(&sqlite_database_path) {
         return ftd::interpreter::utils::e2(
             "`db` does not exists for package-query processor".to_string(),
             doc.name,

--- a/fastn-core/src/library2022/processor/package_tree.rs
+++ b/fastn-core/src/library2022/processor/package_tree.rs
@@ -48,6 +48,7 @@ pub async fn process(
         .into_iter()
         .map(|v| {
             v.strip_prefix(&root)
+                .unwrap_or_else(|| v)
                 .to_string()
                 .replace(std::path::MAIN_SEPARATOR.to_string().as_str(), "/")
         })

--- a/fastn-core/src/library2022/processor/package_tree.rs
+++ b/fastn-core/src/library2022/processor/package_tree.rs
@@ -48,7 +48,7 @@ pub async fn process(
         .into_iter()
         .map(|v| {
             v.strip_prefix(&root)
-                .unwrap_or_else(|| v)
+                .unwrap_or(v)
                 .to_string()
                 .replace(std::path::MAIN_SEPARATOR.to_string().as_str(), "/")
         })

--- a/fastn-core/src/package/mod.rs
+++ b/fastn-core/src/package/mod.rs
@@ -626,7 +626,7 @@ impl Package {
         ds: &fastn_ds::DocumentStore,
     ) -> fastn_core::Result<fastn_core::Package> {
         let file_extract_path = package_root.join("FASTN.ftd");
-        if !file_extract_path.exists() {
+        if !ds.exists(&file_extract_path) {
             let fastn_string = self.get_fastn().await?;
             ds.write_content(&file_extract_path, fastn_string.into_bytes())
                 .await?;

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -633,6 +633,7 @@ impl Sitemap {
                 match fastn_core::Config::get_file_name(
                     current_package_root,
                     section.get_file_id().as_str(),
+                    &config.ds
                 ) {
                     Ok(name) => {
                         if current_package_root.eq(package_root) {
@@ -650,6 +651,7 @@ impl Sitemap {
                                 fastn_core::Config::get_file_name(
                                     package_root,
                                     section.get_file_id().as_str(),
+                                    &config.ds
                                 )
                                     .map_err(|e| {
                                         fastn_core::Error::UsageError {
@@ -697,7 +699,7 @@ impl Sitemap {
                 } else if crate::http::url_regex().find(id.as_str()).is_some() {
                     (None, None)
                 } else {
-                    match fastn_core::Config::get_file_name(current_package_root, id.as_str()) {
+                    match fastn_core::Config::get_file_name(current_package_root, id.as_str(), &config.ds) {
                         Ok(name) => {
                             if current_package_root.eq(package_root) {
                                 (Some(current_package_root.join(name)), None)
@@ -710,7 +712,7 @@ impl Sitemap {
                         }
                         Err(_) => (
                             Some(package_root.join(
-                                fastn_core::Config::get_file_name(package_root, id.as_str()).map_err(
+                                fastn_core::Config::get_file_name(package_root, id.as_str(),&config.ds).map_err(
                                     |e| fastn_core::Error::UsageError {
                                         message: format!(
                                             "`{}` not found, fix fastn.sitemap in FASTN.ftd. Error: {:?}",
@@ -757,7 +759,7 @@ impl Sitemap {
             {
                 (None, None)
             } else {
-                match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str()) {
+                match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str(), &config.ds) {
                     Ok(name) => {
                         if current_package_root.eq(package_root) {
                             (Some(current_package_root.join(name)), None)
@@ -774,6 +776,7 @@ impl Sitemap {
                                 fastn_core::Config::get_file_name(
                                     package_root,
                                     toc.get_file_id().as_str(),
+                                    &config.ds
                                 )
                                     .map_err(|e| {
                                         fastn_core::Error::UsageError {

--- a/fastn-core/src/snapshot.rs
+++ b/fastn-core/src/snapshot.rs
@@ -30,7 +30,7 @@ pub(crate) async fn get_latest_snapshots(
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<std::collections::BTreeMap<String, u128>> {
     let latest_file_path = path.join(".history/.latest.ftd");
-    if !latest_file_path.exists() {
+    if !ds.exists(&latest_file_path) {
         // TODO: should we error out here?
         return Ok(Default::default());
     }
@@ -145,7 +145,7 @@ pub(crate) async fn get_workspace(
     config: &fastn_core::Config,
 ) -> fastn_core::Result<std::collections::BTreeMap<String, Workspace>> {
     let latest_file_path = config.ds.root().join(".fastn").join("workspace.ftd");
-    if !latest_file_path.exists() {
+    if !config.ds.exists(&latest_file_path) {
         // TODO: should we error out here?
         return Ok(Default::default());
     }

--- a/fastn-core/src/track.rs
+++ b/fastn-core/src/track.rs
@@ -29,7 +29,7 @@ pub(crate) async fn get_tracking_info_(
     config: &fastn_core::Config,
     track_path: &fastn_ds::Path,
 ) -> fastn_core::Result<Vec<fastn_core::track::TrackingInfo>> {
-    if !track_path.exists() {
+    if !config.ds.exists(&track_path) {
         return fastn_core::usage_error(format!("No tracking found for {}", track_path));
     }
 

--- a/fastn-core/src/track.rs
+++ b/fastn-core/src/track.rs
@@ -29,7 +29,7 @@ pub(crate) async fn get_tracking_info_(
     config: &fastn_core::Config,
     track_path: &fastn_ds::Path,
 ) -> fastn_core::Result<Vec<fastn_core::track::TrackingInfo>> {
-    if !config.ds.exists(&track_path) {
+    if !config.ds.exists(track_path) {
         return fastn_core::usage_error(format!("No tracking found for {}", track_path));
     }
 

--- a/fastn-core/src/tracker.rs
+++ b/fastn-core/src/tracker.rs
@@ -17,7 +17,7 @@ pub(crate) async fn get_tracks(
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<std::collections::BTreeMap<String, Track>> {
     let mut tracks = std::collections::BTreeMap::new();
-    if !path.exists() {
+    if !config.ds.exists(path) {
         return Ok(tracks);
     }
 

--- a/fastn-core/src/translation.rs
+++ b/fastn-core/src/translation.rs
@@ -160,7 +160,7 @@ impl TranslatedDocument {
             }
             let translated_document = translated_documents.get(file.as_str()).unwrap();
             let track_path = fastn_core::utils::track_path(file.as_str(), config.ds.root());
-            if !track_path.exists() {
+            if !config.ds.exists(&track_path) {
                 translation_status.insert(
                     file,
                     TranslatedDocument::NeverMarked {
@@ -224,12 +224,12 @@ pub(crate) async fn get_translation_status_counts(
         last_modified_on: None,
     };
     for (file, timestamp) in snapshots {
-        if !path.join(file).exists() {
+        if !config.ds.exists(&path.join(file)) {
             translation_status_count.missing += 1;
             continue;
         }
         let track_path = fastn_core::utils::track_path(file.as_str(), path);
-        if !track_path.exists() {
+        if !config.ds.exists(&track_path) {
             translation_status_count.never_marked += 1;
             continue;
         }

--- a/fastn-core/src/workspace.rs
+++ b/fastn-core/src/workspace.rs
@@ -72,7 +72,7 @@ impl fastn_core::Config {
 
     pub async fn get_available_crs(&self) -> fastn_core::Result<Vec<i32>> {
         let mut response = vec![];
-        if self.clone_available_crs_path().exists() {
+        if self.ds.exists(&self.clone_available_crs_path()) {
             let crs = self
                 .ds
                 .read_to_string(&self.clone_available_crs_path())

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -40,10 +40,6 @@ impl Path {
             })
     }
 
-    pub fn exists(&self) -> bool {
-        self.path.exists()
-    }
-
     pub fn file_name(&self) -> Option<String> {
         self.path.file_name().map(|v| v.to_string())
     }
@@ -153,7 +149,7 @@ impl DocumentStore {
 
         // Create the directory if it doesn't exist
         if let Some(parent) = full_path.parent() {
-            if !parent.exists() {
+            if !parent.path.exists() {
                 tokio::fs::create_dir_all(parent.path).await?;
             }
         }
@@ -173,6 +169,9 @@ impl DocumentStore {
     }
 
     pub async fn remove(&self, path: &Path) -> Result<(), RemoveError> {
+        if !path.path.exists() {
+            return Ok(());
+        }
         if path.path.is_file() {
             tokio::fs::remove_file(&path.path).await?;
         } else if path.path.is_dir() {
@@ -205,6 +204,10 @@ impl DocumentStore {
                 }
             }) //todo: improve error message
             .collect::<Vec<fastn_ds::Path>>()
+    }
+
+    pub fn exists(&self, path: &fastn_ds::Path) -> bool {
+        path.path.exists()
     }
 }
 

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -31,14 +31,13 @@ impl Path {
         })
     }
 
-    pub fn strip_prefix(&self, base: &Self) -> Self {
-        Path {
-            path: self
-                .path
-                .strip_prefix(base.path.as_str())
-                .unwrap()
-                .to_path_buf(),
-        }
+    pub fn strip_prefix(&self, base: &Self) -> Option<Self> {
+        self.path
+            .strip_prefix(base.path.as_str())
+            .ok()
+            .map(|v| Path {
+                path: v.to_path_buf(),
+            })
     }
 
     pub fn exists(&self) -> bool {


### PR DESCRIPTION
This PR has following changes:

### Change the signature of `fastn_ds::Path::strip_prefix` function from:
```rs
pub fn strip_prefix(&self, base: &Self) -> fastn_ds::Path
```
to
```rs
pub fn strip_prefix(&self, base: &Self) -> Option<fastn_ds::Path> 
```

### Move `fastn_ds::Path::exists` to `fastn_ds::DocumentStore::exists`
```diff
- impl fastn_ds::Path {
-    pub fn exists(&self) -> bool {
-       self.path.exists()
-    }
- }

+ impl fastn_ds::DocumentStore {
+    pub fn exists(&self, path: &fastn_ds::Path) -> bool {
+        path.path.exists()
+    }
+ }
```