### PR TITLE
Use `actions/checkout@v4` everywhere

### DIFF
--- a/.github/workflows/cue.yml
+++ b/.github/workflows/cue.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/deploy-fastn-com.yml
+++ b/.github/workflows/deploy-fastn-com.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: source <(curl -fsSL https://fastn.com/install.sh)
       - run: |
           cd fastn.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: FranzDiebold/github-env-vars-action@v2
       - name: Running examples
         id: run_examples
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Prepare `build` branch creation
         id: clone_main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check if `build` branch exists
         id: branch_exists
         continue-on-error: true
@@ -53,7 +53,7 @@ jobs:
           git commit --allow-empty -m "Initializing build branch"
           git push origin build
       - name: Checkout build branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.branch_exists.outcome == 'success'
         with:
           ref: build

--- a/.github/workflows/optimize-imgs.yml
+++ b/.github/workflows/optimize-imgs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       FASTN_ENABLE_EMAIL: false
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       #      - name: Set up cargo cache
       #        uses: actions/cache@v3 # there is also https://github.com/Swatinem/rust-cache
       #        continue-on-error: false


### PR DESCRIPTION
The v4 uses the latest nodejs runtime so github won't give warnings of
using old nodejs versions.
