### PR TITLE
Export `WasmError` and `handle` from v0.5/fastn-wasm

### DIFF
--- a/v0.5/fastn-wasm/src/lib.rs
+++ b/v0.5/fastn-wasm/src/lib.rs
@@ -17,7 +17,7 @@ pub(crate) mod register;
 mod sqlite;
 mod store;
 
-pub use process_http_request::process_http_request;
+pub use process_http_request::{process_http_request, WasmError, handle};
 pub(crate) use store::Conn;
 pub use store::{ConnectionExt, SQLError, Store, StoreExt, StoreImpl};
 


### PR DESCRIPTION
These exported names are needed when the latest fastn is used in FifthTry's servers.