### PR TITLE
cmd: Added sub-command `--check` in `fastn update`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
 name = "fastn-update"
 version = "0.1.0"
 dependencies = [
+ "colored",
  "fastn-core",
  "fastn-ds",
  "fastn-package",

--- a/fastn-core/tests/02-hello/cmd.p1
+++ b/fastn-core/tests/02-hello/cmd.p1
@@ -4,7 +4,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing www.amitu.com/manifest.json ... done in <omitted>
 Processing www.amitu.com/FASTN/ ... done in <omitted>
 Processing www.amitu.com/fail_doc/ ... Failed done in <omitted>

--- a/fastn-core/tests/03-nested-document/cmd.p1
+++ b/fastn-core/tests/03-nested-document/cmd.p1
@@ -5,7 +5,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing amitu/manifest.json ... done in <omitted>
 Processing amitu/FASTN/ ... done in <omitted>
 Processing amitu/ ... done in <omitted>

--- a/fastn-core/tests/04-import-code-block/cmd.p1
+++ b/fastn-core/tests/04-import-code-block/cmd.p1
@@ -5,7 +5,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing amitu/manifest.json ... done in <omitted>
 Processing amitu/FASTN/ ... done in <omitted>
 Processing amitu/ ... done in <omitted>

--- a/fastn-core/tests/05-hello-font/cmd.p1
+++ b/fastn-core/tests/05-hello-font/cmd.p1
@@ -4,7 +4,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing www.amitu.com/manifest.json ... done in <omitted>
 Processing www.amitu.com/FASTN/ ... done in <omitted>
 Processing www.amitu.com/hello.py ... done in <omitted>

--- a/fastn-core/tests/08-static-assets/cmd.p1
+++ b/fastn-core/tests/08-static-assets/cmd.p1
@@ -4,7 +4,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing www.amitu.com/manifest.json ... done in <omitted>
 Processing www.amitu.com/FASTN/ ... done in <omitted>
 Processing www.amitu.com/ ... done in <omitted>

--- a/fastn-core/tests/09-markdown-pages/cmd.p1
+++ b/fastn-core/tests/09-markdown-pages/cmd.p1
@@ -4,7 +4,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing amitu/manifest.json ... done in <omitted>
 Processing amitu/FASTN/ ... done in <omitted>
 Processing amitu/ ... done in <omitted>

--- a/fastn-core/tests/11-readme-with-index/cmd.p1
+++ b/fastn-core/tests/11-readme-with-index/cmd.p1
@@ -4,7 +4,7 @@ output: amitu/.build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing amitu/manifest.json ... done in <omitted>
 Processing amitu/FASTN/ ... done in <omitted>
 Processing amitu/README.md ... Skipped done in <omitted>

--- a/fastn-core/tests/16-include-processor/cmd.p1
+++ b/fastn-core/tests/16-include-processor/cmd.p1
@@ -4,7 +4,7 @@ output: .build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing fifthtry.github.io/amitu/manifest.json ... done in <omitted>
 Processing fifthtry.github.io/amitu/FASTN/ ... done in <omitted>
 Processing fifthtry.github.io/amitu/ ... done in <omitted>

--- a/fastn-core/tests/17-sitemap/cmd.p1
+++ b/fastn-core/tests/17-sitemap/cmd.p1
@@ -4,7 +4,7 @@ output: .build
 
 -- stdout:
 
-Updated package dependency
+Updated package dependency.
 Processing fastn-stack.github.io/guide/manifest.json ... done in <omitted>
 Processing fastn-stack.github.io/guide/FASTN/ ... done in <omitted>
 Processing fastn-stack.github.io/guide/guide/install/ ... done in <omitted>

--- a/fastn-core/tests/20-fastn-update-check/cmd.p1
+++ b/fastn-core/tests/20-fastn-update-check/cmd.p1
@@ -1,9 +1,14 @@
 -- fbt:
 cmd: $FBT_CWD/../target/debug/fastn --test update --check
-exit-code: 1
+exit-code: 7
 
 -- stdout:
 
 -- stderr:
 
-FastnCoreError(UpdateError { message: "Check error: Write operation detected during check for package 'fastn-community.github.io/bling' at '<cwd>/.packages/fastn-community.github.io/bling/Changelog.md'" })
+Error: Out of Sync Package
+
+The package 'fastn-community.github.io/bling' is out of sync with the FASTN.ftd file.
+
+File: '<cwd>/.packages/fastn-community.github.io/bling/Changelog.md'
+Operation: Write Attempt

--- a/fastn-core/tests/20-fastn-update-check/cmd.p1
+++ b/fastn-core/tests/20-fastn-update-check/cmd.p1
@@ -1,0 +1,9 @@
+-- fbt:
+cmd: $FBT_CWD/../target/debug/fastn --test update --check
+exit-code: 1
+
+-- stdout:
+
+-- stderr:
+
+FastnCoreError(UpdateError { message: "Check error: Write operation detected during check for package 'fastn-community.github.io/bling' at '<cwd>/.packages/fastn-community.github.io/bling/Changelog.md'" })

--- a/fastn-core/tests/20-fastn-update-check/input/FASTN.ftd
+++ b/fastn-core/tests/20-fastn-update-check/input/FASTN.ftd
@@ -1,0 +1,5 @@
+-- import: fastn
+
+-- fastn.package: fastn-stack.github.io/fastn-update-check
+
+-- fastn.dependency: fastn-community.github.io/bling

--- a/fastn-core/tests/20-fastn-update-check/input/index.ftd
+++ b/fastn-core/tests/20-fastn-update-check/input/index.ftd
@@ -1,0 +1,6 @@
+-- import: fastn-community.github.io/bling/quote
+
+-- quote.chalice: Nelson Mandela
+
+The greatest glory in living lies not in never falling, but in rising every time
+we fall.

--- a/fastn-update/Cargo.toml
+++ b/fastn-update/Cargo.toml
@@ -21,3 +21,4 @@ indicatif.workspace = true
 thiserror.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+colored.workspace = true

--- a/fastn-update/src/lib.rs
+++ b/fastn-update/src/lib.rs
@@ -62,6 +62,19 @@ pub enum DependencyError {
     },
 }
 
