### PR TITLE
`ftd.app-path` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.81"
+version = "0.4.82"
 dependencies = [
  "actix-web",
  "camino",

--- a/fastn-core/fbt-tests/02-hello/output/index.html
+++ b/fastn-core/fbt-tests/02-hello/output/index.html
@@ -788,6 +788,12 @@ a.value = v
 }
 
 
+
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
 window.node_change_main = {};
 window.node_change_main["document__title"] = function(data) {
 if(function(){

--- a/fastn-core/fbt-tests/03-nested-document/output/index.html
+++ b/fastn-core/fbt-tests/03-nested-document/output/index.html
@@ -745,6 +745,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/03-nested-document/output/nested/document/index.html
+++ b/fastn-core/fbt-tests/03-nested-document/output/nested/document/index.html
@@ -745,6 +745,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/03-nested-document/output/nested/index.html
+++ b/fastn-core/fbt-tests/03-nested-document/output/nested/index.html
@@ -745,6 +745,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/04-import-code-block/output/index.html
+++ b/fastn-core/fbt-tests/04-import-code-block/output/index.html
@@ -746,6 +746,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/04-import-code-block/output/lib/index.html
+++ b/fastn-core/fbt-tests/04-import-code-block/output/lib/index.html
@@ -745,6 +745,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/05-hello-font/output/index.html
+++ b/fastn-core/fbt-tests/05-hello-font/output/index.html
@@ -785,6 +785,12 @@ a.value = v
 }
 
 
+
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
 window.node_change_main = {};
 window.node_change_main["2:main__src"] = function(data) {
 if(!data["ftd#dark-mode"]){

--- a/fastn-core/fbt-tests/08-static-assets/output/index.html
+++ b/fastn-core/fbt-tests/08-static-assets/output/index.html
@@ -360,6 +360,17 @@ td {
   }
 }
 global["main"] = main;
+ftd.app_path = function (args) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "www_amitu_com";
+  try {
+    let __args__ = fastn_utils.getArgs({
+    }, args);
+    return ("" + fastn_utils.getStaticValue(__args__.path));
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
 fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "code-theme-9A3284FD117DFF7CFD432FF860A5E14169FA592BC3DA4F5E8A6975143F5EA07F.css";
 fastn_dom.codeData.availableThemes["coldark-theme.light"] = "code-theme-99CD7B013C96C4632F0AEA39AC265387B814AE85A7D33666A4AE4BEFF59016D0.css";
 fastn_dom.codeData.availableThemes["coy-theme"] = "code-theme-B3AEA322EADEDA61F0E219845A0E9C8E73F6345E49362B46E6F52CEE40471248.css";

--- a/fastn-core/fbt-tests/08-static-assets/output/manifest.json
+++ b/fastn-core/fbt-tests/08-static-assets/output/manifest.json
@@ -12,15 +12,15 @@
     },
     "scrot.png": {
       "name": "scrot.png",
-      "checksum": "1FDAA73B267106322D6F1FA8BB404F20B4A0579B132379F86747DB91CC6CC55C",
-      "size": 321328
+      "checksum": "1F886288F2E5D0B1657A0691A842575844944334FB942772A130A2F0258B0C2D",
+      "size": 470661
     },
     "static/scrot_2.png": {
       "name": "static/scrot_2.png",
-      "checksum": "1FDAA73B267106322D6F1FA8BB404F20B4A0579B132379F86747DB91CC6CC55C",
-      "size": 321328
+      "checksum": "1F886288F2E5D0B1657A0691A842575844944334FB942772A130A2F0258B0C2D",
+      "size": 470661
     }
   },
   "zip_url": "https://codeload.github.com/amitu/dotcom/zip/refs/heads/main",
-  "checksum": "ABB31FACCE1DAE2FEAE73D4E75BF9913CCABE5BACA06E37258D631793B4972AD"
+  "checksum": "04F1686B70EA1F7F1AC455D13F71F6C6B00E2AA897E561606CFE843333A6B03E"
 }

--- a/fastn-core/fbt-tests/09-markdown-pages/output/index.html
+++ b/fastn-core/fbt-tests/09-markdown-pages/output/index.html
@@ -360,6 +360,17 @@ td {
   }
 }
 global["main"] = main;
