### PR TITLE
Implement `kind` Parsing with Nested Arguments in `fastn 0.5`

### DIFF
--- a/v0.5/fastn-p1/Cargo.toml
+++ b/v0.5/fastn-p1/Cargo.toml
@@ -11,5 +11,7 @@ homepage.workspace = true
 
 [dependencies]
 serde.workspace = true
+
+[dev-dependencies]
 serde_json.workspace = true
 

--- a/v0.5/fastn-p1/src/debug.rs
+++ b/v0.5/fastn-p1/src/debug.rs
@@ -149,9 +149,7 @@ impl JDebug for fastn_p1::PackageName {
 impl JDebug for fastn_p1::ModuleName {
     fn debug(&self, source: &str) -> serde_json::Value {
         if self.path.is_empty() {
-            return serde_json::json! ({
-                "package": self.package.debug(source),
-            });
+            return self.package.debug(source);
         }
 
         serde_json::json! ({

--- a/v0.5/fastn-p1/src/debug.rs
+++ b/v0.5/fastn-p1/src/debug.rs
@@ -101,7 +101,14 @@ impl JDebug for fastn_p1::Kind {
         if let Some(visibility) = &self.visibility {
             o.insert("visibility".into(), visibility.debug(source));
         }
-        o.insert("name".into(), self.name.debug(source));
+        if let Some(v) = self.to_identifier_() {
+            o.insert("name".into(), v.debug(source));
+        } else {
+            o.insert("name".into(), self.name.debug(source));
+        }
+        if let Some(args) = &self.args {
+            o.insert("args".into(), args.debug(source));
+        }
         serde_json::Value::Object(o)
     }
 }

--- a/v0.5/fastn-p1/src/debug.rs
+++ b/v0.5/fastn-p1/src/debug.rs
@@ -101,11 +101,7 @@ impl JDebug for fastn_p1::Kind {
         if let Some(visibility) = &self.visibility {
             o.insert("visibility".into(), visibility.debug(source));
         }
-        if let Some(v) = self.to_identifier_() {
-            o.insert("name".into(), v.debug(source));
-        } else {
-            o.insert("name".into(), self.name.debug(source));
-        }
+        o.insert("name".into(), self.name.debug(source));
         if let Some(args) = &self.args {
             o.insert("args".into(), args.debug(source));
         }

--- a/v0.5/fastn-p1/src/lib.rs
+++ b/v0.5/fastn-p1/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate self as fastn_p1;
 
+#[cfg(test)]
 mod debug;
 mod parser;
 mod section;

--- a/v0.5/fastn-p1/src/parser/kind.rs
+++ b/v0.5/fastn-p1/src/parser/kind.rs
@@ -52,7 +52,7 @@ pub fn kind(scanner: &mut fastn_p1::parser::Scanner) -> Option<fastn_p1::Kind> {
     Some(fastn_p1::Kind {
         name: qi,
         args: Some(args),
-        doc: None, // Documentation not parsed here
+        doc: None,        // Documentation not parsed here
         visibility: None, // Visibility not parsed here
     })
 }

--- a/v0.5/fastn-p1/src/parser/kind.rs
+++ b/v0.5/fastn-p1/src/parser/kind.rs
@@ -4,18 +4,57 @@ pub fn kind(scanner: &mut fastn_p1::parser::Scanner) -> Option<fastn_p1::Kind> {
         None => return None,
     };
 
-    let index = scanner.index();
+    // By scoping `index` here, it becomes eligible for garbage collection as soon
+    // as it’s no longer needed, reducing memory usage. This block performs a look-ahead
+    // to check for an optional `<>` part.
+    {
+        let index = scanner.index();
+        scanner.skip_spaces();
 
-    // do a look ahead to see if it has <> part
-    scanner.skip_spaces();
-
-    if !scanner.take('<') {
-        scanner.reset(index);
-        return Some(qi.into());
+        // Check if there's a `<`, indicating the start of generic arguments.
+        if !scanner.take('<') {
+            scanner.reset(index);
+            // No generics, return as simple `Kind`
+            return Some(qi.into());
+        }
     }
-    scanner.skip_spaces();
 
-    todo!()
+    scanner.skip_spaces();
+    // Parse arguments within the `<...>`
+    let mut args = Vec::new();
+
+    // Continue parsing arguments until `>` is reached
+    loop {
+        // Parse each argument as another `Kind`
+        if let Some(arg) = kind(scanner) {
+            args.push(arg);
+        } else {
+            break;
+        }
+
+        scanner.skip_spaces();
+
+        // If a `>` is found, end of arguments
+        if scanner.take('>') {
+            break;
+        }
+
+        // If a comma is expected between arguments, consume it and move to the next
+        if !scanner.take(',') {
+            // If no comma and no `>`, the syntax is invalid
+            return None;
+        }
+
+        scanner.skip_spaces();
+    }
+
+    // Return a `Kind` with the parsed `name` and `args`
+    Some(fastn_p1::Kind {
+        name: qi,
+        args: Some(args),
+        doc: None, // Documentation not parsed here
+        visibility: None, // Visibility not parsed here
+    })
 }
 
 #[cfg(test)]
@@ -25,36 +64,30 @@ mod test {
     #[test]
     fn kind() {
         t!("string", "string");
+        t!("list<string>", {"name": "list", "args": ["string"]});
+        t!("foo<a, b>", {"name": "foo", "args": ["a", "b"]});
+        t!("foo<bar<k>>", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]});
+        t!(
+            "foo<a, b<asd>, c, d>",
+            {
+                "name": "foo",
+                "args": [
+                    "a",
+                    {"name": "b", "args": ["asd"]},
+                    "c",
+                    "d"
+                ]
+            }
+        );
+        t!(
+            "foo<a, b, c, d, e>",
+            {
+                "name": "foo",
+                "args": ["a","b","c","d","e"]
+            }
+        );
 
-        // t!("list<string>", {"name": "list", "args": [{"name": "string"}]}, "");
-        // t!("foo<a, b>", {"name": "foo", "args": [{"name": "a"},{"name": "b"}]}, "");
-        // t!("foo<bar<k>>", {"name": "foo", "args": [{"name": "bar", "args": [{"name": "k"}]}]}, "");
-        // t!(
-        //     "foo<a, b<asd>, c, d>",
-        //     {
-        //         "name": "foo",
-        //         "args": [
-        //             {"name": "a"},
-        //             {"name": "b", "args": [{"name": "asd"}]},
-        //             {"name": "c"},
-        //             {"name": "d"}
-        //         ]
-        //     },
-        //     ""
-        // );
-        // t!(
-        //     "foo<a, b, c, d, e>",
-        //     {
-        //         "name": "foo",
-        //         "args": [
-        //             {"name": "a"},
-        //             {"name": "b"},
-        //             {"name": "c"},
-        //             {"name": "d"},
-        //             {"name": "e"}
-        //         ]
-        //     },
-        //     ""
-        // );
+        t!("foo<bar<k>> ", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]}, " ");
+        t!("foo<bar<k>>  moo", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]}, "  moo");
     }
 }

