### PR TITLE
Add `expires_at` in `fastn_session` table

### DIFF
--- a/fastn-core/src/migrations/fastn_migrations.rs
+++ b/fastn-core/src/migrations/fastn_migrations.rs
@@ -21,6 +21,7 @@ pub(crate) fn fastn_migrations() -> Vec<fastn_core::package::MigrationData> {
                 data       TEXT    NOT NULL,
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
+                expires_at INTEGER,
 
                 CONSTRAINT fk_fastn_user
                 FOREIGN KEY (uid)


### PR DESCRIPTION
This pull request includes the addition of `expires_at` column to the `fastn_session` table to store the expiration time of sessions.

For existing databases, the following migration script should be run to add the new `expires_at` column:
```sql
ALTER TABLE session
ADD COLUMN expires_at INTEGER;
```

