### PR TITLE
fix: fastn update entry path fix for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "clap",
  "colored",

--- a/fastn-update/src/lib.rs
+++ b/fastn-update/src/lib.rs
@@ -216,10 +216,11 @@ async fn download_and_unpack_zip(
                 package: package_name,
                 name: entry.name(),
             })?;
-            let path = path.to_str().unwrap();
-            let path_without_prefix = match path.split_once(std::path::MAIN_SEPARATOR) {
+            let path_string = path.to_string_lossy().into_owned();
+            let path_normalized = path_string.replace('\\', "/");
+            let path_without_prefix = match path_normalized.split_once('/') {
                 Some((_, path)) => path,
-                None => path,
+                None => &path_normalized,
             };
             if manifest.files.get(path_without_prefix).is_none() {
                 continue;

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.54"
+version = "0.4.55"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This fixes `Dependency error: Failed to resolve dependency` on Windows when using `fastn update` command. The `download_and_unpack` command was not able to successfully remove the prefix from the zip archive entry and search for it in the manifest of the current package. To fix this issue, we are now normalizing the paths before removing the prefix and checking for its existence in the package's manifest.