### PR TITLE
fix(ftd.http): replicate error response behaviour for data response

### DIFF
--- a/fastn-js/js/ftd.js
+++ b/fastn-js/js/ftd.js
@@ -300,7 +300,11 @@ const ftd = (function () {
                                 "both .errors and .data are present in response, ignoring .data",
                             );
                         } else {
-                            data = response.data;
+                            for (let key of Object.keys(response.data)) {
+                                const value = response.data[key];
+                                key = fastn_module + "#" + key;
+                                data[key] = value;
+                            }
                         }
                     }
                     for (let ftd_variable of Object.keys(data)) {


### PR DESCRIPTION
For the `errors` response from server, `ftd.http` correctly prepends defined
variables with the `fastn-module` name provided through `ftd.http-options`.

The same thing is not done for `data` response. This PR fixes this.

E.g.

```ftd
-- optional string $name:

-- ftd.text: $name
if: { name }

-- ftd.text: test
$on-click$: send-req()

-- ftd.http-options opts:
method: GET
fastn-module: fastn-test-multiauth/

-- void send-req():
ftd.http-options opts: $opts

ftd.http(
    "http://localhost:3000/test.json",
    opts
)
```

The response from the server (`http://localhost:3000/test.json`):

```json
{
    "data": {
        "name": "spiderman"
    }
}
```

The `ftd.text` shows "spiderman" with this change.
