### PR TITLE
fix: static files not being copied in incremental build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.49"
+version = "0.4.50"
 dependencies = [
  "clap",
  "colored",

--- a/fastn-core/src/commands/build.rs
+++ b/fastn-core/src/commands/build.rs
@@ -305,13 +305,28 @@ async fn incremental_build(
     let mut processed: Vec<String> = vec![];
 
     if cache_hit {
-        let mut unresolved_dependencies: Vec<String> = documents
-            .iter()
-            .filter(|(_, f)| f.is_ftd())
-            .map(|(_, f)| remove_extension(f.get_id()))
-            .collect_vec();
+        let mut unresolved_dependencies = vec![];
         let mut resolved_dependencies: Vec<String> = vec![];
         let mut resolving_dependencies: Vec<String> = vec![];
+
+        for file in documents.values() {
+            // copy static files
+            if file.is_static() {
+                handle_file(
+                    file,
+                    config,
+                    base_url,
+                    ignore_failed,
+                    test,
+                    true,
+                    Some(&mut c),
+                )
+                .await?;
+                continue;
+            }
+
+            unresolved_dependencies.push(remove_extension(file.get_id()));
+        }
 
         while let Some(unresolved_dependency) = unresolved_dependencies.pop() {
             // println!("Current UR: {}", unresolved_dependency.as_str());

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.49"
+version = "0.4.50"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ftd/t/js/92-self-reference-record.ftd
+++ b/ftd/t/js/92-self-reference-record.ftd
@@ -45,3 +45,7 @@ color: red
 -- end: ftd.column
 
 -- end: display-name
+
+
+-- ftd.text: Now the full name is Arpita Jaiswal
+if: { arpita.full-name == "Arpita" }

--- a/ftd/t/js/92-self-reference-record.html
+++ b/ftd/t/js/92-self-reference-record.html
@@ -18,7 +18,7 @@
     </style>
 </head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column"><div data-id="4" class="__c-3">Arpita</div><div data-id="5" class="__c-4">Arpita</div></div><comment data-id="6"></comment><div data-id="7" class="ft_column"><div data-id="8" class="__c-5">Arpita</div><div data-id="9" class="__c-6">Arpita</div></div><div data-id="10" class="ft_column"><div data-id="11" class="__c-7">FifthTry</div><div data-id="12" class="__c-8">FifthTry</div></div><div data-id="13" class="ft_column"><div data-id="14" class="__c-9">fastn</div><div data-id="15" class="__c-10">fastn framework</div></div><div data-id="16" class="ft_column"><div data-id="17" class="__c-11">John</div><div data-id="18" class="__c-12">John Doe</div></div></div></body><style id="styles">
+<body data-id="1"><div data-id="2" class="ft_column __w-1 __h-2"><div data-id="3" class="ft_column"><div data-id="4" class="__c-3">Arpita</div><div data-id="5" class="__c-4">Arpita</div></div><comment data-id="6"></comment><div data-id="7" class="ft_column"><div data-id="8" class="__c-5">Arpita</div><div data-id="9" class="__c-6">Arpita</div></div><div data-id="10" class="ft_column"><div data-id="11" class="__c-7">FifthTry</div><div data-id="12" class="__c-8">FifthTry</div></div><div data-id="13" class="ft_column"><div data-id="14" class="__c-9">fastn</div><div data-id="15" class="__c-10">fastn framework</div></div><div data-id="16" class="ft_column"><div data-id="17" class="__c-11">John</div><div data-id="18" class="__c-12">John Doe</div></div><comment data-id="19"></comment><div data-id="20">Now the full name is Arpita Jaiswal</div></div></body><style id="styles">
     .__w-1 { width: 100%; }
 	.__h-2 { height: 100%; }
 	.__c-3 { color: green !important; }
@@ -45,6 +45,15 @@
       let rooti0 = foo__display_name(root, inherited, {
         name: item
       });
+      return rooti0;
+    });
+    fastn_dom.conditionalDom(parent, [
+      global.foo__arpita.get("full_name")
+    ], function () {
+      return (fastn_utils.getStaticValue(global.foo__arpita.get("full_name")) == "Arpita");
+    }, function (root) {
+      let rooti0 = fastn_dom.createKernel(root, fastn_dom.ElementKind.Text);
+      rooti0.setProperty(fastn_dom.PropertyKind.StringValue, "Now the full name is Arpita Jaiswal", inherited);
       return rooti0;
     });
   } finally {


### PR DESCRIPTION
This fixes the issue where static files were not being copied to the `.build` folder. It now checks if a file is a static file or a ftd file. if it is a static file, it copies it to the .build folder, otherwise it adds the ftd file to a vector of unresolved documents and it will be later resolved by incremental build.