### PR TITLE
fix: tests and use env_bool instead of env::var

### DIFF
--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -182,7 +182,11 @@ impl DocumentStore {
             None => {
                 let source = self.read_content(&fastn_ds::Path::new(path)).await?;
                 let module = wasmtime::Module::from_binary(&WASM_ENGINE, &source)?;
-                if std::env::var("DEBUG_SERVE_SITE_FROM_FOLDER").is_err() {
+                if self
+                    .env_bool("DEBUG_SERVE_SITE_FROM_FOLDER", false)
+                    .await
+                    .unwrap_or(false)
+                {
                     // we are only storing compiled module if we are not in debug mode
                     self.wasm_modules.insert(path.to_string(), module.clone());
                 }

--- a/ftd/src/ftd2021/test.rs
+++ b/ftd/src/ftd2021/test.rs
@@ -19038,7 +19038,7 @@ mod document {
         pretty_assertions::assert_eq!(
             bag.get::<Vec<Meta>>("meta").unwrap(),
             vec![Meta {
-                license: s("BSD"),
+                license: s("AGPL-3"),
                 reader: vec![
                     Someone::Username { username: s("foo") },
                     Someone::Who { who: s("everyone") }


### PR DESCRIPTION
we have a handy utility method that enforces values of either `false` or
`true` which is what is needed here.
