### PR TITLE
Fix(CI): use `fastn` bin in $PATH

### DIFF
--- a/.github/workflows/deploy-fastn-com.yml
+++ b/.github/workflows/deploy-fastn-com.yml
@@ -17,5 +17,5 @@ jobs:
       - run: source <(curl -fsSL https://fastn.com/install.sh)
       - run: |
           cd fastn.com
-          echo "Using $(~/.fastn/bin/fastn --version) to upload fastn.com to FifthTry"
-          ~/.fastn/bin/fastn upload fastn >> $GITHUB_STEP_SUMMARY
+          echo "Using $(fastn --version) to upload fastn.com to FifthTry"
+          fastn upload fastn >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/optimize-imgs.yml
+++ b/.github/workflows/optimize-imgs.yml
@@ -24,7 +24,7 @@ jobs:
           compressOnly: true # don't make a commit!
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           title: Compressed Images
           branch-suffix: timestamp


### PR DESCRIPTION
- Fix `fastn` binary path.

- @amitu has to do the following to make `.github/workflows/optimize-imgs.yml` work.
 
    From [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request):
    > For this action to work you must explicitly allow GitHub Actions to create pull requests. This setting can be found in a repository's settings under Actions > General > Workflow permissions.

    > For repositories belonging to an organization, this setting can be managed by admins in organization settings under Actions > General > Workflow permissions.


- Update `peter-evans/create-pull-request` to v7.
