### PR TITLE
Added session_id method in Request

### DIFF
--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -241,15 +241,7 @@ impl RequestConfig {
     }
 
     pub(crate) fn session_id(&self) -> Option<String> {
-        // why not `fastn-sid` cookie?
-        // Cookies are only available in browser context. It is easier to read session id (if
-        // available) from a custom HTTP header in situation like when we are rendering a document
-        // inside of an iframe.
-        self.request.headers().get("X-FASTN-ACTOR").map(|v| {
-            v.to_str()
-                .expect("X-FASTN-ACTOR is a valid ascii string (uuid)")
-                .to_string()
-        })
+        self.request.session_id()
     }
 }
 

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -356,9 +356,11 @@ impl Request {
         // Cookies are only accessible in a browser context. It is easier to read the session ID (if
         // available) from a custom HTTP header in scenarios such as rendering a document inside an iframe.
         match self.headers().get("X-FASTN-ACTOR") {
-            Some(v) => Some(v.to_str()
-                .expect("X-FASTN-ACTOR is a valid ascii string (uuid)")
-                .to_string()),
+            Some(v) => Some(
+                v.to_str()
+                    .expect("X-FASTN-ACTOR is a valid ascii string (uuid)")
+                    .to_string(),
+            ),
             None => self.cookie(fastn_core::http::SESSION_COOKIE_NAME),
         }
     }

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -1,4 +1,4 @@
-pub const SESSION_COOKIE_NAME: &str = "fastn_session";
+pub const SESSION_COOKIE_NAME: &str = "fastn-sid";
 
 #[macro_export]
 macro_rules! server_error {
@@ -348,6 +348,18 @@ impl Request {
         match self.user_agent() {
             Some(user_agent) => is_bot(&user_agent),
             None => true,
+        }
+    }
+
+    pub fn session_id(&self) -> Option<String> {
+        // Note: Besides checking `fastn-sid` cookie, we also check `X-FASTN-ACTOR` header because
+        // Cookies are only accessible in a browser context. It is easier to read the session ID (if
+        // available) from a custom HTTP header in scenarios such as rendering a document inside an iframe.
+        match self.headers().get("X-FASTN-ACTOR") {
+            Some(v) => Some(v.to_str()
+                .expect("X-FASTN-ACTOR is a valid ascii string (uuid)")
+                .to_string()),
+            None => self.cookie(fastn_core::http::SESSION_COOKIE_NAME),
         }
     }
 }

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -8,7 +8,9 @@ pub async fn process(
     match ud(
         &req_config.config.ds,
         req_config.config.get_db_url().await.as_str(),
-        req_config.request.cookie(fastn_core::http::SESSION_COOKIE_NAME),
+        req_config
+            .request
+            .cookie(fastn_core::http::SESSION_COOKIE_NAME),
     )
     .await
     {

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -5,10 +5,9 @@ pub async fn process(
     doc: &ftd::interpreter::TDoc<'_>,
     req_config: &fastn_core::RequestConfig,
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
-    match ud(
-        &req_config.config.ds,
+    match req_config.config.ds.ud(
         req_config.config.get_db_url().await.as_str(),
-        req_config
+        &req_config
             .request
             .cookie(fastn_core::http::SESSION_COOKIE_NAME),
     )
@@ -21,74 +20,4 @@ pub async fn process(
             value.line_number(),
         ),
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum UserDataError {
-    #[error("multiple rows found: {0} {1}")]
-    MultipleRowsFound(String, usize),
-    #[error("serde error: {0}: {1}")]
-    SerdeError(String, serde_json::Error),
-    #[error("sql error: {0}")]
-    SqlError(#[from] fastn_utils::SqlError),
-}
-
-pub async fn ud(
-    ds: &fastn_ds::DocumentStore,
-    db_url: &str,
-    sid: Option<String>,
-) -> Result<Option<ft_sys_shared::UserData>, UserDataError> {
-    if let Ok(v) = ds.env("DEBUG_LOGGED_IN").await {
-        let mut v = v.splitn(4, ' ');
-        return Ok(Some(ft_sys_shared::UserData {
-            id: v.next().unwrap().parse().unwrap(),
-            identity: v.next().unwrap_or_default().to_string(),
-            name: v.next().map(|v| v.to_string()).unwrap_or_default(),
-            email: v.next().map(|v| v.to_string()).unwrap_or_default(),
-            verified_email: true,
-        }));
-    }
-
-    let sid = match sid {
-        Some(v) => v,
-        None => return Ok(None),
-    };
-
-    let mut rows = ds.sql_query(
-        db_url,
-        r#"
-            SELECT
-                fastn_user.id as id,
-                fastn_user.identity as identity,
-                fastn_user.name as name,
-                json_extract(fastn_user.data, '$.email.emails[0]') as email,
-                json_array_length(fastn_user.data, '$.email.verified_emails') as verified_email_count
-            FROM fastn_user
-            JOIN fastn_session
-            WHERE
-                fastn_session.id = $1
-                AND fastn_user.id = fastn_session.uid
-            "#,
-        vec![sid.as_str().into()],
-    ).await?;
-
-    let mut row = match rows.len() {
-        1 => rows.pop().unwrap(),
-        0 => return Ok(None),
-        n => return Err(UserDataError::MultipleRowsFound(sid, n)),
-    };
-
-    Ok(Some(ft_sys_shared::UserData {
-        verified_email: serde_json::from_value::<i32>(row.pop().unwrap())
-            .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?
-            > 0,
-        email: serde_json::from_value(row.pop().unwrap())
-            .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
-        name: serde_json::from_value(row.pop().unwrap())
-            .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
-        identity: serde_json::from_value(row.pop().unwrap())
-            .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
-        id: serde_json::from_value(row.pop().unwrap())
-            .map_err(|e| UserDataError::SerdeError(sid, e))?,
-    }))
 }

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -10,9 +10,7 @@ pub async fn process(
         .ds
         .ud(
             req_config.config.get_db_url().await.as_str(),
-            &req_config
-                .request
-                .cookie(fastn_core::http::SESSION_COOKIE_NAME),
+            &req_config.request.session_id(),
         )
         .await
     {

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -5,13 +5,16 @@ pub async fn process(
     doc: &ftd::interpreter::TDoc<'_>,
     req_config: &fastn_core::RequestConfig,
 ) -> ftd::interpreter::Result<ftd::interpreter::Value> {
-    match req_config.config.ds.ud(
-        req_config.config.get_db_url().await.as_str(),
-        &req_config
-            .request
-            .cookie(fastn_core::http::SESSION_COOKIE_NAME),
-    )
-    .await
+    match req_config
+        .config
+        .ds
+        .ud(
+            req_config.config.get_db_url().await.as_str(),
+            &req_config
+                .request
+                .cookie(fastn_core::http::SESSION_COOKIE_NAME),
+        )
+        .await
     {
         Ok(ud) => doc.from_json(&ud, &kind, &value),
         Err(e) => ftd::interpreter::utils::e2(

--- a/fastn-core/src/library2022/processor/user_details.rs
+++ b/fastn-core/src/library2022/processor/user_details.rs
@@ -8,7 +8,7 @@ pub async fn process(
     match ud(
         &req_config.config.ds,
         req_config.config.get_db_url().await.as_str(),
-        req_config.request.cookie("fastn-sid"),
+        req_config.request.cookie(fastn_core::http::SESSION_COOKIE_NAME),
     )
     .await
     {

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -6,9 +6,9 @@ extern crate self as fastn_ds;
 mod create_pool;
 pub mod http;
 pub mod reqwest_util;
+mod user_data;
 mod utils;
 pub mod wasm;
-mod user_data;
 pub use user_data::UserDataError;
 
 pub use create_pool::create_pool;

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -8,6 +8,8 @@ pub mod http;
 pub mod reqwest_util;
 mod utils;
 pub mod wasm;
+mod user_data;
+pub use user_data::UserDataError;
 
 pub use create_pool::create_pool;
 

--- a/fastn-ds/src/user_data.rs
+++ b/fastn-ds/src/user_data.rs
@@ -1,0 +1,71 @@
+impl fastn_ds::DocumentStore {
+    pub async fn ud(
+        &self,
+        db_url: &str,
+        session_id: &Option<String>,
+    ) -> Result<Option<ft_sys_shared::UserData>, UserDataError> {
+        if let Ok(v) = self.env("DEBUG_LOGGED_IN").await {
+            let mut v = v.splitn(4, ' ');
+            return Ok(Some(ft_sys_shared::UserData {
+                id: v.next().unwrap().parse().unwrap(),
+                identity: v.next().unwrap_or_default().to_string(),
+                name: v.next().map(|v| v.to_string()).unwrap_or_default(),
+                email: v.next().map(|v| v.to_string()).unwrap_or_default(),
+                verified_email: true,
+            }));
+        }
+
+        let sid = match session_id {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+
+        let mut rows = self.sql_query(
+            db_url,
+            r#"
+            SELECT
+                fastn_user.id as id,
+                fastn_user.identity as identity,
+                fastn_user.name as name,
+                json_extract(fastn_user.data, '$.email.emails[0]') as email,
+                json_array_length(fastn_user.data, '$.email.verified_emails') as verified_email_count
+            FROM fastn_user
+            JOIN fastn_session
+            WHERE
+                fastn_session.id = $1
+                AND fastn_user.id = fastn_session.uid
+            "#,
+            vec![sid.as_str().into()],
+        ).await?;
+
+        let mut row = match rows.len() {
+            1 => rows.pop().unwrap(),
+            0 => return Ok(None),
+            n => return Err(UserDataError::MultipleRowsFound(sid.clone(), n)),
+        };
+
+        Ok(Some(ft_sys_shared::UserData {
+            verified_email: serde_json::from_value::<i32>(row.pop().unwrap())
+                .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?
+                > 0,
+            email: serde_json::from_value(row.pop().unwrap())
+                .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
+            name: serde_json::from_value(row.pop().unwrap())
+                .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
+            identity: serde_json::from_value(row.pop().unwrap())
+                .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
+            id: serde_json::from_value(row.pop().unwrap())
+                .map_err(|e| UserDataError::SerdeError(sid.clone(), e))?,
+        }))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UserDataError {
+    #[error("multiple rows found: {0} {1}")]
+    MultipleRowsFound(String, usize),
+    #[error("serde error: {0}: {1}")]
+    SerdeError(String, serde_json::Error),
+    #[error("sql error: {0}")]
+    SqlError(#[from] fastn_utils::SqlError),
+}


### PR DESCRIPTION
Earlier the `session_id` method in `RequestConfig` only read session from request header `X-FASTN-ACTOR`. Fix this by reading from cookie too. Also moved the logic to `Request::session_id` method, so that it can be used by `hostn::route` too.

Related PR: https://github.com/FifthTry/ft/pull/182