--- a/v0.5/fastn-p1/src/parser/kind.rs
+++ b/v0.5/fastn-p1/src/parser/kind.rs
@@ -64,16 +64,19 @@ mod test {
     #[test]
     fn kind() {
         t!("string", "string");
-        t!("list<string>", {"name": "list", "args": ["string"]});
-        t!("foo<a, b>", {"name": "foo", "args": ["a", "b"]});
-        t!("foo<bar<k>>", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]});
+        t!("list<string>", {"name": {"module": "list"}, "args": ["string"]});
+        t!("foo<a, b>", {"name": {"module": "foo"}, "args": ["a", "b"]});
+        t!(
+            "foo<bar<k>>",
+            {"name": {"module": "foo"}, "args": [{"name": {"module": "bar"}, "args": ["k"]}]}
+        );
         t!(
             "foo<a, b<asd>, c, d>",
             {
-                "name": "foo",
+                "name": {"module": "foo"},
                 "args": [
                     "a",
-                    {"name": "b", "args": ["asd"]},
+                    {"name": {"module": "b"}, "args": ["asd"]},
                     "c",
                     "d"
                 ]
@@ -82,12 +85,20 @@ mod test {
         t!(
             "foo<a, b, c, d, e>",
             {
-                "name": "foo",
+                "name": {"module": "foo"},
                 "args": ["a","b","c","d","e"]
             }
         );
 
-        t!("foo<bar<k>> ", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]}, " ");
-        t!("foo<bar<k>>  moo", {"name": "foo", "args": [{"name": "bar", "args": ["k"]}]}, "  moo");
+        t!(
+            "foo<bar<k>> ",
+            {"name": {"module": "foo"}, "args": [{"name": {"module": "bar"}, "args": ["k"]}]},
+            " "
+        );
+        t!(
+            "foo<bar<k>>  moo",
+            {"name": {"module": "foo"}, "args": [{"name": {"module": "bar"}, "args": ["k"]}]},
+            "  moo"
+        );
     }
 }

