### PR TITLE
Fix(ftd#json): Construct correct json string by unescaping first

### DIFF
--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -1318,11 +1318,20 @@ impl Document {
             let mut o = serde_json::Map::new();
             for (k, v) in data {
                 if let Some(value) = v.resolve(&tdoc, 0)?.to_serde_value(&tdoc)? {
+                    let value = match value {
+                        serde_json::Value::String(s) => serde_json::Value::String(unescape(&s)?),
+                        v => v,
+                    };
                     o.insert(k, serde_json::to_value(value)?);
                 }
             }
 
             return Ok(Some(serde_json::to_vec(&o)?));
+        }
+
+        #[inline]
+        fn unescape(s: &str) -> serde_json::Result<String> {
+            serde_json::from_str(&format!("\"{}\"", s))
         }
 
         Ok(None)

--- a/ftd/t/js/103-ftd-json-templ.ftd
+++ b/ftd/t/js/103-ftd-json-templ.ftd
@@ -1,0 +1,17 @@
+-- template create-account-confirmation-html(link, name):
+string link:
+string name:
+
+<html>
+<body>
+<h1>Hi $name,</h1>
+<a href="$link">$link</a>
+</body>
+</html>
+
+
+-- string html: $create-account-confirmation-html(link = https://fastn.com/, name = John)
+
+
+-- ftd.json:
+html: $html

--- a/ftd/t/js/103-ftd-json-templ.html
+++ b/ftd/t/js/103-ftd-json-templ.html
@@ -1,0 +1,1 @@
+{"html":"<html>\n<body>\n<h1>Hi John,</h1>\n<a href=\"https://fastn.com/\">https://fastn.com/</a>\n</body>\n</html>"}


### PR DESCRIPTION
The string is usually coming from some file read where the escape sequences are interpreted as literal escape sequences - The string "\\n" is treated as two characters: \ and n.

Rust strings treat escape sequences as literal characters unless explicitly unescaped.

The `unescape` function takes the string with literal escape sequences and uses serde_json::from_str to unescape it.


The following ftd code:

```ftd
-- template create-account-confirmation-html(link, name):
string link:
string name:

<html>
    <head>
        <title>Confirm your account</title>
    </head>
    <body>
        <h1>Hi $name,</h1>
        <p>Click the link below to confirm your account</p>
        <a href="$link">Confirm your account</a>
        In case you can't click the link, copy and paste the following link in your browser:
        <br>
        <a href="$link">$link</a>
    </body>
</html>


-- string html: $create-account-confirmation-html(link = https://google.com/, name = Siddhant)


-- ftd.json:
html: $html
```

will output:


```json
{"html":"<html>\n    <head>\n        <title>Confirm your account</title>\n    </head>\n    <body>\n        <h1>Hi Siddhant,</h1>\n        <p>Click the link below to confirm your account</p>\n        <a href=\"https://google.com/\">Confirm your account</a>\n        In case you can't click the link, copy and paste the following link in your browser:\n        <br>\n        <a href=\"https://google.com/\">https://google.com/</a>\n    </body>\n</html>"}
```

Before this change, the output would look something like (notice \\\n):

```json
{"html":"<html>\\n    <head>\\n        <title>Confirm your account</title>\\n    </head>\\n    <body>\\n        <h1>Hi Default Name,</h1>\\n        <p>Click the link below to confirm your account</p>\\n        <a href=\\\"https://www.fifthtry.com/some-link/\\\">Confirm your account</a>\\n        In case you can't click the link, copy and paste the following link in your browser:\\n        <br>\\n        <a href=\\\"https://www.fifthtry.com/some-link/\\\">https://www.fifthtry.com/some-link/</a>\\n    </body>\\n</html>","subject":"Confirm you account","text":"Hi Default Name,\\n\\nClick the link below to confirm your account:\\n\\nhttps://www.fifthtry.com/some-link/\\n\\nIn case you can't click the link, copy and paste it in your browser."}
```
