### PR TITLE
Add ability to serve html files

### DIFF
--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -57,10 +57,17 @@ async fn serve_file(
         }
     };
 
+    if let fastn_core::File::Code(doc) = f {
+        let path = doc.get_full_path().to_string();
+        let mime = mime_guess::from_path(path).first_or_text_plain();
+        return fastn_core::http::ok_with_content_type(doc.content.into_bytes(), mime);
+    }
+
     let main_document = match f {
         fastn_core::File::Ftd(main_document) => main_document,
         _ => {
             tracing::error!(msg = "unknown handler", path = path.as_str());
+            tracing::info!("file: {f:?}");
             return fastn_core::server_error!("unknown handler");
         }
     };

--- a/fastn-core/src/package/package_doc.rs
+++ b/fastn-core/src/package/package_doc.rs
@@ -296,6 +296,7 @@ pub(crate) fn file_id_to_names(id: &str) -> Vec<String> {
             "index.ftd".to_string(),
             "README.md".to_string(),
             "index.md".to_string(),
+            "index.html".to_string(),
         ];
     }
     let mut ids = vec![];
@@ -306,6 +307,7 @@ pub(crate) fn file_id_to_names(id: &str) -> Vec<String> {
     ids.extend([
         format!("{}.ftd", id),
         format!("{}/index.ftd", id),
+        format!("{}/index.html", id),
         // Todo: removing `md` file support for now
         // format!("{}.md", id),
         // format!("{}/README.md", id),

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -1,4 +1,4 @@
-/// `Sitemap` stores the sitemap for the fastn package defines in the FASTN.ftd
+/// `Sitemap` stores the sitemap for the fastn package defined in the FASTN.ftd
 ///
 /// ```ftd
 /// -- fastn.sitemap:
@@ -12,7 +12,7 @@
 ///
 /// In above example, the id starts with `#` becomes the section. Similarly the id
 /// starts with `##` becomes the subsection and then the id starts with `-` becomes
-/// the table od content (TOC).
+/// the table of content (TOC).
 pub mod dynamic_urls;
 pub mod section;
 pub mod toc;

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -350,6 +350,7 @@ impl DocumentStore {
         Ok(contents)
     }
 
+    #[tracing::instrument]
     pub async fn read_to_string(
         &self,
         path: &fastn_ds::Path,


### PR DESCRIPTION
fastn should support .html files. This helps users who are migrating their websites from other static site generators to fastn.