### PR TITLE
Fix: Set an upper limit for loops and trigger an error on redefinition with an existing alias name

### DIFF
--- a/ftd-ast/src/ast.rs
+++ b/ftd-ast/src/ast.rs
@@ -241,7 +241,7 @@ impl Ast {
         matches!(self, Ast::WebComponentDefinition(_))
     }
 
-    pub fn is_component(&self) -> bool {
+    pub fn is_component_invocation(&self) -> bool {
         matches!(self, Ast::ComponentInvocation(_))
     }
 

--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -290,12 +290,7 @@ impl InterpreterState {
                     .open("/tmp/max-loop-iters.log")
                     .unwrap();
 
-                write!(
-                    file,
-                    "[MAX_LOOP_ITER]: id: {}; doc: {}\n",
-                    self.id, doc_name
-                )
-                .unwrap();
+                writeln!(file, "[MAX_LOOP_ITER]: id: {}; doc: {}", self.id, doc_name).unwrap();
 
                 return Err(ftd::interpreter::Error::OtherError(
                     "Exhausted allocated MAX_LOOP_ITER. The fastn package might have some bug."

--- a/ftd/src/interpreter/tdoc.rs
+++ b/ftd/src/interpreter/tdoc.rs
@@ -1146,7 +1146,7 @@ impl<'a> TDoc<'a> {
                 .ast
                 .iter()
                 .filter(|v| {
-                    !v.is_component()
+                    !v.is_component_invocation()
                         && (v.name().eq(thing_name.as_str())
                             || v.name().starts_with(format!("{}.", thing_name).as_str()))
                 })
@@ -1554,7 +1554,7 @@ impl<'a> TDoc<'a> {
                         state.id.as_str(),
                         &current_parsed_document.doc_aliases,
                     );
-                    !v.is_component()
+                    !v.is_component_invocation()
                         && (name.eq(&format!("{}#{}", doc_name, thing_name))
                             || name.starts_with(format!("{}#{}.", doc_name, thing_name).as_str()))
                 })
@@ -1591,7 +1591,7 @@ impl<'a> TDoc<'a> {
                 .ast
                 .iter()
                 .filter(|v| {
-                    !v.is_component()
+                    !v.is_component_invocation()
                         && (v.name().eq(&thing_name)
                             || v.name().starts_with(format!("{}.", thing_name).as_str()))
                 })

--- a/ftd/t/js/26-re-export.ftd
+++ b/ftd/t/js/26-re-export.ftd
@@ -1,6 +1,3 @@
--- import: 01-basic as dd
-
-
 -- dd: Arpita
 
 


### PR DESCRIPTION
```ftd
-- import: my-package/my-module

-- my-module:
```

The above code snippet makes the server go into an infinite loop. This
shouldn't be allowed as we're trying to directly render a module. In
most cases `-- my-module.a-component:` is what people want.

```ftd
-- import: my-package/something

-- string something: some value

-- ftd.text: $something
```

The above code snippet will also throw the same error. Trying to define a thing (variable in this case) with the same name as an alias (`something` import alias in this case) is not allowed. Trying to similar things leads to ambiguity.

A max. iteration limit is also added to the suspicious loop so that the server never goes down in these kind of events. Logs for this are written to a separate file so that, over time, we can debug and improve the edge cases.