### PR TITLE
fastn fmt

### DIFF
--- a/fastn-core/src/commands/fmt.rs
+++ b/fastn-core/src/commands/fmt.rs
@@ -1,0 +1,293 @@
+pub async fn fmt(
+    config: &fastn_core::Config,
+    file: Option<&str>,
+    no_indentation: bool,
+) -> fastn_core::Result<()> {
+    use itertools::Itertools;
+
+    let documents = config
+        .get_files(&config.package)
+        .await?
+        .into_iter()
+        .filter_map(|v| v.get_ftd_document())
+        .collect_vec();
+
+    for ftd_document in documents {
+        if let Some(file) = file {
+            if !ftd_document.id.eq(file) {
+                continue;
+            }
+        }
+
+        let parsed_content =
+            parsed_to_sections(format!("{}\n\n", ftd_document.content.as_str()).as_str());
+        let content = format_sections(parsed_content);
+    }
+
+    Ok(())
+}
+
+struct Section {
+    value: String,
+    kind: SectionKind,
+}
+
+pub enum SectionKind {
+    Comment,
+    Empty,
+    Section {
+        name: String,
+        end: bool,
+        sub_sections: Vec<Section>,
+    },
+}
+
+impl Section {
+    fn new_comment(value: &str) -> Section {
+        Section {
+            value: value.to_string(),
+            kind: SectionKind::Comment,
+        }
+    }
+
+    fn new_empty(value: &str) -> Section {
+        Section {
+            value: value.to_string(),
+            kind: SectionKind::Empty,
+        }
+    }
+
+    fn new_section(name: &str, value: &str) -> Section {
+        Section {
+            value: value.to_string(),
+            kind: SectionKind::Section {
+                name: name.to_string(),
+                end: false,
+                sub_sections: vec![],
+            },
+        }
+    }
+}
+
+fn format_sections(sections: Vec<Section>) -> String {
+    let mut output = vec![];
+    for section in sections {
+        output.push(format_section(&section, 0))
+    }
+    output.join("\n")
+}
+
+fn format_section(section: &Section, indentation: usize) -> String {
+    match &section.kind {
+        SectionKind::Comment => add_indentation(section.value.as_str(), indentation),
+        SectionKind::Empty => section.value.to_string(),
+        SectionKind::Section {
+            name,
+            end,
+            sub_sections,
+        } => format_section_kind(
+            name.as_str(),
+            *end,
+            sub_sections.as_slice(),
+            section.value.as_str(),
+            indentation,
+        ),
+    }
+}
+
+fn format_section_kind(
+    section_name: &str,
+    end: bool,
+    sub_sections: &[Section],
+    value: &str,
+    indentation: usize,
+) -> String {
+    let mut output = vec![add_indentation(value, indentation)];
+    for section in sub_sections {
+        output.push(format_section(section, indentation + 1));
+    }
+    if end {
+        output.push(add_indentation(
+            format!("-- end: {section_name}").as_str(),
+            indentation,
+        ));
+    }
+    output.join("\n")
+}
+
+fn add_indentation(input: &str, indentation: usize) -> String {
+    if indentation.eq(&0) {
+        return String::new();
+    }
+    let mut value = vec![];
+    for i in input.split('\n') {
+        value.push(format!("{}{}", "\t".repeat(indentation), i));
+    }
+    value.join("\n")
+}
+
+fn parsed_to_sections(input: &str) -> Vec<Section> {
+    let mut sections = vec![];
+    let mut input = input.to_string();
+    while !input.is_empty() {
+        if end_section(&mut input, &mut sections) {
+            continue;
+        } else if let Some(empty_section) = empty_section(&mut input) {
+            sections.push(empty_section);
+        } else if let Some(comment_section) = comment_section(&mut input) {
+            sections.push(comment_section);
+        } else if let Some(section) = section(&mut input, &mut sections) {
+            sections.push(section);
+        }
+    }
+
+    sections
+}
+
+fn end_section(input: &mut String, sections: &mut Vec<Section>) -> bool {
+    let mut remaining = None;
+    let first_line = if let Some((first_line, rem)) = input.split_once('\n') {
+        remaining = Some(rem.to_string());
+        first_line.to_string()
+    } else {
+        input.to_string()
+    };
+
+    let mut sub_sections = vec![];
+    let section_name = if let Some(section_name) = end_section_name(first_line.as_str()) {
+        section_name
+    } else {
+        return false;
+    };
+    while let Some(mut section) = sections.pop() {
+        match &mut section.kind {
+            SectionKind::Section {
+                name,
+                end,
+                sub_sections: s,
+            } if section_name.eq(name) => {
+                *end = true;
+                *s = sub_sections.clone();
+                sections.push(section);
+                *input = remaining.unwrap_or_default();
+                return true;
+            }
+            _ => {
+                sections.push(section);
+            }
+        }
+    }
+
+    panic!("cannot find section {} to end", section_name)
+}
+
+fn end_section_name(input: &str) -> Option<String> {
+    use itertools::Itertools;
+
+    let input = input.split_whitespace().join(" ");
+    input.strip_prefix("-- end:").map(|v| v.to_string())
+}
+
+fn section(input: &mut String, sections: &mut Vec<Section>) -> Option<Section> {
+    use itertools::Itertools;
+
+    let section_name = get_section_name(input)?;
+    let mut value = vec![];
+    let mut first_time_encounter_section = true;
+    while let Some((first_line, remaining)) = input.split_once('\n') {
+        let first_line = first_line.trim().to_string();
+        if first_line.starts_with("-- ") || first_line.starts_with("/-- ") {
+            if first_time_encounter_section {
+                first_time_encounter_section = false;
+                value.push(first_line);
+                continue;
+            }
+            *input = format!("{first_line}\n{remaining}");
+            break;
+        }
+        value.push(first_line);
+    }
+
+    if !value.is_empty() {
+        let mut value = value.join("\n").to_string();
+        if !value.trim().is_empty() {
+            if let Some((v, probable_comment_section)) = value.rsplit_once("\n\n") {
+                let mut probable_comment_section = probable_comment_section.to_string();
+                if let Some(comment_section) = comment_section(&mut probable_comment_section) {
+                    if probable_comment_section.eq("\n") {
+                        sections.push(comment_section);
+                        value = format!("{v}\n\n");
+                    }
+                }
+            }
+        }
+        Some(Section::new_section(
+            section_name.as_str(),
+            value.join("\n").as_str(),
+        ))
+    } else {
+        None
+    }
+}
+
+fn get_section_name(input: &str) -> Option<String> {
+    use itertools::Itertools;
+
+    let first_line = if let Some((first_line, _)) = input.split_once('\n') {
+        first_line.trim().to_string()
+    } else {
+        input.trim().to_string()
+    };
+    if !first_line.starts_with("-- ") && !first_line.starts_with("/-- ") {
+        None
+    } else if let Some((section_name_kind, _)) = first_line.split_once(':') {
+        Some(
+            section_name_kind
+                .split_whitespace()
+                .join(" ")
+                .split_once(' ')
+                .map(|(_, v)| v.to_string())
+                .unwrap_or_else(|| section_name_kind.to_string()),
+        )
+    } else {
+        None
+    }
+}
+
+fn empty_section(input: &mut String) -> Option<Section> {
+    let mut value = vec![];
+    while let Some((first_line, remaining)) = input.split_once('\n') {
+        let first_line = first_line.trim().to_string();
+        if !first_line.is_empty() {
+            *input = format!("{first_line}\n{remaining}");
+            break;
+        }
+        value.push(first_line);
+    }
+
+    if !value.is_empty() {
+        Some(Section::new_empty(value.join("\n").as_str()))
+    } else {
+        None
+    }
+}
+
+fn comment_section(input: &mut String) -> Option<Section> {
+    let mut value = vec![];
+    while let Some((first_line, remaining)) = input.split_once('\n') {
+        let first_line = first_line.trim().to_string();
+        if first_line.starts_with("-- ")
+            || first_line.starts_with("/-- ")
+            || !first_line.starts_with(";;")
+        {
+            *input = format!("{first_line}\n{remaining}");
+            break;
+        }
+        value.push(first_line);
+    }
+    if !value.is_empty() {
+        Some(Section::new_comment(value.join("\n").as_str()))
+    } else {
+        None
+    }
+}

