### PR TITLE
Remove fastn_core::Config::update_ids_from_package

### DIFF
--- a/fastn-core/src/apis/cache.rs
+++ b/fastn-core/src/apis/cache.rs
@@ -79,14 +79,14 @@ pub async fn clear_(
     for file in query.file.iter() {
         let main_file_path = config.ds.root().join(file.as_str());
         let package_file_path = config.packages_root.join(file.as_str());
-        if config.ds.exists(&main_file_path) {
+        if config.ds.exists(&main_file_path).await {
             if main_file_path
                 .to_string()
                 .starts_with(&config.ds.root().to_string())
             {
                 config.ds.remove(&main_file_path).await?;
             }
-        } else if config.ds.exists(&package_file_path) {
+        } else if config.ds.exists(&package_file_path).await {
             if package_file_path
                 .to_string()
                 .starts_with(&config.ds.root().to_string())
@@ -124,7 +124,7 @@ pub async fn clear_(
     }
 
     // Download FASTN.ftd again after removing all the content
-    if !config.ds.exists(&config.ds.root().join("FASTN.ftd")) {
+    if !config.ds.exists(&config.ds.root().join("FASTN.ftd")).await {
         fastn_core::commands::serve::download_init_package(&config.package.download_base_url)
             .await?;
     }

--- a/fastn-core/src/commands/check.rs
+++ b/fastn-core/src/commands/check.rs
@@ -7,7 +7,7 @@ pub async fn post_build_check(config: &fastn_core::Config) -> fastn_core::Result
     println!("Post build index assertion started ...");
 
     // if build_path.is_dir() {
-    if !config.ds.exists(&build_path.join(INDEX_FILE)) {
+    if !config.ds.exists(&build_path.join(INDEX_FILE)).await {
         return Err(fastn_core::Error::NotFound(format!(
             "Couldn't find {} in package root folder",
             INDEX_FILE

--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -171,7 +171,7 @@ async fn serve_fastn_file(config: &fastn_core::Config) -> fastn_core::http::Resp
 
 async fn favicon(config: &fastn_core::Config) -> fastn_core::Result<fastn_core::http::Response> {
     let mut path = fastn_ds::Path::new("favicon.ico");
-    if !config.ds.exists(&path) {
+    if !config.ds.exists(&path).await {
         path = fastn_ds::Path::new("static/favicon.ico");
     }
     Ok(static_file(config, path).await)
@@ -182,7 +182,7 @@ async fn static_file(
     config: &fastn_core::Config,
     file_path: fastn_ds::Path,
 ) -> fastn_core::http::Response {
-    if !config.ds.exists(&file_path) {
+    if !config.ds.exists(&file_path).await {
         tracing::error!(
             msg = "no such static file ({})",
             path = file_path.to_string()

--- a/fastn-core/src/commands/translation_status.rs
+++ b/fastn-core/src/commands/translation_status.rs
@@ -40,12 +40,12 @@ pub(crate) async fn get_translation_status(
 ) -> fastn_core::Result<std::collections::BTreeMap<String, TranslationStatus>> {
     let mut translation_status = std::collections::BTreeMap::new();
     for (file, timestamp) in snapshots {
-        if !config.ds.exists(&path.join(file)) {
+        if !config.ds.exists(&path.join(file)).await {
             translation_status.insert(file.clone(), TranslationStatus::Missing);
             continue;
         }
         let track_path = fastn_core::utils::track_path(file.as_str(), path);
-        if !config.ds.exists(&track_path) {
+        if !config.ds.exists(&track_path).await {
             translation_status.insert(file.clone(), TranslationStatus::NeverMarked);
             continue;
         }

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -542,7 +542,7 @@ impl Config {
 
     /// update the config.global_ids map from the contents of a file
     /// in case the user defines the id for any component in the document
-    pub async fn update_global_ids_from_file(
+    async fn update_global_ids_from_file(
         &mut self,
         doc_id: &str,
         data: &str,
@@ -691,6 +691,7 @@ impl Config {
     }
 
     /// updates the terms map from the files of the current package
+    #[allow(dead_code)]
     async fn update_ids_from_package(&mut self) -> fastn_core::Result<()> {
         let path = self.get_root_for_package(&self.package);
         let all_files_path = self.get_all_file_paths(&self.package)?;
@@ -1228,7 +1229,7 @@ impl Config {
             ds,
         };
         // Update global_ids map from the current package files
-        config.update_ids_from_package().await?;
+        // config.update_ids_from_package().await?;
 
         // TODO: Major refactor, while parsing sitemap of a package why do we need config in it?
         config.package.sitemap = {

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -797,7 +797,7 @@ impl Config {
     ) -> fastn_core::Result<fastn_core::Package> {
         let fastn_path = &self.packages_root.join(&package.name).join("FASTN.ftd");
 
-        if !self.ds.exists(fastn_path) {
+        if !self.ds.exists(fastn_path).await {
             let package = self.resolve_package(package).await?;
             self.add_package(&package);
         }
@@ -955,7 +955,7 @@ impl Config {
         }
 
         if let Some(package_root) =
-            utils::find_root_for_file(&self.packages_root.join(id), "FASTN.ftd", &self.ds)
+            utils::find_root_for_file(&self.packages_root.join(id), "FASTN.ftd", &self.ds).await
         {
             let mut package = fastn_core::Package::new("unknown-package");
             package
@@ -1060,7 +1060,7 @@ impl Config {
         })
     }
 
-    pub(crate) fn get_file_name(
+    pub(crate) async fn get_file_name(
         root: &fastn_ds::Path,
         id: &str,
         ds: &fastn_ds::DocumentStore,
@@ -1079,10 +1079,16 @@ impl Config {
             .replace("/index.html", "/")
             .replace("index.html", "/");
         if id.eq("/") {
-            if ds.exists(&root.join(format!("{}index.ftd", add_packages))) {
+            if ds
+                .exists(&root.join(format!("{}index.ftd", add_packages)))
+                .await
+            {
                 return Ok(format!("{}index.ftd", add_packages));
             }
-            if ds.exists(&root.join(format!("{}README.md", add_packages))) {
+            if ds
+                .exists(&root.join(format!("{}README.md", add_packages)))
+                .await
+            {
                 return Ok(format!("{}README.md", add_packages));
             }
             return Err(fastn_core::Error::UsageError {
@@ -1090,16 +1096,28 @@ impl Config {
             });
         }
         id = id.trim_matches('/').to_string();
-        if ds.exists(&root.join(format!("{}{}.ftd", add_packages, id))) {
+        if ds
+            .exists(&root.join(format!("{}{}.ftd", add_packages, id)))
+            .await
+        {
             return Ok(format!("{}{}.ftd", add_packages, id));
         }
-        if ds.exists(&root.join(format!("{}{}/index.ftd", add_packages, id))) {
+        if ds
+            .exists(&root.join(format!("{}{}/index.ftd", add_packages, id)))
+            .await
+        {
             return Ok(format!("{}{}/index.ftd", add_packages, id));
         }
-        if ds.exists(&root.join(format!("{}{}.md", add_packages, id))) {
+        if ds
+            .exists(&root.join(format!("{}{}.md", add_packages, id)))
+            .await
+        {
             return Ok(format!("{}{}.md", add_packages, id));
         }
-        if ds.exists(&root.join(format!("{}{}/README.md", add_packages, id))) {
+        if ds
+            .exists(&root.join(format!("{}{}/README.md", add_packages, id)))
+            .await
+        {
             return Ok(format!("{}{}/README.md", add_packages, id));
         }
         Err(fastn_core::Error::UsageError {
@@ -1112,11 +1130,11 @@ impl Config {
         directory: &fastn_ds::Path,
         ds: &fastn_ds::DocumentStore,
     ) -> fastn_core::Result<fastn_ds::Path> {
-        if let Some(fastn_ftd_root) = utils::find_root_for_file(directory, "FASTN.ftd", ds) {
+        if let Some(fastn_ftd_root) = utils::find_root_for_file(directory, "FASTN.ftd", ds).await {
             return Ok(fastn_ftd_root);
         }
         let fastn_manifest_path =
-            match utils::find_root_for_file(directory, "fastn.manifest.ftd", ds) {
+            match utils::find_root_for_file(directory, "fastn.manifest.ftd", ds).await {
                 Some(fastn_manifest_path) => fastn_manifest_path,
                 None => {
                     return Err(fastn_core::Error::UsageError {
@@ -1149,7 +1167,7 @@ impl Config {
                 accumulator.join(part)
             });
 
-        if ds.exists(&new_package_root.join("FASTN.ftd")) {
+        if ds.exists(&new_package_root.join("FASTN.ftd")).await {
             Ok(new_package_root)
         } else {
             Err(fastn_core::Error::PackageError {

--- a/fastn-core/src/config/utils.rs
+++ b/fastn-core/src/config/utils.rs
@@ -1,16 +1,17 @@
 /// `find_root_for_file()` starts with the given path, which is the current directory where the
 /// application started in, and goes up till it finds a folder that contains `FASTN.ftd` file.
 /// TODO: make async
-pub(crate) fn find_root_for_file(
+#[async_recursion::async_recursion]
+pub(crate) async fn find_root_for_file(
     dir: &fastn_ds::Path,
     file_name: &str,
     ds: &fastn_ds::DocumentStore,
 ) -> Option<fastn_ds::Path> {
-    if ds.exists(&dir.join(file_name)) {
+    if ds.exists(&dir.join(file_name)).await {
         Some(dir.clone())
     } else {
         if let Some(p) = dir.parent() {
-            return find_root_for_file(&p, file_name, ds);
+            return find_root_for_file(&p, file_name, ds).await;
         };
         None
     }

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -96,7 +96,7 @@ async fn original_package_status(config: &fastn_core::Config) -> fastn_core::Res
         .join("fastn")
         .join("translation")
         .join("original-status.ftd");
-    Ok(if config.ds.exists(&path) {
+    Ok(if config.ds.exists(&path).await {
         config.ds.read_to_string(&path).await?
     } else {
         let body_prefix = match config.package.generate_prefix_string(false) {
@@ -119,7 +119,7 @@ async fn translation_package_status(config: &fastn_core::Config) -> fastn_core::
         .join("fastn")
         .join("translation")
         .join("translation-status.ftd");
-    Ok(if config.ds.exists(&path) {
+    Ok(if config.ds.exists(&path).await {
         config.ds.read_to_string(&path).await?
     } else {
         let body_prefix = match config.package.generate_prefix_string(false) {
@@ -141,7 +141,7 @@ async fn get_messages(
     Ok(match status {
         TranslatedDocument::Missing { .. } => {
             let path = config.ds.root().join("fastn/translation/missing.ftd");
-            if config.ds.exists(&path) {
+            if config.ds.exists(&path).await {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/missing.ftd").to_string()
@@ -149,7 +149,7 @@ async fn get_messages(
         }
         TranslatedDocument::NeverMarked { .. } => {
             let path = config.ds.root().join("fastn/translation/never-marked.ftd");
-            if config.ds.exists(&path) {
+            if config.ds.exists(&path).await {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/never-marked.ftd").to_string()
@@ -157,7 +157,7 @@ async fn get_messages(
         }
         TranslatedDocument::Outdated { .. } => {
             let path = config.ds.root().join("fastn/translation/out-of-date.ftd");
-            if config.ds.exists(&path) {
+            if config.ds.exists(&path).await {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/out-of-date.ftd").to_string()
@@ -165,7 +165,7 @@ async fn get_messages(
         }
         TranslatedDocument::UptoDate { .. } => {
             let path = config.ds.root().join("fastn/translation/upto-date.ftd");
-            if config.ds.exists(&path) {
+            if config.ds.exists(&path).await {
                 config.ds.read_to_string(&path).await?
             } else {
                 include_str!("../ftd/translation/upto-date.ftd").to_string()

--- a/fastn-core/src/library2022/processor/package_query.rs
+++ b/fastn-core/src/library2022/processor/package_query.rs
@@ -23,7 +23,7 @@ pub async fn process(
 
     let sqlite_database_path = req_config.config.ds.root().join(sqlite_database.as_str());
 
-    if !req_config.config.ds.exists(&sqlite_database_path) {
+    if !req_config.config.ds.exists(&sqlite_database_path).await {
         return ftd::interpreter::utils::e2(
             "`db` does not exists for package-query processor".to_string(),
             doc.name,

--- a/fastn-core/src/package/mod.rs
+++ b/fastn-core/src/package/mod.rs
@@ -626,7 +626,7 @@ impl Package {
         ds: &fastn_ds::DocumentStore,
     ) -> fastn_core::Result<fastn_core::Package> {
         let file_extract_path = package_root.join("FASTN.ftd");
-        if !ds.exists(&file_extract_path) {
+        if !ds.exists(&file_extract_path).await {
             let fastn_string = self.get_fastn().await?;
             ds.write_content(&file_extract_path, fastn_string.into_bytes())
                 .await?;

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -634,7 +634,7 @@ impl Sitemap {
                     current_package_root,
                     section.get_file_id().as_str(),
                     &config.ds
-                ) {
+                ).await {
                     Ok(name) => {
                         if current_package_root.eq(package_root) {
                             (Some(current_package_root.join(name)), None)
@@ -652,7 +652,7 @@ impl Sitemap {
                                     package_root,
                                     section.get_file_id().as_str(),
                                     &config.ds
-                                )
+                                ).await
                                     .map_err(|e| {
                                         fastn_core::Error::UsageError {
                                             message: format!(
@@ -699,7 +699,7 @@ impl Sitemap {
                 } else if crate::http::url_regex().find(id.as_str()).is_some() {
                     (None, None)
                 } else {
-                    match fastn_core::Config::get_file_name(current_package_root, id.as_str(), &config.ds) {
+                    match fastn_core::Config::get_file_name(current_package_root, id.as_str(), &config.ds).await {
                         Ok(name) => {
                             if current_package_root.eq(package_root) {
                                 (Some(current_package_root.join(name)), None)
@@ -712,7 +712,7 @@ impl Sitemap {
                         }
                         Err(_) => (
                             Some(package_root.join(
-                                fastn_core::Config::get_file_name(package_root, id.as_str(),&config.ds).map_err(
+                                fastn_core::Config::get_file_name(package_root, id.as_str(),&config.ds).await.map_err(
                                     |e| fastn_core::Error::UsageError {
                                         message: format!(
                                             "`{}` not found, fix fastn.sitemap in FASTN.ftd. Error: {:?}",
@@ -759,7 +759,7 @@ impl Sitemap {
             {
                 (None, None)
             } else {
-                match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str(), &config.ds) {
+                match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str(), &config.ds).await {
                     Ok(name) => {
                         if current_package_root.eq(package_root) {
                             (Some(current_package_root.join(name)), None)
@@ -777,7 +777,7 @@ impl Sitemap {
                                     package_root,
                                     toc.get_file_id().as_str(),
                                     &config.ds
-                                )
+                                ).await
                                     .map_err(|e| {
                                         fastn_core::Error::UsageError {
                                             message: format!(

--- a/fastn-core/src/snapshot.rs
+++ b/fastn-core/src/snapshot.rs
@@ -30,7 +30,7 @@ pub(crate) async fn get_latest_snapshots(
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<std::collections::BTreeMap<String, u128>> {
     let latest_file_path = path.join(".history/.latest.ftd");
-    if !ds.exists(&latest_file_path) {
+    if !ds.exists(&latest_file_path).await {
         // TODO: should we error out here?
         return Ok(Default::default());
     }

--- a/fastn-core/src/tracker.rs
+++ b/fastn-core/src/tracker.rs
@@ -17,7 +17,7 @@ pub(crate) async fn get_tracks(
     path: &fastn_ds::Path,
 ) -> fastn_core::Result<std::collections::BTreeMap<String, Track>> {
     let mut tracks = std::collections::BTreeMap::new();
-    if !config.ds.exists(path) {
+    if !config.ds.exists(path).await {
         return Ok(tracks);
     }
 

--- a/fastn-core/src/translation.rs
+++ b/fastn-core/src/translation.rs
@@ -160,7 +160,7 @@ impl TranslatedDocument {
             }
             let translated_document = translated_documents.get(file.as_str()).unwrap();
             let track_path = fastn_core::utils::track_path(file.as_str(), config.ds.root());
-            if !config.ds.exists(&track_path) {
+            if !config.ds.exists(&track_path).await {
                 translation_status.insert(
                     file,
                     TranslatedDocument::NeverMarked {
@@ -224,12 +224,12 @@ pub(crate) async fn get_translation_status_counts(
         last_modified_on: None,
     };
     for (file, timestamp) in snapshots {
-        if !config.ds.exists(&path.join(file)) {
+        if !config.ds.exists(&path.join(file)).await {
             translation_status_count.missing += 1;
             continue;
         }
         let track_path = fastn_core::utils::track_path(file.as_str(), path);
-        if !config.ds.exists(&track_path) {
+        if !config.ds.exists(&track_path).await {
             translation_status_count.never_marked += 1;
             continue;
         }

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -476,14 +476,14 @@ pub fn id_to_path(id: &str) -> String {
 
 /// returns true if an existing file named "file_name"
 /// exists in the root package folder
-fn is_file_in_root(root: &str, file_name: &str, ds: &fastn_ds::DocumentStore) -> bool {
-    ds.exists(&fastn_ds::Path::new(root).join(file_name))
+async fn is_file_in_root(root: &str, file_name: &str, ds: &fastn_ds::DocumentStore) -> bool {
+    ds.exists(&fastn_ds::Path::new(root).join(file_name)).await
 }
 
 /// returns favicon html tag as string
 /// (if favicon is passed as header in fastn.package or if any favicon.* file is present in the root package folder)
 /// otherwise returns None
-fn resolve_favicon(
+async fn resolve_favicon(
     root_path: &str,
     package_name: &str,
     favicon: &Option<String>,
@@ -525,13 +525,13 @@ fn resolve_favicon(
 
                 // Just check if any favicon exists in the root package directory
                 // in the above mentioned priority order
-                let found_favicon_id = if is_file_in_root(root_path, "favicon.ico", ds) {
+                let found_favicon_id = if is_file_in_root(root_path, "favicon.ico", ds).await {
                     "favicon.ico"
-                } else if is_file_in_root(root_path, "favicon.svg", ds) {
+                } else if is_file_in_root(root_path, "favicon.svg", ds).await {
                     "favicon.svg"
-                } else if is_file_in_root(root_path, "favicon.png", ds) {
+                } else if is_file_in_root(root_path, "favicon.png", ds).await {
                     "favicon.png"
-                } else if is_file_in_root(root_path, "favicon.jpg", ds) {
+                } else if is_file_in_root(root_path, "favicon.jpg", ds).await {
                     "favicon.jpg"
                 } else {
                     // Not using any favicon
@@ -646,6 +646,7 @@ pub async fn replace_markers_2022(
                 &config.package.favicon,
                 &config.ds,
             )
+            .await
             .unwrap_or_default()
             .as_str(),
         )
@@ -732,6 +733,7 @@ pub async fn replace_markers_2023(
             &config.package.favicon,
             &config.ds
         )
+        .await
         .unwrap_or_default()
         .as_str(),
         js_script = format!("{js_script}{}", fastn_core::utils::available_code_themes()).as_str(),
@@ -774,7 +776,7 @@ pub(crate) async fn write(
     data: &[u8],
     ds: &fastn_ds::DocumentStore,
 ) -> fastn_core::Result<()> {
-    if ds.exists(&root.join(file_path)) {
+    if ds.exists(&root.join(file_path)).await {
         return Ok(());
     }
     update1(root, file_path, data, ds).await

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -1,7 +1,5 @@
 extern crate self as fastn_ds;
 
-use std::fmt::Formatter;
-
 #[derive(Debug, Clone)]
 pub struct DocumentStore {
     root: Path,
@@ -12,7 +10,7 @@ pub struct Path {
     path: camino::Utf8PathBuf,
 }
 
-impl Path {
+impl fastn_ds::Path {
     pub fn new<T: AsRef<str>>(path: T) -> Self {
         Self {
             path: camino::Utf8PathBuf::from(path.as_ref()),
@@ -56,7 +54,7 @@ impl Path {
 }
 
 impl std::fmt::Display for fastn_ds::Path {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.path.as_str())
     }
 }
@@ -113,15 +111,15 @@ impl DocumentStore {
         }
     }
 
-    pub fn root(&self) -> &Path {
+    pub fn root(&self) -> &fastn_ds::Path {
         &self.root
     }
 
-    pub fn home(&self) -> Path {
-        Path { path: home() }
+    pub fn home(&self) -> fastn_ds::Path {
+        fastn_ds::Path { path: home() }
     }
 
-    pub async fn read_content(&self, path: &Path) -> Result<Vec<u8>, ReadError> {
+    pub async fn read_content(&self, path: &fastn_ds::Path) -> Result<Vec<u8>, ReadError> {
         use tokio::io::AsyncReadExt;
 
         let mut file = tokio::fs::File::open(self.root.join(&path.path).path).await?;
@@ -130,19 +128,23 @@ impl DocumentStore {
         Ok(contents)
     }
 
-    pub async fn read_to_string(&self, path: &Path) -> Result<String, ReadStringError> {
+    pub async fn read_to_string(&self, path: &fastn_ds::Path) -> Result<String, ReadStringError> {
         self.read_content(path)
             .await
             .map_err(ReadStringError::ReadError)
             .and_then(|v| String::from_utf8(v).map_err(ReadStringError::UTF8Error))
     }
 
-    pub async fn copy(&self, from: &Path, to: &Path) -> Result<(), WriteError> {
+    pub async fn copy(&self, from: &fastn_ds::Path, to: &fastn_ds::Path) -> Result<(), WriteError> {
         tokio::fs::copy(&from.path, &to.path).await?;
         Ok(())
     }
 
-    pub async fn write_content(&self, path: &Path, data: Vec<u8>) -> Result<(), WriteError> {
+    pub async fn write_content(
+        &self,
+        path: &fastn_ds::Path,
+        data: Vec<u8>,
+    ) -> Result<(), WriteError> {
         use tokio::io::AsyncWriteExt;
 
         let full_path = self.root.join(&path.path);
@@ -159,16 +161,20 @@ impl DocumentStore {
         Ok(())
     }
 
-    pub async fn read_dir(&self, path: &Path) -> std::io::Result<tokio::fs::ReadDir> {
+    pub async fn read_dir(&self, path: &fastn_ds::Path) -> std::io::Result<tokio::fs::ReadDir> {
         // Todo: Return type should be ftd::interpreter::Result<Vec<fastn_ds::Dir>> not ftd::interpreter::Result<tokio::fs::ReadDir>
         tokio::fs::read_dir(&path.path).await
     }
 
-    pub async fn rename(&self, from: &Path, to: &Path) -> Result<(), RenameError> {
+    pub async fn rename(
+        &self,
+        from: &fastn_ds::Path,
+        to: &fastn_ds::Path,
+    ) -> Result<(), RenameError> {
         Ok(tokio::fs::rename(&from.path, &to.path).await?)
     }
 
-    pub async fn remove(&self, path: &Path) -> Result<(), RemoveError> {
+    pub async fn remove(&self, path: &fastn_ds::Path) -> Result<(), RemoveError> {
         if !path.path.exists() {
             return Ok(());
         }

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -212,7 +212,7 @@ impl DocumentStore {
             .collect::<Vec<fastn_ds::Path>>()
     }
 
-    pub fn exists(&self, path: &fastn_ds::Path) -> bool {
+    pub async fn exists(&self, path: &fastn_ds::Path) -> bool {
         path.path.exists()
     }
 }


### PR DESCRIPTION
- Removed the `fastn_core::Config::update_ids_from_package` function which was used to set `global_id` in the package.
- [fastn_ds::Path::exist to async function](https://github.com/fastn-stack/fastn/pull/1693/commits/159805d22a2a8bac1b67e52f1f601670a93db351)