### PR TITLE
feat(auth): option to disable strong password validation

### DIFF
--- a/fastn-core/src/auth/email_password/create_account.rs
+++ b/fastn-core/src/auth/email_password/create_account.rs
@@ -68,7 +68,7 @@ pub(crate) async fn create_account(
         if req_config
             .config
             .ds
-            .env_bool("FASTN_DISABLE_STRONG_PASSWORD_CHECK", false)
+            .env_bool("DEBUG_FASTN_DISABLE_STRONG_PASSWORD_CHECK", false)
             .await?
             && !user_payload.password.is_empty()
         {

--- a/fastn-core/src/auth/email_password/set_password.rs
+++ b/fastn-core/src/auth/email_password/set_password.rs
@@ -88,8 +88,6 @@ pub(crate) async fn forgot_password_request(
             fastn_core::schema::fastn_user_email::email,
         ));
 
-    dbg!("{:?}", diesel::debug_query::<diesel::pg::Pg, _>(&query));
-
     let user: Option<(fastn_core::auth::FastnUser, fastn_core::utils::CiString)> =
         query.first(&mut conn).await.optional()?;
 
@@ -336,11 +334,7 @@ pub(crate) async fn set_password(
             )
             .returning(fastn_core::schema::fastn_password_reset::user_id);
 
-            dbg!("{:?}", diesel::debug_query::<diesel::pg::Pg, _>(&query));
-
             let user_id: Option<i64> = query.get_result(&mut conn).await.optional()?;
-
-            dbg!(user_id);
 
             if user_id.is_none() {
                 return Ok(fastn_core::http::api_error("Bad Request")?);

--- a/integration-tests/_tests/04-multi-endpoint-test.test.ftd
+++ b/integration-tests/_tests/04-multi-endpoint-test.test.ftd
@@ -13,7 +13,7 @@ fastn.assert.eq(fastn.http_response["data"], "Hello, World!");
 ;; Mountpoint: /ftd/* -> Endpoint: http://fastn.com/ftd/*
 -- fastn.get: Fetching content from fastn.com
 url: /ftd/column/
-http-status: 308
+http-status: 301
 
 -- fastn.get: Redirect to google
 url: /goo/

--- a/integration-tests/_tests/12-auth-create-user.test.ftd
+++ b/integration-tests/_tests/12-auth-create-user.test.ftd
@@ -20,6 +20,17 @@ body: {"username": "siddhant"}
 
 fastn.assert.not_empty(fastn.http_response.errors.payload);
 
+-- fastn.post: Create user with empty data
+url: /-/auth/create-account/?next=/hello/
+body: {"name": "", "email": "", "password": "", "password2": "", "username": "", "accept_terms": false}
+
+
+-- fastn.post.test:
+
+fastn.assert.eq(fastn.http_response.success, false);
+fastn.assert.not_empty(fastn.http_response.errors.password);
+
+
 -- fastn.post: Create user with invalid data
 url: /-/auth/create-account/?next=/hello/
 body: {"name": "John", "email": "john@mail.com", "password": "testpasswd", "password2": "test", "username": "john", "accept_terms": false}
@@ -28,7 +39,6 @@ body: {"name": "John", "email": "john@mail.com", "password": "testpasswd", "pass
 -- fastn.post.test:
 
 fastn.assert.eq(fastn.http_response.success, false);
-fastn.assert.not_empty(fastn.http_response.errors.password);
 fastn.assert.not_empty(fastn.http_response.errors.password2);
 fastn.assert.not_empty(fastn.http_response.errors.accept_terms);
 


### PR DESCRIPTION
Add option to disable strong password validation in `/-/auth/create-account/`.
This can be disabled using the `FASTN_DISABLE_STRONG_PASSWORD_CHECK` env var:

- `true`: disable validation
- `false` (or unset): use [`zxcvbn`](https://docs.rs/zxcvbn/2.2.2/zxcvbn/feedback/struct.Feedback.html) to check for weak passwords


Also removes some `dbg!` calls in `set_password.rs`.