### PR TITLE
fix/1999

### DIFF
--- a/fastn-core/fbt-tests/28-text-input-VALUE/cmd.p1
+++ b/fastn-core/fbt-tests/28-text-input-VALUE/cmd.p1
@@ -1,0 +1,11 @@
+-- fbt:
+cmd: $FBT_CWD/../target/debug/fastn --test build
+output: .build
+
+-- stdout:
+
+No dependencies to update.
+Processing fastn-stack.github.io/text-input-test/manifest.json ... done in <omitted>
+Processing fastn-stack.github.io/text-input-test/ ... done in <omitted>
+Processing fastn-stack.github.io/text-input-test/actions/create-account/ ... done in <omitted>
+Processing fastn-stack.github.io/text-input-test/FASTN/ ... done in <omitted>

--- a/fastn-core/fbt-tests/28-text-input-VALUE/cmd.p1
+++ b/fastn-core/fbt-tests/28-text-input-VALUE/cmd.p1
@@ -6,6 +6,6 @@ output: .build
 
 No dependencies to update.
 Processing fastn-stack.github.io/text-input-test/manifest.json ... done in <omitted>
-Processing fastn-stack.github.io/text-input-test/ ... done in <omitted>
-Processing fastn-stack.github.io/text-input-test/actions/create-account/ ... done in <omitted>
 Processing fastn-stack.github.io/text-input-test/FASTN/ ... done in <omitted>
+Processing fastn-stack.github.io/text-input-test/actions/create-account/ ... done in <omitted>
+Processing fastn-stack.github.io/text-input-test/ ... done in <omitted>

--- a/fastn-core/fbt-tests/28-text-input-VALUE/input/FASTN.ftd
+++ b/fastn-core/fbt-tests/28-text-input-VALUE/input/FASTN.ftd
@@ -1,0 +1,3 @@
+-- import: fastn
+
+-- fastn.package: fastn-stack.github.io/text-input-test

--- a/fastn-core/fbt-tests/28-text-input-VALUE/input/actions/create-account.ftd
+++ b/fastn-core/fbt-tests/28-text-input-VALUE/input/actions/create-account.ftd
@@ -1,0 +1,1 @@
+-- string $name: name

--- a/fastn-core/fbt-tests/28-text-input-VALUE/input/index.ftd
+++ b/fastn-core/fbt-tests/28-text-input-VALUE/input/index.ftd
@@ -1,0 +1,7 @@
+-- import: fastn-stack.github.io/text-input-test/actions/create-account as ca
+
+-- ftd.text-input:
+placeholder: name
+$on-input$: $ftd.set-string($a = $ca.name, v = $VALUE)
+
+-- ftd.text: $ca.name

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727490462,
-        "narHash": "sha256-OrrPiNBiikv9BR464XTT75FzOq7tKAvMbMi7YOKVIeg=",
+        "lastModified": 1729218602,
+        "narHash": "sha256-KDmYxpkFWa0Go0WnOpkgQOypVaQxbwgpEutET5ey1VQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "11a13e50debafae4ae802f1d6b8585101516dd93",
+        "rev": "9051466c82b9b3a6ba9e06be99621ad25423ec94",
         "type": "github"
       },
       "original": {

--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -764,7 +764,9 @@ impl InterpreterState {
                         caller_module: current_module.to_string(),
                     },
                 ));
-            } else if document.foreign_function.iter().any(|v| thing_name.eq(v)) {
+            } else if document.foreign_function.iter().any(|v| thing_name.eq(v))
+                || is_special_value(name, module)
+            {
             } else if module.ne(current_module)
                 && document
                     .re_exports
@@ -1413,4 +1415,8 @@ impl<T> StateWithThing<T> {
             ftd::interpreter::StateWithThing::Thing(t) => Some(t),
         }
     }
+}
+
+fn is_special_value(name: &str, module: &str) -> bool {
+    name.strip_prefix(module) == Some(&ftd::interpreter::FTD_SPECIAL_VALUE.replace("$", "#"))
 }


### PR DESCRIPTION
This at least fixes https://github.com/fastn-stack/fastn/issues/1999:

```ftd
-- import: my-site/actions/create-account as ca

-- ftd.text-input:
placeholder: Name
$on-input$: $ftd.set-string($a = $ca.name, v = $VALUE)

-- ftd.text: $name
```

`ca.name` is defined in `actions/create-account` as:

```ftd
-- string $name: siddhant
```

We ignore the `FTD_SPECIAL_VALUE` (`VALUE`) so that it can later be
processed during the conversion to javascript phase.

https://fastn.com/text-input/ is also working after this change.