+#[derive(Snafu, Debug)]
+pub enum CheckError {
+    #[snafu(display(
+        "Write operation detected during check for package '{}' at '{}'",
+        package,
+        output_path
+    ))]
+    WriteDuringCheck {
+        package: String,
+        output_path: String,
+    },
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateError {
     #[error("Manifest error: {0}")]
@@ -72,6 +85,9 @@ pub enum UpdateError {
 
     #[error("Dependency error: {0}")]
     Dependency(#[from] DependencyError),
+
+    #[error("Check error: {0}")]
+    Check(#[from] CheckError),
 }
 
 async fn resolve_dependency_package(
@@ -96,10 +112,12 @@ async fn update_dependencies(
     current_package: &fastn_core::Package,
     pb: &indicatif::ProgressBar,
     offline: bool,
-) -> Result<(), UpdateError> {
+    check: bool,
+) -> Result<usize, UpdateError> {
     let mut stack = vec![current_package.clone()];
     let mut resolved = std::collections::HashSet::new();
     resolved.insert(current_package.name.to_string());
+    let mut updated_packages: usize = 0;
 
     while let Some(package) = stack.pop() {
         for dependency in package.dependencies {
@@ -163,14 +181,14 @@ async fn update_dependencies(
                     &manifest,
                     &package_name,
                     pb,
+                    check,
                 )
                 .await?;
 
-                ds.write_content(&manifest_path, manifest_bytes)
-                    .await
-                    .context(WriteArchiveContentSnafu {
-                        package: package_name.clone(),
-                    })?
+                write_archive_content(ds, &manifest_path, manifest_bytes, &package_name, check)
+                    .await?;
+
+                updated_packages += 1;
             }
 
             if package_name.eq(&fastn_core::FASTN_UI_INTERFACE) {
@@ -186,7 +204,29 @@ async fn update_dependencies(
 
         pb.inc(1);
     }
-    Ok(())
+    Ok(updated_packages)
+}
+
+async fn write_archive_content(
+    ds: &fastn_ds::DocumentStore,
+    output_path: &fastn_ds::Path,
+    buffer: Vec<u8>,
+    package_name: &str,
+    check: bool,
+) -> Result<(), UpdateError> {
+    if check {
+        return Err(UpdateError::Check(CheckError::WriteDuringCheck {
+            package: package_name.to_string(),
+            output_path: output_path.to_string(),
+        }));
+    }
+
+    Ok(ds
+        .write_content(output_path, buffer)
+        .await
+        .context(WriteArchiveContentSnafu {
+            package: package_name,
+        })?)
 }
 
 async fn download_and_unpack_zip(
@@ -195,7 +235,8 @@ async fn download_and_unpack_zip(
     manifest: &fastn_core::Manifest,
     package_name: &str,
     pb: &indicatif::ProgressBar,
-) -> Result<(), ArchiveError> {
+    check: bool,
+) -> Result<(), UpdateError> {
     let mut archive = fastn_update::utils::download_archive(manifest.zip_url.clone())
         .await
         .context(DownloadArchiveSnafu {
@@ -225,11 +266,7 @@ async fn download_and_unpack_zip(
                 continue;
             }
             let output_path = &dependency_path.join(path_without_prefix);
-            ds.write_content(output_path, buffer)
-                .await
-                .context(WriteArchiveContentSnafu {
-                    package: package_name,
-                })?;
+            write_archive_content(ds, output_path, buffer, package_name, check).await?;
             pb.tick();
         }
     }
@@ -266,7 +303,11 @@ async fn get_manifest(
 }
 
 #[tracing::instrument(skip_all)]
-pub async fn update(config: &fastn_core::Config, offline: bool) -> fastn_core::Result<()> {
+pub async fn update(
+    config: &fastn_core::Config,
+    offline: bool,
+    check: bool,
+) -> fastn_core::Result<()> {
     if config.package.dependencies.is_empty() {
         println!("No dependencies to update.");
         return Ok(());
@@ -282,24 +323,29 @@ pub async fn update(config: &fastn_core::Config, offline: bool) -> fastn_core::R
     pb.set_style(spinner_style);
     pb.set_prefix("Updating dependencies");
 
-    if let Err(e) = update_dependencies(
+    let updated_packages = match update_dependencies(
         &config.ds,
         &config.packages_root,
         current_package,
         &pb,
         offline,
+        check,
     )
     .await
     {
-        return Err(fastn_core::Error::UpdateError {
-            message: e.to_string(),
-        });
-    }
+        Ok(n) => n,
+        Err(e) => {
+            return Err(fastn_core::Error::UpdateError {
+                message: e.to_string(),
+            })
+        }
+    };
 
     pb.finish_and_clear();
 
-    match config.package.dependencies.len() {
-        1 => println!("Updated package dependency"),
+    match updated_packages {
+        0 => println!("No packages updated."),
+        1 => println!("Updated package dependency."),
         n => println!("Updated {} dependencies.", n),
     }
 

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -80,7 +80,7 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
         let inline_css = serve.values_of_("css");
         let offline = serve.get_flag("offline");
 
-        fastn_update::update(&config, offline).await?;
+        fastn_update::update(&config, offline, false).await?;
 
         return fastn_core::listen(
             bind.as_str(),
@@ -95,8 +95,9 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
         .await;
     }
 
-    if matches.subcommand_matches("update").is_some() {
-        return fastn_update::update(&config, false).await;
+    if let Some(update) = matches.subcommand_matches("update") {
+        let check = update.get_flag("check");
+        return fastn_update::update(&config, false, check).await;
     }
 
     if let Some(test) = matches.subcommand_matches("test") {
@@ -115,7 +116,7 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
             .add_inline_css(inline_css)
             .set_test_command_running();
 
-        fastn_update::update(&config, offline).await?;
+        fastn_update::update(&config, offline, false).await?;
 
         return fastn_core::test(
             &config,
@@ -148,7 +149,7 @@ async fn fastn_core_commands(matches: &clap::ArgMatches) -> fastn_core::Result<(
             .add_external_css(external_css)
             .add_inline_css(inline_css);
 
-        fastn_update::update(&config, offline).await?;
+        fastn_update::update(&config, offline, false).await?;
 
         return fastn_core::build(
             &config,
@@ -312,6 +313,7 @@ fn app(version: &'static str) -> clap::Command {
         .subcommand(
             clap::Command::new("update")
                 .about("Update dependency packages for this fastn package")
+                .arg(clap::arg!(--check "Check if packages are in sync with FASTN.ftd without performing updates."))
         )
         .subcommand(sub_command::serve())
 }


### PR DESCRIPTION
We are adding `--check` flag in the `fastn update` command. It will return with failure exit code of `.packages` is not in sync with `FASTN.ftd` and if it tries to perform a write operation during update check.

Discussion Link: [fastn update --check](https://github.com/orgs/fastn-stack/discussions/1740)