### PR TITLE
Fix(CI): filter paths in test-and-formatting workflow

### DIFF
--- a/.github/workflows/tests-and-formatting.yml
+++ b/.github/workflows/tests-and-formatting.yml
@@ -13,10 +13,10 @@ on:
       - '**.html'
       - '**.js'
       - '**.css'
-      - '!t/' # We use this for playground
-      - '!fastn.com/'
-      - '!v0.5/' # TODO: remove this when we're ready to release v0.5
-      - '!.github/'
+      - '!t/**' # We use this for playground
+      - '!fastn.com/**'
+      - '!v0.5/**' # TODO: remove this when we're ready to release v0.5
+      - '!.github/**'
       - '.github/workflows/tests-and-formatting.yml'
   pull_request:
     branches: [ main ]
@@ -29,10 +29,10 @@ on:
       - '**.html'
       - '**.js'
       - '**.css'
-      - '!t/' # We use this for playground
-      - '!fastn.com/'
-      - '!v0.5/' # TODO: remove this when we're ready to release v0.5
-      - '!.github/'
+      - '!t/**' # We use this for playground
+      - '!fastn.com/**'
+      - '!v0.5/**' # TODO: remove this when we're ready to release v0.5
+      - '!.github/**'
       - '.github/workflows/tests-and-formatting.yml'
 jobs:
   tests-and-formatting:


### PR DESCRIPTION
It should ignore the subfolders now.