### PR TITLE
fix: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "clap",
  "colored",


### PR DESCRIPTION
missed the Cargo.lock update which is why the [release failed](https://github.com/fastn-stack/fastn/actions/runs/7768591950). This should fix it.