+ftd.app_path = function (args) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "amitu";
+  try {
+    let __args__ = fastn_utils.getArgs({
+    }, args);
+    return ("" + fastn_utils.getStaticValue(__args__.path));
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
 fastn_dom.codeData.availableThemes["coldark-theme.dark"] = "code-theme-9A3284FD117DFF7CFD432FF860A5E14169FA592BC3DA4F5E8A6975143F5EA07F.css";
 fastn_dom.codeData.availableThemes["coldark-theme.light"] = "code-theme-99CD7B013C96C4632F0AEA39AC265387B814AE85A7D33666A4AE4BEFF59016D0.css";
 fastn_dom.codeData.availableThemes["coy-theme"] = "code-theme-B3AEA322EADEDA61F0E219845A0E9C8E73F6345E49362B46E6F52CEE40471248.css";

--- a/fastn-core/fbt-tests/09-markdown-pages/output/manifest.json
+++ b/fastn-core/fbt-tests/09-markdown-pages/output/manifest.json
@@ -17,10 +17,10 @@
     },
     "scrot.png": {
       "name": "scrot.png",
-      "checksum": "1FDAA73B267106322D6F1FA8BB404F20B4A0579B132379F86747DB91CC6CC55C",
-      "size": 321328
+      "checksum": "1F886288F2E5D0B1657A0691A842575844944334FB942772A130A2F0258B0C2D",
+      "size": 470661
     }
   },
   "zip_url": "https://codeload.github.com/amitu/dotcom/zip/refs/heads/main",
-  "checksum": "4A1B247A1BB66B9C926F832768B66FE7DCE3BD7B75A9BF344CB50F28D74E6947"
+  "checksum": "99F068067033DC51A872095AF65499D7A79BD06EAF1278CDEDEDE39992D88B2A"
 }

--- a/fastn-core/fbt-tests/11-readme-with-index/output/index.html
+++ b/fastn-core/fbt-tests/11-readme-with-index/output/index.html
@@ -745,6 +745,12 @@ a.value = v
 
 
 
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
+
 
 
 

--- a/fastn-core/fbt-tests/15-fpm-dependency-alias/output/index.html
+++ b/fastn-core/fbt-tests/15-fpm-dependency-alias/output/index.html
@@ -638,17 +638,6 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
 @font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 font-style: normal;
 font-weight: 100;
@@ -964,6 +953,866 @@ font-style: normal;
 font-weight: 900;
 src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-latin.woff2) format('woff2');
 font-family: fastn-community-github-io-inter-font-Inter }
+
+
+
+
+
+
+
+
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-roboto-font-Roboto }
+
+
+
+
+
+
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: italic;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-roboto-font-Roboto }
+
+
+
+
+
+
 
 @font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 font-style: italic;
@@ -1547,9 +2396,6 @@ font-family: fastn-community-github-io-opensans-font-Open-Sans }
 
 
 
-
-
-
 @font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 font-style: normal;
 font-weight: 100;
@@ -1867,852 +2713,6 @@ src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-latin.woff2) fo
 font-family: fifthtry-github-io-inter-font-Inter }
 
 
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-italic-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-100-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-300-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-400-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-500-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-700-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/roboto-font/static/Roboto-900-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-roboto-font-Roboto }
-
-
-
-
-
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: italic;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-italic-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-100-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-300-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-400-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-500-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-700-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/roboto-font/static/Roboto-900-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-roboto-font-Roboto }
-
 
 </style>
 <script>
@@ -2864,6 +2864,12 @@ a.value = v
 
 function ftd__set_integer___main(a,v,args,data,id){
 a.value = v
+}
+
+
+
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
 }
 
 

--- a/fastn-core/fbt-tests/16-include-processor/output/index.html
+++ b/fastn-core/fbt-tests/16-include-processor/output/index.html
@@ -745,6 +745,12 @@ a.value = v
 }
 
 
