### PR TITLE
keeping track of processed files

### DIFF
--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -195,6 +195,7 @@ fn is_virtual_dep(path: &str) -> bool {
         || path.ends_with("/-/assets.ftd")
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_dependency_file(
     config: &fastn_core::Config,
     cache: &mut cache::Cache,


### PR DESCRIPTION
```py
d = {}
c = 0

for line in open("t.log"):
    if "Processing" not in line:
        continue
    c += 1

    p = line.split()[2]
    d[p] = d.get(p, 0) + 1
    if d[p] > 1:
        print(p, d[p])

print(c, len(d))
```

Last few lines when analysing log of [fastn.com](https://github.com/fastn-stack/fastn.com):

```txt
fastn-community.github.io/spectrum-ds/static/icon-github.svg 10
fastn-community.github.io/spectrum-ds/static/icon-github-dark.svg 10
fastn-community.github.io/spectrum-ds/static/lock-icon.svg 10
fastn-community.github.io/spectrum-ds/static/lock-icon-dark.svg 10
fastn-community.github.io/spectrum-ds/static/filter.css 10
fastn-community.github.io/header/static/header/hamburger-dark.svg 18
1055 133
```