--- a/v0.5/fastn-p1/src/parser/module_name.rs
+++ b/v0.5/fastn-p1/src/parser/module_name.rs
@@ -31,7 +31,7 @@ mod test {
 
     #[test]
     fn module_name() {
-        t!("foo.com", {"package":"foo.com"});
+        t!("foo.com", "foo.com");
         t!("foo.com/", null);
         t!("foo.com/ ", null, " ");
         t!("foo.com/asd", {"package":"foo.com", "path": ["asd"]});

--- a/v0.5/fastn-p1/src/parser/qualified_identifier.rs
+++ b/v0.5/fastn-p1/src/parser/qualified_identifier.rs
@@ -37,7 +37,8 @@ mod test {
 
     #[test]
     fn qualified_identifier() {
-        t!("foo", { "module": { "package": "foo"}});
+        t!("foo", {"module": {"package": "foo"}});
+        // t!("foo", {"module": "foo"});
         t!("foo.com#bar", { "module": { "package": "foo.com"}, "terms": ["bar"]});
         t!("foo.com#bar.baz", { "module": { "package": "foo.com"}, "terms": ["bar", "baz"]});
         t!(

--- a/v0.5/fastn-p1/src/parser/qualified_identifier.rs
+++ b/v0.5/fastn-p1/src/parser/qualified_identifier.rs
@@ -37,10 +37,10 @@ mod test {
 
     #[test]
     fn qualified_identifier() {
-        t!("foo", {"module": {"package": "foo"}});
+        t!("foo", {"module": "foo"});
         // t!("foo", {"module": "foo"});
-        t!("foo.com#bar", { "module": { "package": "foo.com"}, "terms": ["bar"]});
-        t!("foo.com#bar.baz", { "module": { "package": "foo.com"}, "terms": ["bar", "baz"]});
+        t!("foo.com#bar", { "module": "foo.com", "terms": ["bar"]});
+        t!("foo.com#bar.baz", { "module": "foo.com", "terms": ["bar", "baz"]});
         t!(
             "foo.com/yo#bar.baz",
             {"module": { "package": "foo.com", "path": ["yo"]}, "terms": ["bar", "baz"]},

--- a/v0.5/fastn-p1/src/utils.rs
+++ b/v0.5/fastn-p1/src/utils.rs
@@ -81,6 +81,10 @@ impl fastn_p1::Kind {
             return None;
         }
 
+        self.to_identifier_()
+    }
+
+    pub fn to_identifier_(&self) -> Option<fastn_p1::Identifier> {
         let m = self.name.module.as_ref()?;
         if !m.path.is_empty() {
             return None;

--- a/v0.5/fastn-p1/src/utils.rs
+++ b/v0.5/fastn-p1/src/utils.rs
@@ -81,10 +81,6 @@ impl fastn_p1::Kind {
             return None;
         }
 
-        self.to_identifier_()
-    }
-
-    pub fn to_identifier_(&self) -> Option<fastn_p1::Identifier> {
         let m = self.name.module.as_ref()?;
         if !m.path.is_empty() {
             return None;


### PR DESCRIPTION
This PR finalizes the implementation of the `kind` function by fully implementing optional arguments parsing within the `Kind` structure. With this update, `kind` can now handle complex type-like structures with optional nested arguments enclosed in angle brackets (`<>`).

## Background and Previously Implemented Features

- **Qualified Identifier Parsing:**
The `kind` function initially parses a qualified identifier as the primary name of the `Kind` object.

- **Look-Ahead for Optional Arguments:**
After parsing the identifier, the function performs a look-ahead check for `<`. If `<` is not present, `kind` returns immediately with only the identifier as name, signaling that there are no arguments.

## Key Changes Introduced in this PR

- **Recursive Argument Parsing:**
  - If `<` is found, `kind` enters an argument parsing loop:
    - Parses each argument recursively as a `Kind`, allowing for nested types (e.g., `foo<bar<a>>`).
    - Separates arguments by commas `,` and terminates when a closing `>` is encountered, marking the end of the argument list.

- **Constructing the Kind Object:**
Constructs a `Kind` object with both `name` and `args` (if present).

## Example Cases

`foo<bar<k>>` ->
```json
{"name": {"module": "foo"}, "args": [{"name": {"module": "bar"}, "args": ["k"]}]}
```

`foo<a, b>` -> 
```json
{"name": {"module": "foo"}, "args": ["a", "b"]}
```

`foo<a, b<asd>, c, d>` ->
```json
{
    "name": {"module": "foo"},
    "args": [
        "a",
        {"name": {"module": "b"}, "args": ["asd"]},
        "c",
        "d"
    ]
}
```