+
+function ftd__app_path___main(path,args,data,id){
+return (""+path);
+}
+
+
 window.node_change_main = {};
 window.node_change_main["0:main__text"] = function(data) {
 document.querySelector(`[data-id="0:main"]`).innerHTML = resolve_reference("fifthtry.github.io/amitu#document-id", data);

--- a/fastn-core/fbt-tests/19-offline-build/output/index.html
+++ b/fastn-core/fbt-tests/19-offline-build/output/index.html
@@ -420,646 +420,6 @@ td {
 
 
 
-
-
-
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 100;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 200;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 300;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 400;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 500;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 600;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 700;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 800;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-cyrillic.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-greek-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-greek.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-vietnamese.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-latin-ext.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 900;
-src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-latin.woff2) format('woff2');
-font-family: fifthtry-github-io-inter-font-Inter }
-
-
-
-
-
-
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 100;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 200;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 300;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 400;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 500;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 600;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 700;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 800;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-cyrillic-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-cyrillic.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+1F00-1FFF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-greek-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0370-03FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-greek.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-vietnamese.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-latin-ext.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-font-style: normal;
-font-weight: 900;
-src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-latin.woff2) format('woff2');
-font-family: fastn-community-github-io-inter-font-Inter }
-
 @font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 font-style: italic;
 font-weight: 100;
@@ -1487,7 +847,646 @@ font-family: fastn-community-github-io-roboto-font-Roboto }
 
 
 
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 100;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-100-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 200;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-200-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 300;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-300-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 400;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-400-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 500;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-500-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 600;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-600-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 700;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-700-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 800;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-800-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-cyrillic.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-greek-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-greek.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-vietnamese.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-latin-ext.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 900;
+src: url(-/fifthtry.github.io/inter-font/static/Inter-900-normal-latin.woff2) format('woff2');
+font-family: fifthtry-github-io-inter-font-Inter }
 
+
+
+
+
+
+
+
+
+
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 100;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-100-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 200;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-200-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 300;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-300-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 400;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-400-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 500;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-500-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 600;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-600-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 700;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-700-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 800;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-800-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-cyrillic-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-cyrillic.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+1F00-1FFF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-greek-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0370-03FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-greek.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-vietnamese.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-latin-ext.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
+@font-face { unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+font-style: normal;
+font-weight: 900;
+src: url(-/fastn-community.github.io/inter-font/static/Inter-900-normal-latin.woff2) format('woff2');
+font-family: fastn-community-github-io-inter-font-Inter }
 
 @font-face { unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 font-style: italic;
@@ -2077,6 +2076,7 @@ font-family: fastn-community-github-io-opensans-font-Open-Sans }
 
 
 
+
 </style>
 <script>
     (function() {
@@ -2101,6 +2101,17 @@ font-family: fastn-community-github-io-opensans-font-Open-Sans }
   }
 }
 global["main"] = main;
