### PR TITLE
minor fix: handle underscore in var name

### DIFF
--- a/fastn-expr/src/tokenizer.rs
+++ b/fastn-expr/src/tokenizer.rs
@@ -48,7 +48,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, TokenizerError> {
                 tokens.push(get_token(&current_token));
                 current_token.clear();
             }
-        } else if ((c == '.' && !current_token.is_empty()) || c.is_alphanumeric())
+        } else if (((c == '.' || c == '_') && !current_token.is_empty()) || c.is_alphanumeric())
             || (c == '-' && current_token.is_empty())
         {
             current_token.push(c);
@@ -104,9 +104,9 @@ fn test_expr() {
         ]
     );
     assert_eq!(
-        tokenize(r#"env.ENDPOINT or "or 127.0.0.1:8000""#).unwrap(),
+        tokenize(r#"env.FT_ENDPOINT or "or 127.0.0.1:8000""#).unwrap(),
         vec![
-            Token::Identifier(String::from("env.ENDPOINT")),
+            Token::Identifier(String::from("env.FT_ENDPOINT")),
             Token::Operator(Operator::Or),
             Token::StringLiteral(String::from("or 127.0.0.1:8000"))
         ]

--- a/fastn-expr/src/tokenizer.rs
+++ b/fastn-expr/src/tokenizer.rs
@@ -48,20 +48,29 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, TokenizerError> {
                 tokens.push(get_token(&current_token));
                 current_token.clear();
             }
-        } else if (((c == '.' || c == '_') && !current_token.is_empty()) || c.is_alphanumeric())
-            || (c == '-' && current_token.is_empty())
-        {
-            current_token.push(c);
-        } else if c == '"' {
-            in_string_literal = true;
-        } else if !current_token.is_empty() {
-            tokens.push(get_token(&current_token));
-            current_token.clear();
         } else {
-            return Err(TokenizerError::UnexpectedToken {
-                token: c,
-                position: pos,
-            });
+            match c {
+                '.' | '_' if !current_token.is_empty() => {
+                    current_token.push(c);
+                }
+                '-' if current_token.is_empty() => {
+                    current_token.push(c);
+                }
+                '"' => in_string_literal = true,
+                _ => {
+                    if c.is_alphanumeric() {
+                        current_token.push(c);
+                    } else if !current_token.is_empty() {
+                        tokens.push(get_token(&current_token));
+                        current_token.clear();
+                    } else {
+                        return Err(TokenizerError::UnexpectedToken {
+                            token: c,
+                            position: pos,
+                        });
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes `_` not being accepted in variable names.

Example:
```ftd
-- fastn.url-mappings:

/ft/* -> http+proxy://${env.FT_API_DOMAIN or "127.0.0.1:8001"}/ft/*
```