### PR TITLE
Implicitly load `.wasm` modules from mounted apps

### DIFF
--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -538,13 +538,12 @@ async fn handle_endpoints(
                 app.mount_point
             );
 
-            let wasm_file = 
-                req
-                    .path()
-                    .trim_start_matches(&app.mount_point)
-                    .split_once('/')
-                    .unwrap_or_default()
-                    .0;
+            let wasm_file = req
+                .path()
+                .trim_start_matches(&app.mount_point)
+                .split_once('/')
+                .unwrap_or_default()
+                .0;
 
             let wasm_path = format!(
                 ".packages/{dep_name}/{wasm_file}.wasm",
@@ -553,7 +552,11 @@ async fn handle_endpoints(
 
             tracing::info!("checking for wasm file: {}", wasm_path);
 
-            if !config.ds.exists(&fastn_ds::Path::new(&wasm_path), session_id).await {
+            if !config
+                .ds
+                .exists(&fastn_ds::Path::new(&wasm_path), session_id)
+                .await
+            {
                 tracing::info!("wasm file not found: {}", wasm_path);
                 tracing::info!("Exiting from handle_endpoints");
                 return None;
@@ -562,8 +565,11 @@ async fn handle_endpoints(
             tracing::info!("wasm file found: {}", wasm_path);
 
             &fastn_package::old_fastn::EndpointData {
-                endpoint:  format!("wasm+proxy://{wasm_path}"),
-                mountpoint:  format!("{app}/{wasm_file}", app = app.mount_point.trim_end_matches('/')),
+                endpoint: format!("wasm+proxy://{wasm_path}"),
+                mountpoint: format!(
+                    "{app}/{wasm_file}",
+                    app = app.mount_point.trim_end_matches('/')
+                ),
                 user_id: None, // idk if we're using this
             }
         }

--- a/fastn-core/src/commands/serve.rs
+++ b/fastn-core/src/commands/serve.rs
@@ -13,7 +13,7 @@ fn handle_redirect(
 
 /// path: /-/<package-name>/<file-name>/
 /// path: /<file-name>/
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip(config))]
 async fn serve_file(
     config: &mut fastn_core::RequestConfig,
     path: &camino::Utf8Path,
@@ -56,6 +56,8 @@ async fn serve_file(
             };
         }
     };
+
+    tracing::info!("file: {f:?}");
 
     if let fastn_core::File::Code(doc) = f {
         let path = doc.get_full_path().to_string();
@@ -250,6 +252,8 @@ pub async fn serve_helper(
                     )
                 };
 
+                tracing::info!("redirecting to mount-point: {}, path: {}", mp, path);
+
                 let mut resp =
                     actix_web::HttpResponse::new(actix_web::http::StatusCode::PERMANENT_REDIRECT);
                 resp.headers_mut().insert(
@@ -309,6 +313,7 @@ fn shared_to_http(r: ft_sys_shared::Request) -> fastn_core::Result<fastn_core::h
     Ok(resp)
 }
 
+#[tracing::instrument(skip_all)]
 pub fn handle_default_route(
     req: &fastn_core::http::Request,
     package_name: &str,
@@ -382,6 +387,7 @@ pub fn handle_default_route(
     None
 }
 
+#[tracing::instrument(skip_all)]
 async fn handle_static_route(
     path: &str,
     package_name: &str,
@@ -495,6 +501,7 @@ async fn handle_static_route(
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn handle_endpoints(
     config: &fastn_core::Config,
     req: &fastn_core::http::Request,

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -74,6 +74,7 @@ impl RequestConfig {
         self.config.package.selected_language.clone()
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn new(
         config: &Config,
         request: &fastn_core::http::Request,
@@ -180,7 +181,11 @@ impl RequestConfig {
                 (path_with_package_name, document, path_params, extra_data)
             };
 
+
         let path = path_with_package_name.as_str();
+
+        tracing::info!("resolved path: {path}");
+        tracing::info!("document: {document:?}, path_params: {path_params:?}, extra_data: {extra_data:?}");
 
         if let Some(id) = document {
             let file_name = self
@@ -723,6 +728,7 @@ impl Config {
         ))
     }
 
+    #[tracing::instrument(skip(self))]
     pub(crate) async fn get_file_path_and_resolve(
         &self,
         id: &str,
@@ -731,6 +737,7 @@ impl Config {
         Ok(self.get_file_and_resolve(id, session_id).await?.0)
     }
 
+    #[tracing::instrument(skip(self))]
     pub(crate) async fn get_file_and_resolve(
         &self,
         id: &str,
@@ -766,6 +773,9 @@ impl Config {
         let (file_name, content) = package
             .resolve_by_id(id, None, self.package.name.as_str(), &self.ds, session_id)
             .await?;
+
+        tracing::info!("file: {file_name}");
+
         Ok((format!("{}{}", add_packages, file_name), content))
     }
 

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -181,11 +181,12 @@ impl RequestConfig {
                 (path_with_package_name, document, path_params, extra_data)
             };
 
-
         let path = path_with_package_name.as_str();
 
         tracing::info!("resolved path: {path}");
-        tracing::info!("document: {document:?}, path_params: {path_params:?}, extra_data: {extra_data:?}");
+        tracing::info!(
+            "document: {document:?}, path_params: {path_params:?}, extra_data: {extra_data:?}"
+        );
 
         if let Some(id) = document {
             let file_name = self

--- a/fastn-core/src/config/utils.rs
+++ b/fastn-core/src/config/utils.rs
@@ -35,6 +35,7 @@ pub async fn fastn_doc(
 
 // if path starts with /-/package-name or -/package-name,
 // so it trims the package and return the remaining url
+#[tracing::instrument]
 pub fn trim_package_name(path: &str, package_name: &str) -> Option<String> {
     let package_name1 = format!("-/{}", package_name.trim().trim_matches('/'));
     let path = path.trim().trim_start_matches('/');

--- a/fastn-core/src/package/package_doc.rs
+++ b/fastn-core/src/package/package_doc.rs
@@ -275,6 +275,7 @@ impl fastn_core::Package {
                 }
             } else {
                 for name in file_id_to_names(id) {
+                    tracing::info!("attempting non static file: {}", name);
                     if let Ok(data) = self
                         .fs_fetch_by_file_name(name.as_str(), package_root, ds, session_id)
                         .await
@@ -285,6 +286,7 @@ impl fastn_core::Package {
             }
         }
 
+        tracing::info!("resolve_by_id: not found in the package. Trying fs_fetch_by_id");
         self.fs_fetch_by_id(id, package_root, ds, session_id).await
     }
 }

--- a/fastn-core/src/utils.rs
+++ b/fastn-core/src/utils.rs
@@ -1020,6 +1020,7 @@ pub fn ignore_headers() -> Vec<&'static str> {
     vec!["host", "x-forwarded-ssl"]
 }
 
+#[tracing::instrument]
 pub(crate) fn is_static_path(path: &str) -> bool {
     assert!(path.starts_with('/'));
 

--- a/fastn-ds/src/lib.rs
+++ b/fastn-ds/src/lib.rs
@@ -147,7 +147,7 @@ pub enum HttpError {
 pub type HttpResponse = ::http::Response<bytes::Bytes>;
 
 #[async_trait::async_trait]
-pub trait RequestType {
+pub trait RequestType: std::fmt::Debug {
     fn headers(&self) -> &reqwest::header::HeaderMap;
     fn method(&self) -> &str;
     fn query_string(&self) -> &str;
@@ -457,6 +457,7 @@ impl DocumentStore {
         std::env::var(key).map_err(|_| EnvironmentError::NotSet(key.to_string()))
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn handle_wasm<T>(
         &self,
         wasm_url: String,

--- a/fastn.com/FASTN.ftd
+++ b/fastn.com/FASTN.ftd
@@ -678,6 +678,10 @@ skip: true
 - Endpoint Guide 🚧: /endpoint/
   document: backend/endpoint.ftd
   skip: true
+- `fastn.app`: /app/
+  document: backend/app.ftd
+- WASM modules: /wasm/
+  document: backend/wasm.ftd
 - Dynamic URLs: /dynamic-urls/
   document: backend/dynamic-urls.ftd
 - `processors`: /processor/-/backend/

--- a/fastn.com/backend/app.ftd
+++ b/fastn.com/backend/app.ftd
@@ -1,0 +1,19 @@
+-- ds.page: Fastn app
+
+`-- fastn.app` allows you to mount a fastn package at some url of your fastn package.
+
+-- ds.code: FASTN.ftd
+lang: ftd
+
+\-- fastn.app: Auth App
+mount-point: /-/auth/
+package: lets-auth.fifthtry.site
+
+
+-- ds.markdown:
+
+The above snippet will mount contents of [lets-auth.fifthtry.site](https://lets-auth.fifthtry-community.com/) at the base url (`/-/auth/`) of your app.
+
+Visiting `/-/auth/` will load `index.ftd` of lets-auth.fifthtry.site if it's available.
+
+-- end: ds.page

--- a/fastn.com/backend/app.ftd
+++ b/fastn.com/backend/app.ftd
@@ -1,4 +1,4 @@
--- ds.page: Fastn app
+-- ds.page: `fastn` app
 
 `-- fastn.app` allows you to mount a fastn package at some url of your fastn package.
 

--- a/fastn.com/backend/env-vars.ftd
+++ b/fastn.com/backend/env-vars.ftd
@@ -45,10 +45,6 @@ FASTN_DANGER_ACCEPT_CHECKED_IN_ENV=true fastn serve
 
 -- fastn-check-for-updates:
 
--- ds.h2: Auth variables
-
--- fastn-auth-variables:
-
 -- end: ds.page
 
 
@@ -158,15 +154,6 @@ $env-doc.content
 -- end: ftd.column
 
 -- end: fastn-pg-variables
-
--- component fastn-auth-variables:
-
--- ftd.column:
-	-- fastn-github-client-id:
-	-- fastn-github-client-secret:
--- end: ftd.column
-
--- end: fastn-auth-variables
 
 -- component fastn-github-client-id:
 

--- a/fastn.com/backend/wasm.ftd
+++ b/fastn.com/backend/wasm.ftd
@@ -1,12 +1,12 @@
--- ds.page: WASM backends with [ft-sdk](https://github.com/fastn-stack/ft-sdk/)
+-- ds.page: WASM backends with `ft-sdk`
 
-[ft-sdk](https://github.com/fastn-stack/ft-sdk/) is a rust crate that can be
-used to write backend HTTP handlers. You can then compile your rust code into a
+[`ft-sdk`](https://github.com/fastn-stack/ft-sdk/) is a Rust crate that can be
+used to write backend HTTP handlers. You can then compile your Rust code into a
 webassembly module (`.wasm` file) that can be used with fastn.
 
 Visit https://github.com/fastn-stack/ft-sdk/tree/main/examples/ to see some
 examples on how to write backend code using `ft-sdk`. You also have access to
-[`diesel`](http://diesel.rs/) a popular rust database query builder.
+[`diesel`](http://diesel.rs/) a popular Rust database query builder.
 
 Once compiled, place the `.wasm` file in the root of your fastn
 package and then put the following in your `FASTN.ftd`

--- a/fastn.com/backend/wasm.ftd
+++ b/fastn.com/backend/wasm.ftd
@@ -1,0 +1,42 @@
+-- ds.page: WASM backends with [ft-sdk](https://github.com/fastn-stack/ft-sdk/)
+
+[ft-sdk](https://github.com/fastn-stack/ft-sdk/) is a rust crate that can be
+used to write backend HTTP handlers. You can then compile your rust code into a
+webassembly module (`.wasm` file) that can be used with fastn.
+
+Visit https://github.com/fastn-stack/ft-sdk/tree/main/examples/ to see some
+examples on how to write backend code using `ft-sdk`. You also have access to
+[`diesel`](http://diesel.rs/) a popular rust database query builder.
+
+Once compiled, place the `.wasm` file in the root of your fastn
+package and then put the following in your `FASTN.ftd`
+
+-- ds.code: FASTN.ftd
+lang: ftd
+
+\-- fastn.url-mappings:
+
+;; Assuming your compiled file name is `backend.wasm` and it's on the same
+;; level as your FASTN.ftd in the filesystem
+/backend/* -> wasm+proxy://backend.wasm/*
+
+
+-- ds.h3: WASM modules in [`fastn.app`](/app/)
+
+`fastn` automatically loads `.wasm` files if they exist for a particular
+request. For example, for the following FASTN.ftd configuration:
+
+-- ds.code: FASTN.ftd
+lang: ftd
+
+\-- fastn.app: Auth App
+mount-point: /-/auth/
+package: lets-auth.fifthtry.site
+
+-- ds.markdown:
+
+A request coming on `/-/auth/api/create-account/` will be forwared to the
+`api.wasm` file of `lets-auth.fifthtry.site` if it exists (in it's root
+directory).
+
+-- end: ds.page


### PR DESCRIPTION
```ftd
-- fastn.app: Auth App
mount-point: /-/auth/
package: lets-auth.fifthtry.site
```

For the above configuration in a FASTN.ftd file. We allow the mounted app package to place some `.wasm` modules in its root directory.

So if the request is coming for: `/-/auth/api/*` and there is a "api.wasm" in the root of `lets-auth.fifthtry.site` then the request will be handled as if there was a wasm endpoint configured:

```ftd
-- fastn.url-mappings:

/-/auth/api/* -> wasm+proxy://.packages/lets-auth.fifthtry.site/api.wasm/*
```

That is, a request for `/-/auth/api/*`, will be handled by the `lets-auth.fifthtry.site/api.wasm` if it exists.

If the `.wasm` module does not exist then the typical flow of loading app's .ftd file is followed. This means that precedence is given to .wasm if it exists.