+ftd.app_path = function (args) {
+  let __fastn_super_package_name__ = __fastn_package_name__;
+  __fastn_package_name__ = "fastn_community_github_io_business_card_demo";
+  try {
+    let __args__ = fastn_utils.getArgs({
+    }, args);
+    return ("" + fastn_utils.getStaticValue(__args__.path));
+  } finally {
+    __fastn_package_name__ = __fastn_super_package_name__;
+  }
+}
 fastn_utils.createNestedObject(global, "fastn_community_github_io_business_card_assets__files.assets_fastn_badge_white_svg", function () {
   let record = fastn.recordInstance({
   });

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -28,8 +28,8 @@ fn cached_parse(
 pub fn package_dependent_builtins(
     pkg: &fastn_core::Package,
     req_path: &str,
-) -> Vec<(String, fastn_resolved::Definition)> {
-    vec![(
+) -> [(String, fastn_resolved::Definition); 1] {
+    [(
         "ftd#app-path".to_string(),
         fastn_core::host_builtins::app_path(pkg, req_path),
     )]
@@ -48,7 +48,7 @@ pub async fn interpret_helper(
     let doc = cached_parse(name, source, line_number)?;
 
     let builtin_overrides = package_dependent_builtins(&lib.config.package, lib.request.path());
-    let mut s = ftd::interpreter::interpret_with_line_number(name, doc, builtin_overrides)?;
+    let mut s = ftd::interpreter::interpret_with_line_number(name, doc, Some(builtin_overrides))?;
     lib.module_package_map.insert(
         name.trim_matches('/').to_string(),
         lib.config.package.name.to_string(),

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -31,7 +31,7 @@ pub fn package_dependent_builtins(
 ) -> Vec<(String, fastn_resolved::Definition)> {
     vec![(
         "ftd#app-path".to_string(),
-        fastn_core::host_builtins::app_path(pkg, &req_path),
+        fastn_core::host_builtins::app_path(pkg, req_path),
     )]
 }
 

--- a/fastn-core/src/host_builtins.rs
+++ b/fastn-core/src/host_builtins.rs
@@ -1,7 +1,7 @@
 /// Calling: `ftd.app-path(path = /test/)` in an ftd file of a mounted app will return the path
 /// prefixed with the `mountpoint` of the app.
 ///
-/// The `path` arg must start with a forwar slash (/)
+/// The `path` arg must start with a forward slash (/)
 ///
 /// # Example
 ///

--- a/fastn-core/src/host_builtins.rs
+++ b/fastn-core/src/host_builtins.rs
@@ -1,0 +1,61 @@
+/// Calling: `ftd.app-path(path = /test/)` in an ftd file of a mounted app will return the path
+/// prefixed with the `mountpoint` of the app.
+///
+/// The `path` arg must start with a forwar slash (/)
+///
+/// # Example
+///
+/// ```FASTN.ftd
+/// -- import: fastn
+///
+/// -- fastn.package: test
+///
+/// -- fastn.app: Test
+/// mountpoint: /app/
+/// package: some-test-app.fifthtry.site
+/// ```
+///
+/// ```some-test-app.fifthtry.site/index.ftd
+///
+/// -- ftd.text: $ftd.app-path(path = /test/)
+/// ```
+///
+/// Visiting `/app/` in browser should render /app/test/
+#[inline]
+pub fn app_path(pkg: &fastn_core::Package, req_path: &str) -> fastn_resolved::Definition {
+    let prefix = pkg
+        .apps
+        .iter()
+        .find(|a| req_path.starts_with(&a.mount_point))
+        .map(|a| a.mount_point.clone())
+        .unwrap_or_default();
+    let prefix = prefix.trim_end_matches('/');
+
+    fastn_resolved::Definition::Function(fastn_resolved::Function {
+        name: "ftd#app-path".to_string(),
+        return_kind: fastn_resolved::KindData {
+            kind: fastn_resolved::Kind::string(),
+            caption: false,
+            body: false,
+        },
+        arguments: vec![fastn_resolved::Argument {
+            name: "path".to_string(),
+            kind: fastn_resolved::KindData {
+                kind: fastn_resolved::Kind::string(),
+                caption: false,
+                body: false,
+            },
+            mutable: false,
+            value: None,
+            access_modifier: Default::default(),
+            line_number: 0,
+        }],
+        expression: vec![fastn_resolved::FunctionExpression {
+            expression: format!("\"{}\" + path", prefix),
+            line_number: 0,
+        }],
+        js: None,
+        line_number: 0,
+        external_implementation: false,
+    })
+}

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod catch_panic;
 mod library2022;
 mod migrations;
 
+pub(crate) mod host_builtins;
+
 pub(crate) use auto_import::AutoImport;
 pub use commands::{
     build::build, check::post_build_check, fmt::fmt, query::query, serve::listen, test::test,

--- a/fastn.com/backend/app.ftd
+++ b/fastn.com/backend/app.ftd
@@ -16,4 +16,16 @@ The above snippet will mount contents of [lets-auth.fifthtry.site](https://lets-
 
 Visiting `/-/auth/` will load `index.ftd` of lets-auth.fifthtry.site if it's available.
 
+-- ds.h3: `ftd.app-path` function
+
+This functions let's apps construct paths relative to their mountpoint. For
+example, `lets-auth.fifthtry.site/index.ftd` could show a url to its signin
+page (`lets-auth.fifthtry.site/signin.ftd`) using the following code:
+
+-- ds.code: lets-auth.fifthtry.site/index.ftd
+lang: ftd
+
+\-- ftd.text: Sign In
+link: $ftd.app-path(path = /signin/) \;; will become /-/auth/signin/
+
 -- end: ds.page

--- a/fastn.com/ftd/built-in-functions.ftd
+++ b/fastn.com/ftd/built-in-functions.ftd
@@ -649,6 +649,8 @@ return the path prefixed with the `mountpoint` of the app.
 
 The `path` arg must start with a forward slash (/).
 
+Calling this from any `.ftd` file of the root package will simply return the provided `path` argument.
+
 -- ds.h3: Example
 
 -- ds.code: FASTN.ftd

--- a/fastn.com/ftd/built-in-functions.ftd
+++ b/fastn.com/ftd/built-in-functions.ftd
@@ -642,8 +642,34 @@ or empty.
 
 -- end: ds.rendered
 
+-- ds.h2: `app-path(path: string)`
+
+Calling `ftd.app-path(path = /test/)` in an ftd file of a mounted app will
+return the path prefixed with the `mountpoint` of the app.
+
+The `path` arg must start with a forward slash (/).
+
+-- ds.h3: Example
+
+-- ds.code: FASTN.ftd
+lang: ftd
+
+\-- import: fastn
+
+\-- fastn.package: test
+
+\-- fastn.app: Test
+mountpoint: /app/
+package: some-test-app.fifthtry.site
 
 
+-- ds.code: some-test-app.fifthtry.site/index.ftd
+lang: ftd
+
+\-- ftd.text: $ftd.app-path(path = /test/)
+
+
+-- ds.markdown: Visiting `/app/` in browser should render text "/app/test/"
 
 
 

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.81"
+version = "0.4.82"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -99,14 +99,16 @@ impl InterpreterState {
     #[tracing::instrument(skip(builtins))]
     fn new_with_expanded_builtins(
         id: String,
-        builtins: impl IntoIterator<Item = (String, fastn_resolved::Definition)>,
+        builtins: Option<[(String, fastn_resolved::Definition); 1]>,
     ) -> InterpreterState {
         let mut bag = ftd::interpreter::default::builtins().clone();
 
-        builtins.into_iter().for_each(|(name, def)| {
-            tracing::info!("Overriding builtin with def from fastn: {}", name);
-            bag.insert(name, def);
-        });
+        if let Some(builtins) = builtins {
+            for (name, def) in builtins {
+                tracing::info!("Overriding builtin with def from fastn: {}", name);
+                bag.insert(name, def);
+            }
+        }
 
         InterpreterState {
             id,
@@ -969,14 +971,14 @@ impl InterpreterState {
 
 pub fn interpret(id: &str, source: &str) -> ftd::interpreter::Result<Interpreter> {
     let doc = ParsedDocument::parse_with_line_number(id, source, 0)?;
-    interpret_with_line_number(id, doc, vec![])
+    interpret_with_line_number(id, doc, None)
 }
 
 #[tracing::instrument(skip_all)]
 pub fn interpret_with_line_number(
     id: &str,
     document: ParsedDocument,
-    builtin_overrides: Vec<(String, fastn_resolved::Definition)>,
+    builtin_overrides: Option<[(String, fastn_resolved::Definition); 1]>,
 ) -> ftd::interpreter::Result<Interpreter> {
     use itertools::Itertools;
 


### PR DESCRIPTION
This function let's ftd files inside a mounted package construct urls
that are relative to the mountpoint of the said package.

This helps `fastn.app` mounts to easily construct paths without assuming
(or enforcing) their mountpoints.

Calling `ftd.app-path(path = /test/)` in an ftd file of a mounted app will return the path
prefixed with the `mountpoint` of the app.
                                                                                            
The `path` arg must start with a forward slash (/).

Calling this from any `.ftd` file of the root package will simply return the provided `path` argument.

                                                                                            
# Example
                                                                                            
```FASTN.ftd
-- import: fastn
                                                                                            
-- fastn.package: test
                                                                                            
-- fastn.app: Test
mountpoint: /app/
package: some-test-app.fifthtry.site
```
                                                                                            
```some-test-app.fifthtry.site/index.ftd
                                                                                            
-- ftd.text: $ftd.app-path(path = /test/)
```
                                                                                            
Visiting `/app/` in browser should render /app/test/