--- a/fastn-core/src/commands/mod.rs
+++ b/fastn-core/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod check;
 pub mod create_package;
+pub mod fmt;
 pub mod query;
 pub mod serve;
 pub mod test;

--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -107,7 +107,7 @@ async fn serve_file(
     match f {
         fastn_core::File::Ftd(main_document) => {
             if fastn_core::utils::is_ftd_path(path.as_str()) {
-                return fastn_core::http::ok(main_document.content.as_bytes().to_vec());
+                return fastn_core::http::ok(main_document.content.into_bytes());
             }
             match fastn_core::package::package_doc::read_ftd_(
                 config,

--- a/fastn-core/src/file.rs
+++ b/fastn-core/src/file.rs
@@ -45,14 +45,10 @@ impl File {
         }
     }
     pub fn get_full_path(&self) -> fastn_ds::Path {
-        let (id, base_path) = match self {
-            Self::Ftd(a) => (a.id.to_string(), &a.parent_path),
-            Self::Static(a) => (a.id.to_string(), &a.base_path),
-            Self::Markdown(a) => (a.id.to_string(), &a.parent_path),
-            Self::Code(a) => (a.id.to_string(), &a.parent_path),
-            Self::Image(a) => (a.id.to_string(), &a.base_path),
-        };
-        base_path.join(id)
+        match self {
+            Self::Ftd(a) | Self::Markdown(a) | Self::Code(a) => a.get_full_path(),
+            Self::Image(a) | Self::Static(a) => a.get_full_path(),
+        }
     }
 
     pub fn is_static(&self) -> bool {
@@ -97,6 +93,10 @@ impl Document {
                 .replace(".ftd", "/")
         )
     }
+
+    pub fn get_full_path(&self) -> fastn_ds::Path {
+        self.parent_path.join(self.id.as_str())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -110,6 +110,10 @@ pub struct Static {
 impl Static {
     pub fn id_with_package(&self) -> String {
         format!("{}/{}", self.package_name, self.id)
+    }
+
+    pub fn get_full_path(&self) -> fastn_ds::Path {
+        self.base_path.join(self.id.as_str())
     }
 }
 

--- a/fastn-core/src/file.rs
+++ b/fastn-core/src/file.rs
@@ -65,6 +65,13 @@ impl File {
     pub(crate) fn is_ftd(&self) -> bool {
         matches!(self, Self::Ftd(_))
     }
+
+    pub(crate) fn get_ftd_document(self) -> Option<fastn_core::Document> {
+        match self {
+            fastn_core::File::Ftd(ftd_document) => Some(ftd_document),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -39,7 +39,7 @@ mod mail;
 
 pub(crate) use auto_import::AutoImport;
 pub use commands::{
-    build::build, check::post_build_check, create_package::create_package, query::query,
+    build::build, check::post_build_check, create_package::create_package, fmt::fmt, query::query,
     serve::listen, test::test, update::update,
 };
 pub use config::{Config, FTDEdition, RequestConfig};

--- a/fastn-core/tests/01-help/cmd.p1
+++ b/fastn-core/tests/01-help/cmd.p1
@@ -10,6 +10,7 @@ Usage: fastn [OPTIONS] [COMMAND]
 Commands:
   create-package  Create a new fastn package
   build           Build static site from this fastn package
+  fmt             Format the fastn package
   test            Run the test files in `_tests` folder
   query           JSON Dump in various stages
   serve           Serve package content over HTTP

--- a/fastn-core/tests/18-fmt/cmd.p1
+++ b/fastn-core/tests/18-fmt/cmd.p1
@@ -1,0 +1,8 @@
+-- fbt:
+cmd: $FBT_CWD/../target/debug/fastn --test fmt
+output: .
+
+-- stdout:
+
+Formatting FASTN.ftd ... Done
+Formatting index.ftd ... Done

--- a/fastn-core/tests/18-fmt/input/FASTN.ftd
+++ b/fastn-core/tests/18-fmt/input/FASTN.ftd
@@ -1,0 +1,3 @@
+-- import: fastn
+
+-- fastn.package: fastn-package

--- a/fastn-core/tests/18-fmt/input/index.ftd
+++ b/fastn-core/tests/18-fmt/input/index.ftd
@@ -1,0 +1,57 @@
+-- record employee:
+caption string name:
+string email:
+integer age:
+
+
+
+-- employee list employees:
+
+-- employee: Ram
+email: ram@gmail.com
+age: 23
+
+-- employee: Shyam
+email: shyam23@gmail.com
+age: 28
+
+-- end: employees
+
+
+
+;; Read a single employee from the list by its index
+
+-- employee-card: $employees.0
+
+
+
+;; Iterate over the employees list
+-- employee-card: $emp
+for: $emp in $employees
+
+
+
+-- component employee-card:
+caption employee emp:
+
+;; the outer column
+-- ftd.column:
+
+-- ftd.column:
+
+-- ftd.text: $employee-card.emp.name
+
+;; the description text
+-- ftd.text:
+
+The description you see here:
+  - I am the description text
+  - I am part of employee-card definition
+
+This description comes inside `ftd.column`.
+
+-- end: ftd.column
+
+-- end: ftd.column
+
+-- end: employee-card

--- a/fastn-core/tests/18-fmt/output/FASTN.ftd
+++ b/fastn-core/tests/18-fmt/output/FASTN.ftd
@@ -1,0 +1,3 @@
+-- import: fastn
+
+-- fastn.package: fastn-package

--- a/fastn-core/tests/18-fmt/output/index.ftd
+++ b/fastn-core/tests/18-fmt/output/index.ftd
@@ -1,0 +1,57 @@
+-- record employee:
+caption string name:
+string email:
+integer age:
+
+
+
+-- employee list employees:
+
+-- employee: Ram
+email: ram@gmail.com
+age: 23
+
+-- employee: Shyam
+email: shyam23@gmail.com
+age: 28
+
+-- end: employees
+
+
+
+;; Read a single employee from the list by its index
+
+-- employee-card: $employees.0
+
+
+
+;; Iterate over the employees list
+-- employee-card: $emp
+for: $emp in $employees
+
+
+
+-- component employee-card:
+caption employee emp:
+
+;; the outer column
+-- ftd.column:
+
+	-- ftd.column:
+	
+		-- ftd.text: $employee-card.emp.name
+		
+		;; the description text
+		-- ftd.text:
+		
+		The description you see here:
+		  - I am the description text
+		  - I am part of employee-card definition
+		
+		This description comes inside `ftd.column`.
+		
+	-- end: ftd.column
+
+-- end: ftd.column
+
+-- end: employee-card

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -249,7 +249,7 @@ fn app(version: &'static str) -> clap::Command {
         )
         .subcommand(
             clap::Command::new("fmt")
-                .about("format the fastn package")
+                .about("Format the fastn package")
                 .arg(clap::arg!(file: [FILE]... "The file to format").required(false))
                 .arg(clap::arg!(-i --noidentation "No identation added to file/package").required(false))
         )

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -141,12 +141,7 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
     }
 
     if let Some(fmt) = matches.subcommand_matches("fmt") {
-        return fastn_core::fmt(
-            &config,
-            fmt.value_of_("file"),
-            fmt.get_flag("no-identation"),
-        )
-        .await;
+        return fastn_core::fmt(&config, fmt.value_of_("file"), fmt.get_flag("noidentation")).await;
     }
 
     if let Some(query) = matches.subcommand_matches("query") {
@@ -256,7 +251,7 @@ fn app(version: &'static str) -> clap::Command {
             clap::Command::new("fmt")
                 .about("format the fastn package")
                 .arg(clap::arg!(file: [FILE]... "The file to format").required(false))
-                .arg(clap::arg!(-i --no-identation "No identation added to file/package"))
+                .arg(clap::arg!(-i --noidentation "No identation added to file/package").required(false))
                 .hide(true), // hidden since the feature is not fully developed.
         )
         .subcommand(

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -140,6 +140,15 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
         .await;
     }
 
+    if let Some(fmt) = matches.subcommand_matches("fmt") {
+        return fastn_core::fmt(
+            &config,
+            fmt.value_of_("file"),
+            fmt.get_flag("no-identation"),
+        )
+        .await;
+    }
+
     if let Some(query) = matches.subcommand_matches("query") {
         return fastn_core::query(
             &config,
@@ -242,6 +251,13 @@ fn app(version: &'static str) -> clap::Command {
                 .arg(clap::arg!(--"css" <URL> "CSS text added in ftd files")
                     .action(clap::ArgAction::Append))
                 .arg(clap::arg!(--edition <EDITION> "The FTD edition"))
+        )
+        .subcommand(
+            clap::Command::new("fmt")
+                .about("format the fastn package")
+                .arg(clap::arg!(file: [FILE]... "The file to format").required(false))
+                .arg(clap::arg!(-i --no-identation "No identation added to file/package"))
+                .hide(true), // hidden since the feature is not fully developed.
         )
         .subcommand(
             clap::Command::new("test")

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -252,7 +252,6 @@ fn app(version: &'static str) -> clap::Command {
                 .about("format the fastn package")
                 .arg(clap::arg!(file: [FILE]... "The file to format").required(false))
                 .arg(clap::arg!(-i --noidentation "No identation added to file/package").required(false))
-                .hide(true), // hidden since the feature is not fully developed.
         )
         .subcommand(
             clap::Command::new("test")

--- a/ftd/src/wasm/value.rs
+++ b/ftd/src/wasm/value.rs
@@ -2,7 +2,7 @@ impl ftd::interpreter::Value {
     pub fn create(&self) -> fastn_wasm::Expression {
         match self {
             ftd::interpreter::Value::String { text } => {
-                let data = text.as_bytes().to_vec();
+                let data = text.into_bytes();
 
                 fastn_wasm::Expression::Call {
                     name: "string_new".to_string(),


### PR DESCRIPTION
With this PR, we have a command `fastn fmt` which adds indentation to the `ftd` document.

`fastn fmt`: Formats all ftd files present in the package.
`fastn fmt <file-name>.ftd: Formats `<file-name>.ftd` file