### PR TITLE
Fix: Unescape existing sequence of '\' and '"` before escaping strings

### DIFF
--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -216,7 +216,13 @@ impl Value {
     pub(crate) fn to_js(&self, element_name: &Option<String>) -> String {
         use itertools::Itertools;
         match self {
-            Value::String(s) => format!("\"{}\"", s.replace('\n', "\\n").replace('\"', "\\\"")),
+            Value::String(s) => {
+                let s = s
+                    .replace('\n', "\\n") // escape new line character
+                    .replace(r#"\""#, "\"") // unescape an already escaped seq
+                    .replace('\"', "\\\""); // escape " (quote)
+                format!("\"{}\"", s)
+            }
             Value::Integer(i) => i.to_string(),
             Value::Decimal(f) => f.to_string(),
             Value::Boolean(b) => b.to_string(),

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729218602,
-        "narHash": "sha256-KDmYxpkFWa0Go0WnOpkgQOypVaQxbwgpEutET5ey1VQ=",
+        "lastModified": 1735007320,
+        "narHash": "sha256-NdhUgB9BkLGW9I+Q1GyUUCc3CbDgsg7HLWjG7WZBR5Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9051466c82b9b3a6ba9e06be99621ad25423ec94",
+        "rev": "fb5fdba697ee9a2391ca9ceea3b853b4e3ce37a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The following ftd code will not work with `fastn serve` today:

```
;; Notice the escaped part!
-- string t1: My name is \"Siddhant\"

-- ftd.text: $t1
```

Now `fastn` strings do not require an enclosing `""` so escaping quotes is not really necessary. The following code will work (and it's one of the benefits of fastn strings):

```ftd
;; Notice the first `height` and `width` values are escaped!
-- string t1: My name is "Siddhant"

-- ftd.text: $t1
```

The problem comes when this string comes from a network request (a json response for example), where this is already escaped. Fastn should support escaped `"`s so that such strings also work. www.fifthtry.com history pages fail to load today because we try to render an escaped string.