### PR TITLE
Remove markdown parsing from frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,9 +1575,11 @@ dependencies = [
 name = "fastn-js"
 version = "0.1.0"
 dependencies = [
+ "comrak",
  "fastn-grammar",
  "indoc",
  "itertools 0.13.0",
+ "once_cell",
  "prettify-js",
  "pretty",
  "quick-js",

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -755,11 +755,9 @@ pub async fn replace_markers_2023(
             r#"
                 <script src="{}"></script>
                 <script src="{}"></script>
-                <script src="{}"></script>
                 <link rel="stylesheet" href="{}">
                 {}
             "#,
-            hashed_markdown_js(),
             hashed_prism_js(),
             hashed_default_ftd_js(config.package.name.as_str()),
             hashed_prism_css(),

--- a/fastn-js/Cargo.toml
+++ b/fastn-js/Cargo.toml
@@ -16,6 +16,8 @@ indoc.workspace = true
 fastn-grammar.workspace = true
 prettify-js.workspace = true
 thiserror.workspace = true
+comrak.workspace = true
+once_cell.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 quick-js.workspace = true

--- a/fastn-js/js/dom.js
+++ b/fastn-js/js/dom.js
@@ -2708,13 +2708,6 @@ class Node2 {
             this.#rawInnerValue = staticValue;
         } else if (kind === fastn_dom.PropertyKind.StringValue) {
             this.#rawInnerValue = staticValue;
-            staticValue = fastn_utils.markdown_inline(
-                fastn_utils.escapeHtmlInMarkdown(staticValue),
-            );
-            staticValue = fastn_utils.process_post_markdown(
-                this.#node,
-                staticValue,
-            );
             if (!fastn_utils.isNull(staticValue)) {
                 this.#node.innerHTML = staticValue;
             } else {

--- a/fastn-js/src/lib.rs
+++ b/fastn-js/src/lib.rs
@@ -11,6 +11,7 @@ mod constants;
 mod device;
 mod event;
 mod loop_component;
+mod markup;
 mod mutable_variable;
 mod or_type;
 mod property;
@@ -61,7 +62,6 @@ pub fn fastn_test_js() -> &'static str {
 }
 
 pub fn all_js_without_test_and_ftd_langugage_js() -> String {
-    let markdown_js = fastn_js::markdown_js();
     let fastn_js = include_str_with_debug!("../js/fastn.js");
     let dom_js = include_str_with_debug!("../js/dom.js");
     let utils_js = include_str_with_debug!("../js/utils.js");
@@ -69,7 +69,7 @@ pub fn all_js_without_test_and_ftd_langugage_js() -> String {
     let ftd_js = include_str_with_debug!("../js/ftd.js");
     let web_component_js = include_str_with_debug!("../js/web-component.js");
     let post_init_js = include_str_with_debug!("../js/postInit.js");
-    format!("{markdown_js}{fastn_js}{dom_js}{utils_js}{virtual_js}{web_component_js}{ftd_js}{post_init_js}")
+    format!("{fastn_js}{dom_js}{utils_js}{virtual_js}{web_component_js}{ftd_js}{post_init_js}")
 }
 
 #[macro_export]

--- a/fastn-js/src/markup.rs
+++ b/fastn-js/src/markup.rs
@@ -1,0 +1,77 @@
+// Copied from ftd/src/executor/markup.rs
+
+const MAGIC: &str = "MMMMMMMMMAMMAMSMASMDASMDAMSDMASMDASDMASMDASDMAASD";
+
+pub static MD: once_cell::sync::Lazy<comrak::ComrakOptions> = once_cell::sync::Lazy::new(|| {
+    let mut m = comrak::ComrakOptions::default();
+    m.extension.strikethrough = true;
+    m.extension.table = true;
+    m.extension.autolink = true;
+    m.extension.tasklist = true;
+    m.extension.superscript = true;
+    m.parse.smart = true;
+    m
+});
+
+fn markup(i: &str) -> String {
+    comrak::markdown_to_html(i.replace("![", MAGIC).trim(), &MD)
+        .trim()
+        .replace(MAGIC, "![")
+}
+
+pub fn markup_inline(i: &str) -> String {
+    let (space_before, space_after) = spaces(i);
+    let o = {
+        let mut g = replace_last_occurrence(markup(i).as_str(), "<p>", "");
+        g = replace_last_occurrence(g.as_str(), "</p>", "");
+        g
+    };
+
+    let o = o.replace("</p>", "\n");
+    let o = o.replace("<p>", "");
+
+    format!(
+        "{}{o}{}",
+        repeated_space(space_before),
+        repeated_space(space_after)
+    )
+}
+
+fn repeated_space(n: usize) -> String {
+    (0..n).map(|_| " ").collect::<String>()
+}
+
+/// find the count of spaces at beginning and end of the input string
+fn spaces(s: &str) -> (usize, usize) {
+    let mut space_before = 0;
+    for (i, c) in s.chars().enumerate() {
+        if !c.eq(&' ') {
+            space_before = i;
+            break;
+        }
+        space_before = i + 1;
+    }
+    if space_before.eq(&s.len()) {
+        return (space_before, 0);
+    }
+    let mut space_after = 0;
+    for (i, c) in s.chars().rev().enumerate() {
+        if !c.eq(&' ') {
+            space_after = i;
+            break;
+        }
+        space_after = i + 1;
+    }
+    (space_before, space_after)
+}
+
+fn replace_last_occurrence(s: &str, old_word: &str, new_word: &str) -> String {
+    if !s.contains(old_word) {
+        return s.to_string();
+    }
+    if let Some(idx) = s.rsplit(old_word).next() {
+        let idx = s.len() - idx.len() - old_word.len();
+        return format!("{}{}{}", &s[..idx], new_word, &s[idx + old_word.len()..]);
+    }
+    s.to_string()
+}

--- a/fastn-js/src/to_js.rs
+++ b/fastn-js/src/to_js.rs
@@ -73,7 +73,7 @@ impl fastn_js::SetProperty {
                     "{},",
                     &self
                         .value
-                        .to_js_with_element_name(&Some(self.element_name.clone()))
+                        .to_js_with_element_name(&Some(self.element_name.clone()), self.is_code())
                 )
                 .as_str(),
             ))
@@ -155,7 +155,7 @@ impl fastn_js::Function {
                     format!(
                         "{}: {},",
                         fastn_js::utils::name_to_js_(k),
-                        v.to_js_with_element_name(element_name)
+                        v.to_js_with_element_name(element_name, false)
                     )
                 }),
                 pretty::RcDoc::softline(),


### PR DESCRIPTION
[marked](https://github.com/markedjs/marked/) was used to parse markdown
for each text node in the browser which was making things very slow.

This commit moves markdown parsing to the backend using the `comrak`
crate.

Some cleanups may be required that removes the marked.js files
completely from the codebase but it'll happen later once I get current
changes reviewed.

## `ftd` code that was used to test this

```ftd
-- ftd.text: 

Hello world `hellow` [link](https://google.com/)

\```rust
fn hello () -> {
    

    println!("works?");
    println!("works?");
    println!("works?");
    println!("works?");
    println!("works?");
    println!("works?");



}
\```

-- ftd.code:
lang: rust

#[derive(Debug)]
pub struct SetProperty {
    pub kind: PropertyKind,
    pub value: SetPropertyValue,
    pub element_name: String,
    pub inherited: String,
}

#[derive(Debug)]
pub enum SetPropertyValue {
    Reference(String),
    Value(fastn_js::Value),
    Formula(fastn_js::Formula),
    Clone(String),
}

impl fastn_js::SetPropertyValue {
    pub fn to_js(&self) -> String {
        self.to_js_with_element_name(&None)
    }
}
```

I couldn't see any visual changes before and after this commit. Attaching screenshots anyway:

(before this commit)
<img width="576" alt="image" src="https://github.com/user-attachments/assets/e9f335a1-f182-4668-943e-52e3cb8c4677">

(after this commit)
<img width="576" alt="image" src="https://github.com/user-attachments/assets/92d7b962-d754-46ba-8333-f7f2f8335022">

