### PR TITLE
add: fastn.redirect test helper

### DIFF
--- a/fastn-core/test_fastn.ftd
+++ b/fastn-core/test_fastn.ftd
@@ -61,6 +61,19 @@ string list fixtures:
 
 
 
+-- component redirect:
+caption http-redirect:
+
+-- ftd.text: NOT IMPLEMENTED HERE
+
+-- end: redirect
+
+
+
+
+
+
+
 
 -- record test-data-structure:
 caption next-url:

--- a/ftd/src/interpreter/things/default.rs
+++ b/ftd/src/interpreter/things/default.rs
@@ -10414,6 +10414,10 @@ pub fn default_test_bag() -> indexmap::IndexMap<String, ftd::interpreter::Thing>
             ftd::interpreter::Thing::Component(fastn_post_function()),
         ),
         (
+            "fastn#redirect".to_string(),
+            ftd::interpreter::Thing::Component(fastn_redirect_function()),
+        ),
+        (
             "fastn#test".to_string(),
             ftd::interpreter::Thing::Component(fastn_test_function()),
         ),
@@ -10529,6 +10533,19 @@ pub fn fastn_post_function() -> ftd::interpreter::ComponentDefinition {
         .concat()
         .into_iter()
         .collect(),
+        definition: ftd::interpreter::Component::from_name("ftd.kernel"),
+        css: None,
+        line_number: 0,
+    }
+}
+
+pub fn fastn_redirect_function() -> ftd::interpreter::ComponentDefinition {
+    ftd::interpreter::ComponentDefinition {
+        name: "fastn#redirect".to_string(),
+        arguments: vec![ftd::interpreter::Argument::default(
+            "http-redirect",
+            ftd::interpreter::Kind::string().into_kind_data().caption(),
+        )],
         definition: ftd::interpreter::Component::from_name("ftd.kernel"),
         css: None,
         line_number: 0,

--- a/integration-tests/_tests/11-fastn-redirect.test.ftd
+++ b/integration-tests/_tests/11-fastn-redirect.test.ftd
@@ -1,0 +1,5 @@
+-- import: fastn
+
+-- fastn.test: 11-fastn-redirect
+
+-- fastn.redirect: /redirect-to-hello/ -> /hello/

--- a/integration-tests/redirect-to-hello.ftd
+++ b/integration-tests/redirect-to-hello.ftd
@@ -1,0 +1,1 @@
+-- ftd.redirect: /hello/


### PR DESCRIPTION
Added a new test helper `fastn.redirect`, which can be used for testing redirects.

Example:

```ftd
-- fastn.redirect: /foo/ -> /bar/
```

Discussion: [fastn test helpers](https://github.com/orgs/fastn-stack/discussions/1715)