### PR TITLE
fix: remove manifest.json reads from fs fetch

### DIFF
--- a/fastn-core/src/manifest/manifest_to_package.rs
+++ b/fastn-core/src/manifest/manifest_to_package.rs
@@ -10,6 +10,7 @@ impl fastn_core::Manifest {
         package
             .resolve(&package_root.join(package_name).join("FASTN.ftd"), ds)
             .await?;
+        package.files = self.files.keys().map(|f| f.to_string()).collect();
         package.auto_import_language(
             main_package.requested_language.clone(),
             main_package.selected_language.clone(),

--- a/fastn-core/src/package/mod.rs
+++ b/fastn-core/src/package/mod.rs
@@ -8,6 +8,7 @@ pub mod user_group;
 pub struct Package {
     pub name: String,
     /// The `versioned` stores the boolean value storing of the fastn package is versioned or not
+    pub files: Vec<String>,
     pub versioned: bool,
     pub translation_of: Box<Option<Package>>,
     pub translations: Vec<Package>,
@@ -75,6 +76,7 @@ impl Package {
     pub fn new(name: &str) -> fastn_core::Package {
         fastn_core::Package {
             name: name.to_string(),
+            files: vec![],
             versioned: false,
             translation_of: Box::new(None),
             translations: vec![],
@@ -958,6 +960,7 @@ impl PackageTempIntoPackage for fastn_package::old_fastn::PackageTemp {
 
         Package {
             name: self.name.clone(),
+            files: vec![],
             versioned: self.versioned,
             translation_of: Box::new(translation_of),
             translations,


### PR DESCRIPTION
Removing `manifest.json` reads for dependency packages when resolving static file requests is the first step. The next step would be to update the logic for `ftd.image-src` so that if a particular variant of an image does not exist, it should not attempt to fetch it.