### PR TITLE
Fix: Check for self referencing kinds in `record`, `function` and, `component`

### DIFF
--- a/fastn-core/src/library2022/mod.rs
+++ b/fastn-core/src/library2022/mod.rs
@@ -342,6 +342,7 @@ fn get_processor_data(
             &Default::default(),
             doc,
             variable_definition.line_number,
+            None,
         )?
         .into_optional()
         .ok_or(ftd::interpreter::Error::ValueNotFound {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+          extensions = [ "rust-src" ];
+        };
       in
       rec {
         # nix develop

--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -764,6 +764,7 @@ impl InterpreterState {
             &Default::default(),
             &mut doc,
             variable_definition.line_number,
+            None,
         )? {
             StateWithThing::Thing(t) => t,
             StateWithThing::State(s) => return Ok(s.into_interpreter(self)),

--- a/ftd/src/interpreter/things/function.rs
+++ b/ftd/src/interpreter/things/function.rs
@@ -88,6 +88,7 @@ impl Function {
             &Default::default(),
             doc,
             function.line_number,
+            Some(&function.name),
         )?);
 
         let expression = vec![Expression {

--- a/ftd/src/interpreter/things/kind.rs
+++ b/ftd/src/interpreter/things/kind.rs
@@ -411,7 +411,18 @@ impl KindData {
         known_kinds: &ftd::Map<ftd::interpreter::Kind>,
         doc: &mut ftd::interpreter::TDoc,
         line_number: usize,
+        for_name: Option<&str>,
     ) -> ftd::interpreter::Result<ftd::interpreter::StateWithThing<KindData>> {
+        if let Some(name) = for_name {
+            if name == var_kind.kind {
+                return Err(ftd::interpreter::Error::ParseError {
+                    message: "Self referencing is not allowed.".to_string(),
+                    doc_id: doc.name.to_string(),
+                    line_number,
+                });
+            }
+        }
+
         let mut ast_kind = ftd_p1::AccessModifier::remove_modifiers(var_kind.kind.as_str());
         // let mut ast_kind = var_kind.kind.clone();
         let (caption, body) = check_for_caption_and_body(&mut ast_kind);

--- a/ftd/src/interpreter/things/record.rs
+++ b/ftd/src/interpreter/things/record.rs
@@ -229,6 +229,7 @@ impl Field {
         ast_fields: Vec<ftd_ast::Field>,
         doc: &mut ftd::interpreter::TDoc,
         known_kinds: &ftd::Map<ftd::interpreter::Kind>,
+        for_name: &str,
     ) -> ftd::interpreter::Result<
         ftd::interpreter::StateWithThing<Vec<ftd::executor::FieldWithValue>>,
     > {
@@ -237,7 +238,8 @@ impl Field {
             fields_with_resolved_kinds.push(try_ok_state!(Field::from_ast_field_kind(
                 field,
                 doc,
-                known_kinds
+                known_kinds,
+                for_name,
             )?));
         }
         Ok(ftd::interpreter::StateWithThing::new_thing(
@@ -283,7 +285,7 @@ impl Field {
     }
 
     pub(crate) fn from_ast_fields(
-        name: &str,
+        for_name: &str,
         fields: Vec<ftd_ast::Field>,
         doc: &mut ftd::interpreter::TDoc,
         known_kinds: &ftd::Map<ftd::interpreter::Kind>,
@@ -292,12 +294,13 @@ impl Field {
         let partial_resolved_fields = try_ok_state!(Field::resolve_kinds_from_ast_fields(
             fields,
             doc,
-            known_kinds
+            known_kinds,
+            for_name,
         )?);
 
         // Once ast kinds are resolved, then try resolving ast values
         let resolved_fields =
-            Field::resolve_values_from_ast_fields(name, partial_resolved_fields, doc)?;
+            Field::resolve_values_from_ast_fields(for_name, partial_resolved_fields, doc)?;
 
         Ok(resolved_fields)
     }
@@ -326,6 +329,7 @@ impl Field {
             known_kinds,
             doc,
             field.line_number,
+            None,
         )?);
 
         let value = if let Some(value) = field.value {
@@ -355,6 +359,7 @@ impl Field {
         field: ftd_ast::Field,
         doc: &mut ftd::interpreter::TDoc,
         known_kinds: &ftd::Map<ftd::interpreter::Kind>,
+        for_name: &str,
     ) -> ftd::interpreter::Result<
         ftd::interpreter::StateWithThing<(Field, Option<ftd_ast::VariableValue>)>,
     > {
@@ -363,6 +368,7 @@ impl Field {
             known_kinds,
             doc,
             field.line_number,
+            Some(for_name),
         )?);
 
         Ok(ftd::interpreter::StateWithThing::new_thing((

--- a/ftd/src/interpreter/things/variable.rs
+++ b/ftd/src/interpreter/things/variable.rs
@@ -83,6 +83,7 @@ impl Variable {
             &Default::default(),
             doc,
             variable_definition.line_number,
+            Some(&variable_definition.name),
         )?);
 
         if let Some(processor) = variable_definition.processor {

--- a/ftd/src/interpreter/utils.rs
+++ b/ftd/src/interpreter/utils.rs
@@ -89,6 +89,7 @@ pub(crate) fn kind_eq(
         &Default::default(),
         doc,
         line_number,
+        None,
     )?);
     Ok(ftd::interpreter::StateWithThing::new_thing(
         kind_data.kind.is_same_as(kind),


### PR DESCRIPTION
```ftd
-- work:
smth: smth-idk

-- component work:
work smth:

-- ftd.text: something here

-- end: work
```

Line number 6 on the above code snippet would make `fastn` go in an
infinite loop. We now throw a `ParseError` for this that we can't parse
self referencing kinds.
