### PR TITLE
Changes in Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,12 +210,24 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -525,7 +537,17 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -536,6 +558,22 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "brotli"
@@ -698,6 +736,15 @@ checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown 0.14.3",
  "stacker",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -893,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc-any"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
+dependencies = [
+ "debug-helper",
 ]
 
 [[package]]
@@ -1191,6 +1247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1303,17 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "des"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
+dependencies = [
+ "byteorder",
+ "cipher 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1327,11 +1400,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1690,6 +1772,7 @@ dependencies = [
  "intl-memoizer",
  "itertools 0.12.0",
  "lettre",
+ "magic-crypt",
  "mime_guess",
  "native-tls",
  "notify",
@@ -1705,7 +1788,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "slug",
  "thiserror",
  "tokio",
@@ -1826,7 +1909,7 @@ dependencies = [
  "diffy",
  "ftd 0.2.0",
  "rand",
- "sha2",
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -2223,7 +2306,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2813,6 +2896,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
 
 [[package]]
+name = "magic-crypt"
+version = "3.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c42f95f9d296f2dcb50665f507ed5a68a171453142663ce44d77a4eb217b053"
+dependencies = [
+ "aes 0.7.5",
+ "base64 0.21.5",
+ "block-modes",
+ "crc-any",
+ "des",
+ "digest 0.9.0",
+ "md-5 0.9.1",
+ "sha2 0.9.9",
+ "tiger",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,12 +2926,23 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3030,7 +3141,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "url",
 ]
@@ -3049,6 +3160,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -3245,10 +3362,10 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash 0.4.2",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3299,7 +3416,7 @@ checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3444,10 +3561,10 @@ dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
  "hmac",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "rand",
- "sha2",
+ "sha2 0.10.8",
  "stringprep",
 ]
 
@@ -4238,7 +4355,20 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4249,7 +4379,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4576,6 +4706,17 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiger"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443e531cbcf9de83258cfef70bcd56c91188de5819ebd4b19c85f589e0617005"
+dependencies = [
+ "block-buffer 0.9.0",
+ "byteorder",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -5456,7 +5597,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes",
+ "aes 0.8.3",
  "byteorder",
  "bzip2",
  "constant_time_eq",

--- a/fastn-core/Cargo.toml
+++ b/fastn-core/Cargo.toml
@@ -26,7 +26,7 @@ controller = ["remote"]
 # is created for every user, and local edits in the workspace is allowed.
 remote = []
 
-auth = ["oauth2", "diesel", "diesel_migrations", "diesel-async", "lettre", "argon2"]
+auth = ["oauth2", "diesel", "diesel_migrations", "diesel-async", "lettre", "argon2", "magic-crypt"]
 
 [dependencies]
 actix-web.workspace = true
@@ -61,6 +61,7 @@ indoc.workspace = true
 intl-memoizer.workspace = true
 itertools.workspace = true
 lettre = { workspace = true, optional = true }
+magic-crypt = { workspace = true, optional = true }
 mime_guess.workspace = true
 native-tls.workspace = true
 notify.workspace = true

--- a/fastn-core/src/auth/routes.rs
+++ b/fastn-core/src/auth/routes.rs
@@ -93,10 +93,10 @@ pub async fn handle_auth(
             fastn_core::auth::email_password::create_user(&req, pool, next).await
         }
         "/-/auth/confirm-email/" => {
-            fastn_core::auth::email_password::confirm_email(&req, pool).await
+            fastn_core::auth::email_password::confirm_email(&req, pool, next).await
         }
         "/-/auth/resend-confirmation-email/" => {
-            fastn_core::auth::email_password::resend_email(&req, pool).await
+            fastn_core::auth::email_password::resend_email(&req, pool, next).await
         }
 
         // "/-/auth/send-email-login-code/" => todo!(),

--- a/fastn-core/src/auth/utils.rs
+++ b/fastn-core/src/auth/utils.rs
@@ -6,6 +6,32 @@ pub fn domain(host: &str) -> String {
     }
 }
 
+pub async fn encrypt(input: &str) -> String {
+    use magic_crypt::MagicCryptTrait;
+    let secret_key = fastn_core::auth::utils::secret_key();
+    let mc_obj = magic_crypt::new_magic_crypt!(secret_key.as_str(), 256);
+    mc_obj.encrypt_to_base64(input).as_str().to_owned()
+}
+
+pub async fn decrypt(input: &str) -> Result<String, magic_crypt::MagicCryptError> {
+    use magic_crypt::MagicCryptTrait;
+    let secret_key = fastn_core::auth::utils::secret_key();
+    let mc_obj = magic_crypt::new_magic_crypt!(&secret_key, 256);
+    mc_obj.decrypt_base64_to_string(input)
+}
+
+pub fn secret_key() -> String {
+    match std::env::var("FASTN_SECRET_KEY") {
+        Ok(secret) => secret,
+        Err(_e) => {
+            fastn_core::warning!(
+                "WARN: Using default SECRET_KEY. Provide one using FASTN_SECRET_KEY env var."
+            );
+            "FASTN_TEMP_SECRET".to_string()
+        }
+    }
+}
+
 pub fn is_authenticated(req: &fastn_core::http::Request) -> bool {
     req.cookie(fastn_core::auth::COOKIE_NAME).is_some()
 }

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -756,8 +756,7 @@ mod test {
         let token_err = "no key expected with name token";
         let errors = vec![("user", user_err), ("token", token_err)];
 
-        let res =
-            fastn_core::http::user_err(errors, fastn_core::http::StatusCode::BAD_REQUEST).await?;
+        let res = fastn_core::http::user_err(errors, fastn_core::http::StatusCode::BAD_REQUEST)?;
 
         assert_eq!(res.status(), fastn_core::http::StatusCode::BAD_REQUEST);
 

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -725,7 +725,7 @@ pub async fn github_graphql<T: serde::de::DeserializeOwned>(
 ///     }
 /// }
 /// ```
-pub async fn user_err(
+pub fn user_err(
     errors: Vec<(&str, &str)>,
     status_code: fastn_core::http::StatusCode,
 ) -> fastn_core::Result<fastn_core::http::Response> {

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -6,22 +6,37 @@ pub async fn process(
     req_config: &fastn_core::RequestConfig,
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
     #[cfg(feature = "auth")]
-    if let Some(session_id) = req_config.request.cookie(fastn_core::auth::COOKIE_NAME) {
+    if let Some(session_data) = req_config.request.cookie(fastn_core::auth::COOKIE_NAME) {
         let mut ud = Default::default();
 
-        if !session_id.is_empty() {
-            let session_id: i32 = session_id.parse().map_err(|e| {
-                ftd::interpreter::Error::OtherError(format!("Failed to parse id from string: {e}"))
-            })?;
+        if !session_data.is_empty() {
+            let session_data = fastn_core::auth::utils::decrypt(&session_data)
+                .await
+                .map_err(|e| {
+                    ftd::interpreter::Error::OtherError(format!(
+                        "Failed to decrypt session data. {:?}",
+                        e
+                    ))
+                })?;
 
-            if let Ok((user, email)) =
-                fastn_core::auth::get_authenticated_user_with_email(&session_id).await
-            {
+            #[derive(serde::Deserialize)]
+            struct User {
+                username: String,
+                name: String,
+                email: String,
+            }
+
+            #[derive(serde::Deserialize)]
+            struct SessionData {
+                user: User,
+            }
+
+            if let Ok(data) = serde_json::from_str::<SessionData>(session_data.as_str()) {
                 ud = UserDetails {
                     is_logged_in: true,
-                    username: user.username,
-                    name: user.name,
-                    email,
+                    username: data.user.username,
+                    name: data.user.name,
+                    email: data.user.email,
                 }
             }
         }


### PR DESCRIPTION
- rename auth cookie to `fastn_session` to not clash with existing browser cookies
- use magic_crypt to encrypt cookie before setting it
- encode session_id, username, email and, name in browser cookie
- wrap db calls in transactions wherever necessary
- handle redirect to `next` query param's value