### PR TITLE
Revert changes done by `cargo fix --edition`

### DIFF
--- a/fastn-core/src/commands/test.rs
+++ b/fastn-core/src/commands/test.rs
@@ -343,8 +343,8 @@ async fn get_instructions_from_test(
         println!("Test: {}", title);
     }
 
-    let fixtures = match get_optional_value_list(FIXTURE_HEADER, &property_values, doc)? {
-        Some(fixtures) => {
+    let fixtures =
+        if let Some(fixtures) = get_optional_value_list(FIXTURE_HEADER, &property_values, doc)? {
             let mut resolved_fixtures = vec![];
             for fixture in fixtures.iter() {
                 if let fastn_resolved::Value::String { text } = fixture {
@@ -352,11 +352,9 @@ async fn get_instructions_from_test(
                 }
             }
             resolved_fixtures
-        }
-        _ => {
+        } else {
             vec![]
-        }
-    };
+        };
 
     let fixture_instructions =
         get_fixture_instructions(config, fixtures, included_fixtures).await?;

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -1110,7 +1110,10 @@ impl Config {
 
                 if let Some(found_app) = apps.iter().find(|a| a.package.name.eq(&new_app_package)) {
                     return Err(fastn_core::Error::PackageError {
-                        message: format!("Mounting the same package twice is not yet allowed. Tried mounting `{}` which is aready mounted at `{}`", new_app_package, found_app.mount_point),
+                        message: format!(
+                            "Mounting the same package twice is not yet allowed. Tried mounting `{}` which is aready mounted at `{}`",
+                            new_app_package, found_app.mount_point
+                        ),
                     });
                 }
 

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -1110,10 +1110,7 @@ impl Config {
 
                 if let Some(found_app) = apps.iter().find(|a| a.package.name.eq(&new_app_package)) {
                     return Err(fastn_core::Error::PackageError {
-                        message: format!(
-                            "Mounting the same package twice is not yet allowed. Tried mounting `{}` which is aready mounted at `{}`",
-                            new_app_package, found_app.mount_point
-                        ),
+                        message: format!("Mounting the same package twice is not yet allowed. Tried mounting `{}` which is aready mounted at `{}`", new_app_package, found_app.mount_point),
                     });
                 }
 
@@ -1134,7 +1131,7 @@ impl Config {
         fastn_wasm::insert_or_update(
             &config.all_packages,
             package.name.to_string(),
-            config.package.to_owned(),
+            package.to_owned(),
         );
 
         fastn_core::migrations::migrate(&config).await?;
@@ -1215,15 +1212,12 @@ impl Config {
         package_name: &str,
         default: Option<fastn_core::Package>,
     ) -> fastn_core::Package {
-        match self.all_packages.get(package_name) {
-            Some(package) => package.get().to_owned(),
-            _ => {
-                if let Some(package) = default {
-                    package.to_owned()
-                } else {
-                    self.package.to_owned()
-                }
-            }
+        if let Some(package) = self.all_packages.get(package_name) {
+            package.get().to_owned()
+        } else if let Some(package) = default {
+            package.to_owned()
+        } else {
+            self.package.to_owned()
         }
     }
 

--- a/fastn-core/src/config/mod.rs
+++ b/fastn-core/src/config/mod.rs
@@ -1134,7 +1134,7 @@ impl Config {
         fastn_wasm::insert_or_update(
             &config.all_packages,
             package.name.to_string(),
-            package.to_owned(),
+            config.package.to_owned(),
         );
 
         fastn_core::migrations::migrate(&config).await?;

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -50,7 +50,6 @@ pub async fn interpret_helper(
 
     let builtin_overrides = package_dependent_builtins(&lib.config, lib.request.path());
     let mut s = ftd::interpreter::interpret_with_line_number(name, doc, Some(builtin_overrides))?;
-
     lib.module_package_map.insert(
         name.trim_matches('/').to_string(),
         lib.config.package.name.to_string(),
@@ -452,43 +451,37 @@ pub async fn resolve_foreign_variable2022(
                         .get(&format!("{}/{}", package.name, dark_path))
                     {
                         dark_mode = dark.to_string();
+                    } else if let Ok(dark) = package
+                        .resolve_by_file_name(
+                            dark_path.as_str(),
+                            None,
+                            &lib.config.ds,
+                            preview_session_id,
+                        )
+                        .await
+                    {
+                        print!("Processing {}/{} ... ", package.name.as_str(), dark_path);
+                        fastn_core::utils::write(
+                            &lib.config.build_dir().join("-").join(package.name.as_str()),
+                            dark_path.as_str(),
+                            dark.as_slice(),
+                            &lib.config.ds,
+                            preview_session_id,
+                        )
+                        .await
+                        .map_err(|e| {
+                            ftd::ftd2021::p1::Error::ParseError {
+                                message: e.to_string(),
+                                doc_id: lib.document_id.to_string(),
+                                line_number: 0,
+                            }
+                        })?;
+                        fastn_core::utils::print_end(
+                            format!("Processed {}/{}", package.name.as_str(), dark_path).as_str(),
+                            start,
+                        );
                     } else {
-                        match package
-                            .resolve_by_file_name(
-                                dark_path.as_str(),
-                                None,
-                                &lib.config.ds,
-                                preview_session_id,
-                            )
-                            .await
-                        {
-                            Ok(dark) => {
-                                print!("Processing {}/{} ... ", package.name.as_str(), dark_path);
-                                fastn_core::utils::write(
-                                    &lib.config.build_dir().join("-").join(package.name.as_str()),
-                                    dark_path.as_str(),
-                                    dark.as_slice(),
-                                    &lib.config.ds,
-                                    preview_session_id,
-                                )
-                                .await
-                                .map_err(|e| {
-                                    ftd::ftd2021::p1::Error::ParseError {
-                                        message: e.to_string(),
-                                        doc_id: lib.document_id.to_string(),
-                                        line_number: 0,
-                                    }
-                                })?;
-                                fastn_core::utils::print_end(
-                                    format!("Processed {}/{}", package.name.as_str(), dark_path)
-                                        .as_str(),
-                                    start,
-                                );
-                            }
-                            _ => {
-                                dark_mode.clone_from(&light_mode);
-                            }
-                        }
+                        dark_mode.clone_from(&light_mode);
                     }
                     lib.downloaded_assets.insert(
                         format!("{}/{}", package.name, dark_path),
@@ -759,64 +752,47 @@ pub async fn resolve_foreign_variable2(
                 let dark_path = format!("{}-dark.{}", file.replace('.', "/"), ext);
                 if download_assets && !file.ends_with("-dark") {
                     let start = std::time::Instant::now();
-                    match lib
+                    if let Some(dark) = lib
                         .config
                         .downloaded_assets
                         .get(&format!("{}/{}", package.name, dark_path))
                     {
-                        Some(dark) => {
-                            dark_mode = dark.to_string();
-                        }
-                        _ => {
-                            match package
-                                .resolve_by_file_name(
-                                    dark_path.as_str(),
-                                    None,
-                                    &lib.config.config.ds,
-                                    session_id,
-                                )
-                                .await
-                            {
-                                Ok(dark) => {
-                                    print!(
-                                        "Processing {}/{} ... ",
-                                        package.name.as_str(),
-                                        dark_path
-                                    );
-                                    fastn_core::utils::write(
-                                        &lib.config
-                                            .config
-                                            .build_dir()
-                                            .join("-")
-                                            .join(package.name.as_str()),
-                                        dark_path.as_str(),
-                                        dark.as_slice(),
-                                        &lib.config.config.ds,
-                                        session_id,
-                                    )
-                                    .await
-                                    .map_err(|e| {
-                                        ftd::ftd2021::p1::Error::ParseError {
-                                            message: e.to_string(),
-                                            doc_id: lib.document_id.to_string(),
-                                            line_number: 0,
-                                        }
-                                    })?;
-                                    fastn_core::utils::print_end(
-                                        format!(
-                                            "Processed {}/{}",
-                                            package.name.as_str(),
-                                            dark_path
-                                        )
-                                        .as_str(),
-                                        start,
-                                    );
-                                }
-                                _ => {
-                                    dark_mode.clone_from(&light_mode);
-                                }
+                        dark_mode = dark.to_string();
+                    } else if let Ok(dark) = package
+                        .resolve_by_file_name(
+                            dark_path.as_str(),
+                            None,
+                            &lib.config.config.ds,
+                            session_id,
+                        )
+                        .await
+                    {
+                        print!("Processing {}/{} ... ", package.name.as_str(), dark_path);
+                        fastn_core::utils::write(
+                            &lib.config
+                                .config
+                                .build_dir()
+                                .join("-")
+                                .join(package.name.as_str()),
+                            dark_path.as_str(),
+                            dark.as_slice(),
+                            &lib.config.config.ds,
+                            session_id,
+                        )
+                        .await
+                        .map_err(|e| {
+                            ftd::ftd2021::p1::Error::ParseError {
+                                message: e.to_string(),
+                                doc_id: lib.document_id.to_string(),
+                                line_number: 0,
                             }
-                        }
+                        })?;
+                        fastn_core::utils::print_end(
+                            format!("Processed {}/{}", package.name.as_str(), dark_path).as_str(),
+                            start,
+                        );
+                    } else {
+                        dark_mode.clone_from(&light_mode);
                     }
                     lib.config.downloaded_assets.insert(
                         format!("{}/{}", package.name, dark_path),

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -592,9 +592,15 @@ pub fn is_bot(user_agent: &str) -> bool {
 
 #[test]
 fn test_is_bot() {
-    assert!(is_bot("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/"));
-    assert!(is_bot("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)) Chrome/"));
-    assert!(!is_bot("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"));
+    assert!(is_bot(
+        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/"
+    ));
+    assert!(is_bot(
+        "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)) Chrome/"
+    ));
+    assert!(!is_bot(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ));
 }
 
 pub(crate) fn get_header_key(header_key: &str) -> Option<&str> {

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -180,16 +180,13 @@ impl Request {
         let headers = {
             let mut headers = reqwest::header::HeaderMap::new();
             for (key, value) in req.headers() {
-                match (
+                if let (Ok(v), Ok(k)) = (
                     value.to_str().unwrap_or("").parse::<http::HeaderValue>(),
                     http::HeaderName::from_bytes(key.as_str().as_bytes()),
                 ) {
-                    (Ok(v), Ok(k)) => {
-                        headers.insert(k, v.clone());
-                    }
-                    _ => {
-                        tracing::warn!("failed to parse header: {key:?} {value:?}");
-                    }
+                    headers.insert(k, v.clone());
+                } else {
+                    tracing::warn!("failed to parse header: {key:?} {value:?}");
                 }
             }
             headers
@@ -595,15 +592,9 @@ pub fn is_bot(user_agent: &str) -> bool {
 
 #[test]
 fn test_is_bot() {
-    assert!(is_bot(
-        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/"
-    ));
-    assert!(is_bot(
-        "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)) Chrome/"
-    ));
-    assert!(!is_bot(
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    ));
+    assert!(is_bot("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/"));
+    assert!(is_bot("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)) Chrome/"));
+    assert!(!is_bot("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"));
 }
 
 pub(crate) fn get_header_key(header_key: &str) -> Option<&str> {

--- a/fastn-core/src/library/toc.rs
+++ b/fastn-core/src/library/toc.rs
@@ -285,26 +285,23 @@ impl TocParser {
                         let url_regex = regex::Regex::new(
                             r":[ ]?(?P<url>(?:https?)?://(?:[a-zA-Z0-9]+\.)?(?:[A-z0-9]+\.)(?:[A-z0-9]+)(?:[/A-Za-z0-9\?:\&%]+))"
                         ).unwrap();
-                        match url_regex.find(current_title.as_str()) {
-                            Some(regex_match) => {
-                                let curr_title = current_title.as_str();
-                                (
-                                    Some(curr_title[..regex_match.start()].trim().to_string()),
-                                    Some(
-                                        curr_title[regex_match.start()..regex_match.end()]
-                                            .trim_start_matches(':')
-                                            .trim()
-                                            .to_string(),
-                                    ),
-                                )
-                            }
-                            _ => {
-                                return Err(ParseError::InvalidTOCItem {
+                        if let Some(regex_match) = url_regex.find(current_title.as_str()) {
+                            let curr_title = current_title.as_str();
+                            (
+                                Some(curr_title[..regex_match.start()].trim().to_string()),
+                                Some(
+                                    curr_title[regex_match.start()..regex_match.end()]
+                                        .trim_start_matches(':')
+                                        .trim()
+                                        .to_string(),
+                                ),
+                            )
+                        } else {
+                            return Err(ParseError::InvalidTOCItem {
                                 doc_id: self.doc_name.clone(),
                                 message: "Ambiguous <title>: <URL> evaluation. Multiple colons found. Either specify the complete URL or specify the url as an attribute".to_string(),
                                 row_content: current_title.as_str().to_string(),
                             });
-                            }
                         }
                     }
                 };
@@ -429,10 +426,10 @@ mod test {
     use pretty_assertions::assert_eq;
 
     macro_rules! p {
-        ($s:expr, $t: expr_2021,) => {
+        ($s:expr, $t: expr,) => {
             p!($s, $t)
         };
-        ($s:expr, $t: expr_2021) => {
+        ($s:expr, $t: expr) => {
             assert_eq!(
                 super::ToC::parse($s, "test_doc").unwrap_or_else(|e| panic!("{}", e)),
                 $t

--- a/fastn-core/src/manifest/utils.rs
+++ b/fastn-core/src/manifest/utils.rs
@@ -2,13 +2,12 @@ static GITHUB_PAGES_REGEX: once_cell::sync::Lazy<regex::Regex> =
     once_cell::sync::Lazy::new(|| regex::Regex::new(r"([^/]+)\.github\.io/([^/]+)").unwrap());
 
 fn extract_github_details(package_name: &str) -> Option<(String, String)> {
-    match GITHUB_PAGES_REGEX.captures(package_name) {
-        Some(captures) => {
-            let username = captures.get(1).unwrap().as_str().to_string();
-            let repository = captures.get(2).unwrap().as_str().to_string();
-            Some((username, repository))
-        }
-        _ => None,
+    if let Some(captures) = GITHUB_PAGES_REGEX.captures(package_name) {
+        let username = captures.get(1).unwrap().as_str().to_string();
+        let repository = captures.get(2).unwrap().as_str().to_string();
+        Some((username, repository))
+    } else {
+        None
     }
 }
 

--- a/fastn-core/src/sitemap/mod.rs
+++ b/fastn-core/src/sitemap/mod.rs
@@ -426,26 +426,23 @@ impl SitemapParser {
                     _ => {
                         // The URL can have its own colons. So match the URL first
                         let url_regex = crate::http::url_regex();
-                        match url_regex.find(current_title.as_str()) {
-                            Some(regex_match) => {
-                                let curr_title = current_title.as_str();
-                                (
-                                    Some(curr_title[..regex_match.start()].trim().to_string()),
-                                    Some(
-                                        curr_title[regex_match.start()..regex_match.end()]
-                                            .trim_start_matches(':')
-                                            .trim()
-                                            .to_string(),
-                                    ),
-                                )
-                            }
-                            _ => {
-                                return Err(ParseError::InvalidTOCItem {
+                        if let Some(regex_match) = url_regex.find(current_title.as_str()) {
+                            let curr_title = current_title.as_str();
+                            (
+                                Some(curr_title[..regex_match.start()].trim().to_string()),
+                                Some(
+                                    curr_title[regex_match.start()..regex_match.end()]
+                                        .trim_start_matches(':')
+                                        .trim()
+                                        .to_string(),
+                                ),
+                            )
+                        } else {
+                            return Err(ParseError::InvalidTOCItem {
                                 doc_id: self.doc_name.clone(),
                                 message: "Ambiguous <title>: <URL> evaluation. Multiple colons found. Either specify the complete URL or specify the url as an attribute".to_string(),
                                 row_content: current_title.as_str().to_string(),
                             });
-                            }
                         }
                     }
                 };
@@ -624,7 +621,7 @@ impl Sitemap {
             config: &fastn_core::Config,
             session_id: &Option<String>,
         ) -> fastn_core::Result<()> {
-            let (file_location, translation_file_location) = match config
+            let (file_location, translation_file_location) = if let Ok(file_name) = config
                 .get_file_path_and_resolve(
                     &section
                         .document
@@ -634,18 +631,17 @@ impl Sitemap {
                 )
                 .await
             {
-                Ok(file_name) => (
+                (
                     Some(config.ds.root().join(file_name.as_str())),
                     Some(config.ds.root().join(file_name.as_str())),
-                ),
-                _ => {
-                    if crate::http::url_regex()
-                        .find(section.get_file_id().as_str())
-                        .is_some()
-                    {
-                        (None, None)
-                    } else {
-                        match fastn_core::Config::get_file_name(
+                )
+            } else if crate::http::url_regex()
+                .find(section.get_file_id().as_str())
+                .is_some()
+            {
+                (None, None)
+            } else {
+                match fastn_core::Config::get_file_name(
                     current_package_root,
                     section.get_file_id().as_str(),
                     &config.ds,
@@ -683,8 +679,6 @@ impl Sitemap {
                         None,
                     ),
                 }
-                    }
-                }
             };
             section.file_location = file_location;
             section.translation_file_location = translation_file_location;
@@ -710,7 +704,7 @@ impl Sitemap {
             session_id: &Option<String>,
         ) -> fastn_core::Result<()> {
             if let Some(ref id) = subsection.get_file_id() {
-                let (file_location, translation_file_location) = match config
+                let (file_location, translation_file_location) = if let Ok(file_name) = config
                     .get_file_path_and_resolve(
                         &subsection
                             .document
@@ -720,15 +714,14 @@ impl Sitemap {
                     )
                     .await
                 {
-                    Ok(file_name) => (
+                    (
                         Some(config.ds.root().join(file_name.as_str())),
                         Some(config.ds.root().join(file_name.as_str())),
-                    ),
-                    _ => {
-                        if crate::http::url_regex().find(id.as_str()).is_some() {
-                            (None, None)
-                        } else {
-                            match fastn_core::Config::get_file_name(current_package_root, id.as_str(), &config.ds, session_id).await {
+                    )
+                } else if crate::http::url_regex().find(id.as_str()).is_some() {
+                    (None, None)
+                } else {
+                    match fastn_core::Config::get_file_name(current_package_root, id.as_str(), &config.ds, session_id).await {
                         Ok(name) => {
                             if current_package_root.eq(package_root) {
                                 (Some(current_package_root.join(name)), None)
@@ -753,8 +746,6 @@ impl Sitemap {
                             None,
                         ),
                     }
-                        }
-                    }
                 };
                 subsection.file_location = file_location;
                 subsection.translation_file_location = translation_file_location;
@@ -774,26 +765,25 @@ impl Sitemap {
             config: &fastn_core::Config,
             session_id: &Option<String>,
         ) -> fastn_core::Result<()> {
-            let (file_location, translation_file_location) = match config
+            let (file_location, translation_file_location) = if let Ok(file_name) = config
                 .get_file_path_and_resolve(
                     &toc.document.clone().unwrap_or_else(|| toc.get_file_id()),
                     session_id,
                 )
                 .await
             {
-                Ok(file_name) => (
+                (
                     Some(config.ds.root().join(file_name.as_str())),
                     Some(config.ds.root().join(file_name.as_str())),
-                ),
-                _ => {
-                    if toc.get_file_id().trim().is_empty()
-                        || crate::http::url_regex()
-                            .find(toc.get_file_id().as_str())
-                            .is_some()
-                    {
-                        (None, None)
-                    } else {
-                        match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str(), &config.ds, session_id).await {
+                )
+            } else if toc.get_file_id().trim().is_empty()
+                || crate::http::url_regex()
+                    .find(toc.get_file_id().as_str())
+                    .is_some()
+            {
+                (None, None)
+            } else {
+                match fastn_core::Config::get_file_name(current_package_root, toc.get_file_id().as_str(), &config.ds, session_id).await {
                     Ok(name) => {
                         if current_package_root.eq(package_root) {
                             (Some(current_package_root.join(name)), None)
@@ -825,8 +815,6 @@ impl Sitemap {
                         ),
                         None,
                     ),
-                }
-                    }
                 }
             };
             toc.file_location = file_location;

--- a/fastn-core/src/sitemap/utils.rs
+++ b/fastn-core/src/sitemap/utils.rs
@@ -46,13 +46,10 @@ pub fn url_match(
                 param_type,
             } => {
                 count += 1;
-                match get_value_type(req_part, param_type) {
-                    Ok(value) => {
-                        path_parameters.push((name.to_string(), value));
-                    }
-                    _ => {
-                        return Ok((false, vec![]));
-                    }
+                if let Ok(value) = get_value_type(req_part, param_type) {
+                    path_parameters.push((name.to_string(), value));
+                } else {
+                    return Ok((false, vec![]));
                 }
             }
         };

--- a/fastn-runtime/src/lib.rs
+++ b/fastn-runtime/src/lib.rs
@@ -227,37 +227,28 @@ impl<T: std::cmp::PartialEq> VecMap<T> {
     }
 
     pub fn insert(&mut self, key: String, value: T) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                v.push(value);
-            }
-            _ => {
-                self.value.insert(key, vec![value]);
-            }
+        if let Some(v) = self.value.get_mut(&key) {
+            v.push(value);
+        } else {
+            self.value.insert(key, vec![value]);
         }
     }
 
     pub fn unique_insert(&mut self, key: String, value: T) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                if !v.contains(&value) {
-                    v.push(value);
-                }
+        if let Some(v) = self.value.get_mut(&key) {
+            if !v.contains(&value) {
+                v.push(value);
             }
-            _ => {
-                self.value.insert(key, vec![value]);
-            }
+        } else {
+            self.value.insert(key, vec![value]);
         }
     }
 
     pub fn extend(&mut self, key: String, value: Vec<T>) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                v.extend(value);
-            }
-            _ => {
-                self.value.insert(key, value);
-            }
+        if let Some(v) = self.value.get_mut(&key) {
+            v.extend(value);
+        } else {
+            self.value.insert(key, value);
         }
     }
 

--- a/fastn-update/src/lib.rs
+++ b/fastn-update/src/lib.rs
@@ -117,7 +117,7 @@ macro_rules! mprint {
 
 // macro called mred that prints in red a message, using ansi colors for red,
 macro_rules! mdone {
-    ($red: expr_2021, $($arg:tt)*) => {
+    ($red: expr, $($arg:tt)*) => {
         use colored::Colorize;
 
         if !fastn_core::utils::is_test() {

--- a/fastn/src/main.rs
+++ b/fastn/src/main.rs
@@ -372,7 +372,7 @@ pub fn version() -> &'static str {
 
 fn set_env_vars(is_test_running: bool) {
     let checked_in = {
-        match std::process::Command::new("git")
+        if let Ok(status) = std::process::Command::new("git")
             .arg("ls-files")
             .arg("--error-unmatch")
             .arg(".env")
@@ -380,10 +380,9 @@ fn set_env_vars(is_test_running: bool) {
             .stderr(std::process::Stdio::null())
             .status()
         {
-            Ok(status) => {
-                status.success() // .env is checked in
-            }
-            _ => false,
+            status.success() // .env is checked in
+        } else {
+            false
         }
     };
 

--- a/fbt_lib/src/dir_diff.rs
+++ b/fbt_lib/src/dir_diff.rs
@@ -163,9 +163,10 @@ fn walk_dir<P: AsRef<std::path::Path>>(path: P) -> Result<walkdir::IntoIter, std
     let mut walkdir = walkdir::WalkDir::new(path)
         .sort_by(compare_by_file_name)
         .into_iter();
-    match walkdir.next() {
-        Some(Err(e)) => Err(e.into()),
-        _ => Ok(walkdir),
+    if let Some(Err(e)) = walkdir.next() {
+        Err(e.into())
+    } else {
+        Ok(walkdir)
     }
 }
 

--- a/ftd/src/executor/utils.rs
+++ b/ftd/src/executor/utils.rs
@@ -96,13 +96,13 @@ pub(crate) fn update_condition_in_component(
             expression: fastn_resolved::evalexpr::ExprNode::new(
                 fastn_resolved::evalexpr::Operator::RootNode,
             )
-            .add_children(vec![fastn_resolved::evalexpr::ExprNode::new(
-                fastn_resolved::evalexpr::Operator::And,
-            )
             .add_children(vec![
-                outer_condition.expression,
-                condition.expression.to_owned(),
-            ])]),
+                fastn_resolved::evalexpr::ExprNode::new(fastn_resolved::evalexpr::Operator::And)
+                    .add_children(vec![
+                        outer_condition.expression,
+                        condition.expression.to_owned(),
+                    ]),
+            ]),
             references,
             line_number: 0,
         };

--- a/ftd/src/executor/utils.rs
+++ b/ftd/src/executor/utils.rs
@@ -96,13 +96,13 @@ pub(crate) fn update_condition_in_component(
             expression: fastn_resolved::evalexpr::ExprNode::new(
                 fastn_resolved::evalexpr::Operator::RootNode,
             )
+            .add_children(vec![fastn_resolved::evalexpr::ExprNode::new(
+                fastn_resolved::evalexpr::Operator::And,
+            )
             .add_children(vec![
-                fastn_resolved::evalexpr::ExprNode::new(fastn_resolved::evalexpr::Operator::And)
-                    .add_children(vec![
-                        outer_condition.expression,
-                        condition.expression.to_owned(),
-                    ]),
-            ]),
+                outer_condition.expression,
+                condition.expression.to_owned(),
+            ])]),
             references,
             line_number: 0,
         };
@@ -482,24 +482,23 @@ fn update_inherited_reference_in_property_value(
                 reference.to_string()
             };
 
-            match fastn_resolved::PropertyValue::from_ast_value(
-                ftd_ast::VariableValue::String {
-                    // TODO: ftd#default-colors, ftd#default-types
-                    value: format!("${}", reference_name),
-                    line_number: 0,
-                    source: ftd_ast::ValueSource::Default,
-                    condition: None,
-                },
-                &mut doc.itdoc(),
-                property_value.is_mutable(),
-                Some(&property_value.kind().into_kind_data()),
-            ) {
-                Ok(ftd::interpreter::StateWithThing::Thing(property)) => {
-                    *property_value = property;
-                }
-                _ => {
-                    property_value.set_reference_or_clone(reference_name.as_str());
-                }
+            if let Ok(ftd::interpreter::StateWithThing::Thing(property)) =
+                fastn_resolved::PropertyValue::from_ast_value(
+                    ftd_ast::VariableValue::String {
+                        // TODO: ftd#default-colors, ftd#default-types
+                        value: format!("${}", reference_name),
+                        line_number: 0,
+                        source: ftd_ast::ValueSource::Default,
+                        condition: None,
+                    },
+                    &mut doc.itdoc(),
+                    property_value.is_mutable(),
+                    Some(&property_value.kind().into_kind_data()),
+                )
+            {
+                *property_value = property;
+            } else {
+                property_value.set_reference_or_clone(reference_name.as_str());
             }
 
             property_value.set_reference_or_clone(
@@ -520,44 +519,43 @@ fn update_inherited_reference_in_property_value(
             || reference_or_clone
                 .starts_with(format!("{}.colors", ftd::interpreter::FTD_INHERITED).as_str()))
     {
-        match fastn_resolved::PropertyValue::from_ast_value(
-            ftd_ast::VariableValue::String {
-                // TODO: ftd#default-colors, ftd#default-types
-                value: {
-                    format!(
-                        "$ftd#default-{}{}",
-                        if reference_or_clone.starts_with(
-                            format!("{}.types", ftd::interpreter::FTD_INHERITED).as_str()
-                        ) {
-                            "types"
-                        } else {
-                            "colors"
-                        },
-                        reference_or_clone
-                            .trim_start_matches(
+        if let Ok(ftd::interpreter::StateWithThing::Thing(property)) =
+            fastn_resolved::PropertyValue::from_ast_value(
+                ftd_ast::VariableValue::String {
+                    // TODO: ftd#default-colors, ftd#default-types
+                    value: {
+                        format!(
+                            "$ftd#default-{}{}",
+                            if reference_or_clone.starts_with(
                                 format!("{}.types", ftd::interpreter::FTD_INHERITED).as_str()
-                            )
-                            .trim_start_matches(
-                                format!("{}.colors", ftd::interpreter::FTD_INHERITED).as_str()
-                            )
-                    )
+                            ) {
+                                "types"
+                            } else {
+                                "colors"
+                            },
+                            reference_or_clone
+                                .trim_start_matches(
+                                    format!("{}.types", ftd::interpreter::FTD_INHERITED).as_str()
+                                )
+                                .trim_start_matches(
+                                    format!("{}.colors", ftd::interpreter::FTD_INHERITED).as_str()
+                                )
+                        )
+                    },
+                    line_number: 0,
+                    source: ftd_ast::ValueSource::Default,
+                    condition: None,
                 },
-                line_number: 0,
-                source: ftd_ast::ValueSource::Default,
-                condition: None,
-            },
-            &mut doc.itdoc(),
-            property_value.is_mutable(),
-            Some(&property_value.kind().into_kind_data()),
-        ) {
-            Ok(ftd::interpreter::StateWithThing::Thing(property)) => {
-                *property_value = property;
-            }
-            _ => {
-                property_value.set_reference_or_clone(
-                    format!("ftd#{}", reference_or_clone.trim_start_matches("ftd.")).as_str(),
-                );
-            }
+                &mut doc.itdoc(),
+                property_value.is_mutable(),
+                Some(&property_value.kind().into_kind_data()),
+            )
+        {
+            *property_value = property;
+        } else {
+            property_value.set_reference_or_clone(
+                format!("ftd#{}", reference_or_clone.trim_start_matches("ftd.")).as_str(),
+            );
         }
     }
 }
@@ -616,7 +614,7 @@ pub(crate) fn get_evaluated_property(
         },
     )?;
     let sources = argument.to_sources();
-    match ftd::interpreter::utils::find_properties_by_source(
+    if let Some(property) = ftd::interpreter::utils::find_properties_by_source(
         sources.as_slice(),
         properties,
         doc_name,
@@ -626,24 +624,21 @@ pub(crate) fn get_evaluated_property(
     .into_iter()
     .find(|v| v.condition.is_none())
     {
-        Some(property) => get_evaluated_property(
+        get_evaluated_property(
             &property,
             properties,
             arguments,
             component_name,
             doc_name,
             line_number,
-        ),
-        _ => {
-            if argument.kind.is_optional() || argument.kind.is_list() {
-                Ok(None)
-            } else {
-                ftd::executor::utils::parse_error(
-                    format!("Expected Value for `{}`", key).as_str(),
-                    doc_name,
-                    line_number,
-                )
-            }
-        }
+        )
+    } else if argument.kind.is_optional() || argument.kind.is_list() {
+        Ok(None)
+    } else {
+        ftd::executor::utils::parse_error(
+            format!("Expected Value for `{}`", key).as_str(),
+            doc_name,
+            line_number,
+        )
     }
 }

--- a/ftd/src/executor/value.rs
+++ b/ftd/src/executor/value.rs
@@ -157,23 +157,18 @@ pub(crate) fn find_value_by_argument(
         }
     } else {
         for p in properties.iter() {
-            match p.resolve(&doc.itdoc(), inherited_variables) {
-                Ok(Some(v)) => {
-                    value = Some(v);
-                    line_number = Some(p.line_number);
-                    if p.condition.is_some() {
-                        break;
-                    }
+            if let Ok(Some(v)) = p.resolve(&doc.itdoc(), inherited_variables) {
+                value = Some(v);
+                line_number = Some(p.line_number);
+                if p.condition.is_some() {
+                    break;
                 }
-                _ => {
-                    if p.condition.is_none() {
-                        if let Some(v) = p.value.get_reference_or_clone() {
-                            value = Some(fastn_resolved::Value::new_string(
-                                format!("{{{}}}", v).as_str(),
-                            ));
-                            line_number = Some(p.line_number);
-                        }
-                    }
+            } else if p.condition.is_none() {
+                if let Some(v) = p.value.get_reference_or_clone() {
+                    value = Some(fastn_resolved::Value::new_string(
+                        format!("{{{}}}", v).as_str(),
+                    ));
+                    line_number = Some(p.line_number);
                 }
             }
         }

--- a/ftd/src/ftd2021/p1/parser.rs
+++ b/ftd/src/ftd2021/p1/parser.rs
@@ -411,10 +411,10 @@ mod test {
     // invocation of these, instead of inside these, so jumping to failing test
     // is easier.
     macro_rules! p {
-        ($s:expr, $t: expr_2021,) => {
+        ($s:expr, $t: expr,) => {
             p!($s, $t)
         };
-        ($s:expr, $t: expr_2021) => {
+        ($s:expr, $t: expr) => {
             assert_eq!(
                 super::parse($s, "foo")
                     .unwrap_or_else(|e| panic!("{}", e))
@@ -427,10 +427,10 @@ mod test {
     }
 
     macro_rules! f {
-        ($s:expr, $m: expr_2021,) => {
+        ($s:expr, $m: expr,) => {
             f!($s, $m)
         };
-        ($s:expr, $m: expr_2021) => {
+        ($s:expr, $m: expr) => {
             match super::parse($s, "foo") {
                 Ok(r) => panic!("expected failure, found: {:?}", r),
                 Err(e) => {
@@ -656,17 +656,15 @@ mod test {
 
         "
             ),
-            vec![
-                super::Section::with_name("step")
-                    .add_header("method", "GET")
-                    .add_sub_section(
-                        super::SubSection::with_name("realm.rr.activity")
-                            .add_header("okind", "")
-                            .add_header("oid", "")
-                            .add_header("ekind", "")
-                            .and_body("null")
-                    )
-            ]
+            vec![super::Section::with_name("step")
+                .add_header("method", "GET")
+                .add_sub_section(
+                    super::SubSection::with_name("realm.rr.activity")
+                        .add_header("okind", "")
+                        .add_header("oid", "")
+                        .add_header("ekind", "")
+                        .and_body("null")
+                )]
         )
     }
 
@@ -918,10 +916,8 @@ mod test {
 
             "
             ),
-            vec![
-                super::Section::with_name("foo")
-                    .add_sub_section(super::SubSection::with_name("bar").and_body("hello"))
-            ],
+            vec![super::Section::with_name("foo")
+                .add_sub_section(super::SubSection::with_name("bar").and_body("hello"))],
         );
     }
 

--- a/ftd/src/ftd2021/p1/parser.rs
+++ b/ftd/src/ftd2021/p1/parser.rs
@@ -656,15 +656,17 @@ mod test {
 
         "
             ),
-            vec![super::Section::with_name("step")
-                .add_header("method", "GET")
-                .add_sub_section(
-                    super::SubSection::with_name("realm.rr.activity")
-                        .add_header("okind", "")
-                        .add_header("oid", "")
-                        .add_header("ekind", "")
-                        .and_body("null")
-                )]
+            vec![
+                super::Section::with_name("step")
+                    .add_header("method", "GET")
+                    .add_sub_section(
+                        super::SubSection::with_name("realm.rr.activity")
+                            .add_header("okind", "")
+                            .add_header("oid", "")
+                            .add_header("ekind", "")
+                            .and_body("null")
+                    )
+            ]
         )
     }
 
@@ -916,8 +918,10 @@ mod test {
 
             "
             ),
-            vec![super::Section::with_name("foo")
-                .add_sub_section(super::SubSection::with_name("bar").and_body("hello"))],
+            vec![
+                super::Section::with_name("foo")
+                    .add_sub_section(super::SubSection::with_name("bar").and_body("hello"))
+            ],
         );
     }
 

--- a/ftd/src/ftd2021/p2/document.rs
+++ b/ftd/src/ftd2021/p2/document.rs
@@ -25,11 +25,10 @@ impl Document {
                 value, flags: flag, ..
             }) = v
             {
-                let val = match value.resolve(0, &doc) {
-                    Ok(val) => val,
-                    _ => {
-                        continue;
-                    }
+                let val = if let Ok(val) = value.resolve(0, &doc) {
+                    val
+                } else {
+                    continue;
                 };
                 if let Some(value) = get_value(&val, &doc) {
                     d.insert(k.to_string(), value);
@@ -53,11 +52,10 @@ impl Document {
             if let ftd::Value::List { data, .. } = value {
                 let mut list_data = vec![];
                 for val in data {
-                    let val = match val.resolve(0, doc) {
-                        Ok(val) => val,
-                        _ => {
-                            continue;
-                        }
+                    let val = if let Ok(val) = val.resolve(0, doc) {
+                        val
+                    } else {
+                        continue;
                     };
                     if let Some(val) = get_value(&val, doc) {
                         list_data.push(val);
@@ -597,7 +595,11 @@ impl Document {
 
         // find any text with caption
         if let Some(t) = Self::find_text(&self.main.container.children, |t| {
-            if t.line { Some(t.text.clone()) } else { None }
+            if t.line {
+                Some(t.text.clone())
+            } else {
+                None
+            }
         }) {
             return Some(t);
         }
@@ -662,7 +664,7 @@ impl Document {
                     format!("not a record: {:?}", t),
                     self.name.as_str(),
                     0,
-                );
+                )
             }
         };
 
@@ -678,7 +680,7 @@ impl Document {
                     doc_id: "".to_string(),
                     line_number: 0,
                     key: key.to_string(),
-                });
+                })
             }
         };
         let doc = ftd::ftd2021::p2::TDoc {
@@ -741,7 +743,7 @@ impl Document {
                     format!("unhandled value found(value_to_json): {:?}", v),
                     self.name.as_str(),
                     0,
-                );
+                )
             }
         })
     }

--- a/ftd/src/ftd2021/p2/document.rs
+++ b/ftd/src/ftd2021/p2/document.rs
@@ -595,11 +595,7 @@ impl Document {
 
         // find any text with caption
         if let Some(t) = Self::find_text(&self.main.container.children, |t| {
-            if t.line {
-                Some(t.text.clone())
-            } else {
-                None
-            }
+            if t.line { Some(t.text.clone()) } else { None }
         }) {
             return Some(t);
         }
@@ -664,7 +660,7 @@ impl Document {
                     format!("not a record: {:?}", t),
                     self.name.as_str(),
                     0,
-                )
+                );
             }
         };
 
@@ -680,7 +676,7 @@ impl Document {
                     doc_id: "".to_string(),
                     line_number: 0,
                     key: key.to_string(),
-                })
+                });
             }
         };
         let doc = ftd::ftd2021::p2::TDoc {
@@ -743,7 +739,7 @@ impl Document {
                     format!("unhandled value found(value_to_json): {:?}", v),
                     self.name.as_str(),
                     0,
-                )
+                );
             }
         })
     }

--- a/ftd/src/ftd2021/p2/interpreter.rs
+++ b/ftd/src/ftd2021/p2/interpreter.rs
@@ -192,186 +192,146 @@ impl InterpreterState {
                             &parsed_document.instructions,
                         )?,
                     });
+            } else if let Ok(ftd::ftd2021::variable::VariableData {
+                type_: ftd::ftd2021::variable::Type::Component,
+                ..
+            }) = var_data
+            {
+                // declare a function
+                let d = ftd::Component::from_p1(&p1, &doc)?;
+                let name = doc.resolve_name(p1.line_number, &d.full_name.to_string())?;
+                if self.bag.contains_key(name.as_str()) {
+                    return ftd::ftd2021::p2::utils::e2(
+                        format!("{} is already declared", d.full_name),
+                        doc.name,
+                        p1.line_number,
+                    );
+                }
+                thing.push((name, ftd::ftd2021::p2::Thing::Component(d)));
+                // processed_p1.push(p1.name.to_string());
+            } else if let Ok(ref var_data) = var_data {
+                let d = if p1
+                    .header
+                    .str(doc.name, p1.line_number, "$processor$")
+                    .is_ok()
+                {
+                    // processor case: 1
+                    return Ok(Interpreter::StuckOnProcessor {
+                        state: self,
+                        section: p1,
+                    });
+                } else if var_data.is_none() || var_data.is_optional() {
+                    // declare and instantiate a variable
+                    ftd::Variable::from_p1(&p1, &doc)?
+                } else {
+                    // declare and instantiate a list
+                    ftd::Variable::list_from_p1(&p1, &doc)?
+                };
+                let name = doc.resolve_name(p1.line_number, &d.name)?;
+                if self.bag.contains_key(name.as_str()) {
+                    return ftd::ftd2021::p2::utils::e2(
+                        format!("{} is already declared", d.name),
+                        doc.name,
+                        p1.line_number,
+                    );
+                }
+                thing.push((name, ftd::ftd2021::p2::Thing::Variable(d)));
+            } else if let ftd::ftd2021::p2::Thing::Variable(mut v) =
+                doc.get_thing(p1.line_number, p1.name.as_str())?
+            {
+                assert!(
+                    !(p1.header
+                        .str_optional(doc.name, p1.line_number, "if")?
+                        .is_some()
+                        && p1
+                            .header
+                            .str_optional(doc.name, p1.line_number, "$processor$")?
+                            .is_some())
+                );
+                let (doc_name, remaining) = ftd::ftd2021::p2::utils::get_doc_name_and_remaining(
+                    doc.resolve_name(p1.line_number, p1.name.as_str())?.as_str(),
+                )?;
+                if remaining.is_some()
+                    && p1
+                        .header
+                        .str_optional(doc.name, p1.line_number, "if")?
+                        .is_some()
+                {
+                    return ftd::ftd2021::p2::utils::e2(
+                        "Currently not supporting `if` for field value update.",
+                        doc.name,
+                        p1.line_number,
+                    );
+                }
+                if let Some(expr) = p1.header.str_optional(doc.name, p1.line_number, "if")? {
+                    let val = v.get_value(&p1, &doc)?;
+                    v.conditions.push((
+                        ftd::ftd2021::p2::Boolean::from_expression(
+                            expr,
+                            &doc,
+                            &Default::default(),
+                            (None, None),
+                            p1.line_number,
+                        )?,
+                        val,
+                    ));
+                } else if p1
+                    .header
+                    .str_optional(doc.name, p1.line_number, "$processor$")?
+                    .is_some()
+                {
+                    // processor case: 2
+                    return Ok(Interpreter::StuckOnProcessor {
+                        state: self,
+                        section: p1.to_owned(),
+                    });
+                    // let start = std::time::Instant::now();
+                    // let value = self.lib.process(p1, &doc)?;
+                    // *d_processor = d_processor.saturating_add(std::time::Instant::now() - start);
+                    // v.value = ftd::PropertyValue::Value { value };
+                } else {
+                    v.update_from_p1(&p1, &doc)?;
+                }
+                thing.push((
+                    doc.resolve_name(p1.line_number, doc_name.as_str())?,
+                    ftd::ftd2021::p2::Thing::Variable(doc.set_value(
+                        p1.line_number,
+                        p1.name.as_str(),
+                        v,
+                    )?),
+                ));
             } else {
-                match var_data {
-                    Ok(ftd::ftd2021::variable::VariableData {
-                        type_: ftd::ftd2021::variable::Type::Component,
-                        ..
-                    }) => {
-                        // declare a function
-                        let d = ftd::Component::from_p1(&p1, &doc)?;
-                        let name = doc.resolve_name(p1.line_number, &d.full_name.to_string())?;
-                        if self.bag.contains_key(name.as_str()) {
-                            return ftd::ftd2021::p2::utils::e2(
-                                format!("{} is already declared", d.full_name),
-                                doc.name,
-                                p1.line_number,
-                            );
-                        }
-                        thing.push((name, ftd::ftd2021::p2::Thing::Component(d)));
-                        // processed_p1.push(p1.name.to_string());
+                // cloning because https://github.com/rust-lang/rust/issues/59159
+                match (doc.get_thing(p1.line_number, p1.name.as_str())?).clone() {
+                    ftd::ftd2021::p2::Thing::Variable(_) => {
+                        return ftd::ftd2021::p2::utils::e2(
+                            format!("variable should have prefix $, found: `{}`", p1.name),
+                            doc.name,
+                            p1.line_number,
+                        );
                     }
-                    _ => {
-                        match var_data {
-                            Ok(ref var_data) => {
-                                let d = if p1
-                                    .header
-                                    .str(doc.name, p1.line_number, "$processor$")
-                                    .is_ok()
-                                {
-                                    // processor case: 1
-                                    return Ok(Interpreter::StuckOnProcessor {
-                                        state: self,
-                                        section: p1,
-                                    });
-                                } else if var_data.is_none() || var_data.is_optional() {
-                                    // declare and instantiate a variable
-                                    ftd::Variable::from_p1(&p1, &doc)?
-                                } else {
-                                    // declare and instantiate a list
-                                    ftd::Variable::list_from_p1(&p1, &doc)?
-                                };
-                                let name = doc.resolve_name(p1.line_number, &d.name)?;
-                                if self.bag.contains_key(name.as_str()) {
-                                    return ftd::ftd2021::p2::utils::e2(
-                                        format!("{} is already declared", d.name),
-                                        doc.name,
-                                        p1.line_number,
-                                    );
-                                }
-                                thing.push((name, ftd::ftd2021::p2::Thing::Variable(d)));
-                            }
-                            _ => {
-                                match doc.get_thing(p1.line_number, p1.name.as_str())? {
-                                    ftd::ftd2021::p2::Thing::Variable(mut v) => {
-                                        assert!(
-                                            !(p1.header
-                                                .str_optional(doc.name, p1.line_number, "if")?
-                                                .is_some()
-                                                && p1
-                                                    .header
-                                                    .str_optional(
-                                                        doc.name,
-                                                        p1.line_number,
-                                                        "$processor$"
-                                                    )?
-                                                    .is_some())
-                                        );
-                                        let (doc_name, remaining) =
-                                            ftd::ftd2021::p2::utils::get_doc_name_and_remaining(
-                                                doc.resolve_name(p1.line_number, p1.name.as_str())?
-                                                    .as_str(),
-                                            )?;
-                                        if remaining.is_some()
-                                            && p1
-                                                .header
-                                                .str_optional(doc.name, p1.line_number, "if")?
-                                                .is_some()
-                                        {
-                                            return ftd::ftd2021::p2::utils::e2(
-                                                "Currently not supporting `if` for field value update.",
-                                                doc.name,
-                                                p1.line_number,
-                                            );
-                                        }
-                                        match p1.header.str_optional(
-                                            doc.name,
-                                            p1.line_number,
-                                            "if",
-                                        )? {
-                                            Some(expr) => {
-                                                let val = v.get_value(&p1, &doc)?;
-                                                v.conditions.push((
-                                                    ftd::ftd2021::p2::Boolean::from_expression(
-                                                        expr,
-                                                        &doc,
-                                                        &Default::default(),
-                                                        (None, None),
-                                                        p1.line_number,
-                                                    )?,
-                                                    val,
-                                                ));
-                                            }
-                                            _ => {
-                                                if p1
-                                                    .header
-                                                    .str_optional(
-                                                        doc.name,
-                                                        p1.line_number,
-                                                        "$processor$",
-                                                    )?
-                                                    .is_some()
-                                                {
-                                                    // processor case: 2
-                                                    return Ok(Interpreter::StuckOnProcessor {
-                                                        state: self,
-                                                        section: p1.to_owned(),
-                                                    });
-                                                    // let start = std::time::Instant::now();
-                                                    // let value = self.lib.process(p1, &doc)?;
-                                                    // *d_processor = d_processor.saturating_add(std::time::Instant::now() - start);
-                                                    // v.value = ftd::PropertyValue::Value { value };
-                                                } else {
-                                                    v.update_from_p1(&p1, &doc)?;
-                                                }
-                                            }
-                                        }
-                                        thing.push((
-                                            doc.resolve_name(p1.line_number, doc_name.as_str())?,
-                                            ftd::ftd2021::p2::Thing::Variable(doc.set_value(
-                                                p1.line_number,
-                                                p1.name.as_str(),
-                                                v,
-                                            )?),
-                                        ));
-                                    }
-                                    _ => {
-                                        // cloning because https://github.com/rust-lang/rust/issues/59159
-                                        match (doc.get_thing(p1.line_number, p1.name.as_str())?)
-                                            .clone()
-                                        {
-                                            ftd::ftd2021::p2::Thing::Variable(_) => {
-                                                return ftd::ftd2021::p2::utils::e2(
-                                                    format!(
-                                                        "variable should have prefix $, found: `{}`",
-                                                        p1.name
-                                                    ),
-                                                    doc.name,
-                                                    p1.line_number,
-                                                );
-                                            }
-                                            ftd::ftd2021::p2::Thing::Component(c) => {
-                                                if p1
-                                                    .header
-                                                    .str_optional(
-                                                        doc.name,
-                                                        p1.line_number,
-                                                        "$processor$",
-                                                    )?
-                                                    .is_some()
-                                                {
-                                                    // processor case: 3
-                                                    return Ok(Interpreter::StuckOnProcessor {
-                                                        state: self,
-                                                        section: p1.to_owned(),
-                                                    });
-                                                }
-                                                match p1.header.str(
-                                                    doc.name,
-                                                    p1.line_number,
-                                                    "$loop$",
-                                                ) {
-                                                    Ok(loop_data) => {
-                                                        let section_to_subsection =
-                                                            ftd::ftd2021::p1::SubSection {
-                                                                name: p1.name.to_string(),
-                                                                caption: p1.caption.to_owned(),
-                                                                header: p1.header.to_owned(),
-                                                                body: p1.body.to_owned(),
-                                                                is_commented: p1.is_commented,
-                                                                line_number: p1.line_number,
-                                                            };
-                                                        parsed_document.instructions.push(
+                    ftd::ftd2021::p2::Thing::Component(c) => {
+                        if p1
+                            .header
+                            .str_optional(doc.name, p1.line_number, "$processor$")?
+                            .is_some()
+                        {
+                            // processor case: 3
+                            return Ok(Interpreter::StuckOnProcessor {
+                                state: self,
+                                section: p1.to_owned(),
+                            });
+                        }
+                        if let Ok(loop_data) = p1.header.str(doc.name, p1.line_number, "$loop$") {
+                            let section_to_subsection = ftd::ftd2021::p1::SubSection {
+                                name: p1.name.to_string(),
+                                caption: p1.caption.to_owned(),
+                                header: p1.header.to_owned(),
+                                body: p1.body.to_owned(),
+                                is_commented: p1.is_commented,
+                                line_number: p1.line_number,
+                            };
+                            parsed_document.instructions.push(
                                 ftd::Instruction::RecursiveChildComponent {
                                     child: ftd::ftd2021::component::recursive_child_component(
                                         loop_data,
@@ -382,20 +342,18 @@ impl InterpreterState {
                                     )?,
                                 },
                             );
-                                                    }
-                                                    _ => {
-                                                        let mut parent =
-                                                            ftd::ChildComponent::from_p1(
-                                                                p1.line_number,
-                                                                p1.name.as_str(),
-                                                                &p1.header,
-                                                                &p1.caption,
-                                                                &p1.body,
-                                                                &doc,
-                                                                &Default::default(),
-                                                            )?;
+                        } else {
+                            let mut parent = ftd::ChildComponent::from_p1(
+                                p1.line_number,
+                                p1.name.as_str(),
+                                &p1.header,
+                                &p1.caption,
+                                &p1.body,
+                                &doc,
+                                &Default::default(),
+                            )?;
 
-                                                        ftd::ftd2021::InterpreterState::evaluate_component_for_headings(
+                            ftd::ftd2021::InterpreterState::evaluate_component_for_headings(
                                 &mut parsed_document.page_headings,
                                 &c,
                                 &mut parent,
@@ -403,16 +361,13 @@ impl InterpreterState {
                                 &self.package_name,
                             )?;
 
-                                                        let mut children = vec![];
+                            let mut children = vec![];
 
-                                                        for sub in p1.sub_sections.0.iter() {
-                                                            match sub.header.str(
-                                                                doc.name,
-                                                                p1.line_number,
-                                                                "$loop$",
-                                                            ) {
-                                                                Ok(loop_data) => {
-                                                                    children.push(
+                            for sub in p1.sub_sections.0.iter() {
+                                if let Ok(loop_data) =
+                                    sub.header.str(doc.name, p1.line_number, "$loop$")
+                                {
+                                    children.push(
                                         ftd::ftd2021::component::recursive_child_component(
                                             loop_data,
                                             sub,
@@ -421,24 +376,21 @@ impl InterpreterState {
                                             None,
                                         )?,
                                     );
-                                                                }
-                                                                _ => {
-                                                                    let root_name =
+                                } else {
+                                    let root_name =
                                         ftd::ftd2021::p2::utils::get_root_component_name(
                                             &doc,
                                             parent.root.as_str(),
                                             sub.line_number,
                                         )?;
-                                                                    let child = if root_name
-                                                                        .eq("ftd#text")
-                                                                    {
-                                                                        ftd::ftd2021::p2::utils::get_markup_child(
+                                    let child = if root_name.eq("ftd#text") {
+                                        ftd::ftd2021::p2::utils::get_markup_child(
                                             sub,
                                             &doc,
                                             &parent.arguments,
                                         )?
-                                                                    } else {
-                                                                        ftd::ChildComponent::from_p1(
+                                    } else {
+                                        ftd::ChildComponent::from_p1(
                                             sub.line_number,
                                             sub.name.as_str(),
                                             &sub.header,
@@ -447,56 +399,40 @@ impl InterpreterState {
                                             &doc,
                                             &parent.arguments,
                                         )?
-                                                                    };
-                                                                    children.push(child);
-                                                                }
-                                                            }
-                                                        }
-
-                                                        parsed_document.instructions.push(
-                                                            ftd::Instruction::Component {
-                                                                children,
-                                                                parent,
-                                                            },
-                                                        )
-                                                    }
-                                                }
-                                            }
-                                            ftd::ftd2021::p2::Thing::Record(mut r) => {
-                                                r.add_instance(&p1, &doc)?;
-                                                thing.push((
-                                                    doc.resolve_name(p1.line_number, &p1.name)?,
-                                                    ftd::ftd2021::p2::Thing::Record(r),
-                                                ));
-                                            }
-                                            ftd::ftd2021::p2::Thing::OrType(_r) => {
-                                                // do we allow initialization of a record by name? nopes
-                                                return ftd::ftd2021::p2::utils::e2(
-                                                    format!("'{}' is an or-type", p1.name.as_str()),
-                                                    doc.name,
-                                                    p1.line_number,
-                                                );
-                                            }
-                                            ftd::ftd2021::p2::Thing::OrTypeWithVariant {
-                                                ..
-                                            } => {
-                                                // do we allow initialization of a record by name? nopes
-                                                return ftd::ftd2021::p2::utils::e2(
-                                                    format!(
-                                                        "'{}' is an or-type variant",
-                                                        p1.name.as_str(),
-                                                    ),
-                                                    doc.name,
-                                                    p1.line_number,
-                                                );
-                                            }
-                                        };
-                                    }
+                                    };
+                                    children.push(child);
                                 }
                             }
+
+                            parsed_document
+                                .instructions
+                                .push(ftd::Instruction::Component { children, parent })
                         }
                     }
-                }
+                    ftd::ftd2021::p2::Thing::Record(mut r) => {
+                        r.add_instance(&p1, &doc)?;
+                        thing.push((
+                            doc.resolve_name(p1.line_number, &p1.name)?,
+                            ftd::ftd2021::p2::Thing::Record(r),
+                        ));
+                    }
+                    ftd::ftd2021::p2::Thing::OrType(_r) => {
+                        // do we allow initialization of a record by name? nopes
+                        return ftd::ftd2021::p2::utils::e2(
+                            format!("'{}' is an or-type", p1.name.as_str()),
+                            doc.name,
+                            p1.line_number,
+                        );
+                    }
+                    ftd::ftd2021::p2::Thing::OrTypeWithVariant { .. } => {
+                        // do we allow initialization of a record by name? nopes
+                        return ftd::ftd2021::p2::utils::e2(
+                            format!("'{}' is an or-type variant", p1.name.as_str(),),
+                            doc.name,
+                            p1.line_number,
+                        );
+                    }
+                };
             }
             self.bag.extend(thing);
         }

--- a/ftd/src/ftd2021/p2/kind.rs
+++ b/ftd/src/ftd2021/p2/kind.rs
@@ -132,33 +132,75 @@ impl Kind {
         doc_id: &str,
     ) -> ftd::ftd2021::p1::Result<ftd::Value> {
         Ok(match self {
-            ftd::ftd2021::p2::Kind::String { default: Some(d), .. } => ftd::Value::String {text: d.to_string(), source: ftd::TextSource::Default} ,
-            ftd::ftd2021::p2::Kind::Integer { default: Some(d), .. } => ftd::Value::Integer { value: match d.parse::<i64>() {
+            ftd::ftd2021::p2::Kind::String {
+                default: Some(d), ..
+            } => ftd::Value::String {
+                text: d.to_string(),
+                source: ftd::TextSource::Default,
+            },
+            ftd::ftd2021::p2::Kind::Integer {
+                default: Some(d), ..
+            } => ftd::Value::Integer {
+                value: match d.parse::<i64>() {
                     Ok(v) => v,
-                    Err(_) => return ftd::ftd2021::p2::utils::e2(format!("{} is not an integer", d), doc_id, line_number),
+                    Err(_) => {
+                        return ftd::ftd2021::p2::utils::e2(
+                            format!("{} is not an integer", d),
+                            doc_id,
+                            line_number,
+                        );
+                    }
                 },
             },
-            ftd::ftd2021::p2::Kind::Decimal { default: Some(d), .. } => ftd::Value::Decimal { value: d.parse::<f64>().map_err(|e| ftd::ftd2021::p1::Error::ParseError {
-                    message: e.to_string(),
-                    doc_id: doc_id.to_string(),
+            ftd::ftd2021::p2::Kind::Decimal {
+                default: Some(d), ..
+            } => ftd::Value::Decimal {
+                value: d
+                    .parse::<f64>()
+                    .map_err(|e| ftd::ftd2021::p1::Error::ParseError {
+                        message: e.to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number,
+                    })?,
+            },
+            ftd::ftd2021::p2::Kind::Boolean {
+                default: Some(d), ..
+            } => ftd::Value::Boolean {
+                value: d
+                    .parse::<bool>()
+                    .map_err(|e| ftd::ftd2021::p1::Error::ParseError {
+                        message: e.to_string(),
+                        doc_id: doc_id.to_string(),
+                        line_number,
+                    })?,
+            },
+            ftd::ftd2021::p2::Kind::Optional { kind, .. } => {
+                if let Ok(f) = kind.to_value(line_number, doc_id) {
+                    ftd::Value::Optional {
+                        data: Box::new(Some(f)),
+                        kind: kind.as_ref().to_owned(),
+                    }
+                } else {
+                    ftd::Value::Optional {
+                        data: Box::new(None),
+                        kind: kind.as_ref().to_owned(),
+                    }
+                }
+            }
+            ftd::ftd2021::p2::Kind::List { kind, .. } => ftd::Value::List {
+                data: vec![],
+                kind: kind.as_ref().to_owned(),
+            },
+            _ => {
+                return ftd::ftd2021::p2::utils::e2(
+                    format!(
+                        "2 Kind supported for default value are string, integer, decimal and boolean with default value, found: kind `{:?}`",
+                        &self
+                    ),
+                    doc_id,
                     line_number,
-                })?,
-            },
-            ftd::ftd2021::p2::Kind::Boolean { default: Some(d), .. } => ftd::Value::Boolean { value: d.parse::<bool>().map_err(|e| ftd::ftd2021::p1::Error::ParseError {
-                    message: e.to_string(),
-                    doc_id: doc_id.to_string(),
-                    line_number,
-                })?,
-            },
-            ftd::ftd2021::p2::Kind::Optional {kind, ..} => if let Ok(f) = kind.to_value(line_number, doc_id) {
-                ftd::Value::Optional {data: Box::new(Some(f)), kind: kind.as_ref().to_owned()}
-            } else {
-                ftd::Value::Optional {data: Box::new(None), kind: kind.as_ref().to_owned()}
-            },
-            ftd::ftd2021::p2::Kind::List { kind, .. } => ftd::Value::List { data: vec![], kind: kind.as_ref().to_owned() },
-            _ => return ftd::ftd2021::p2::utils::e2(
-                format!("2 Kind supported for default value are string, integer, decimal and boolean with default value, found: kind `{:?}`", &self),
-                doc_id,  line_number),
+                );
+            }
         })
     }
 
@@ -488,7 +530,7 @@ impl Kind {
                                 value: ftd::Value::None {
                                     kind: *kind.clone(),
                                 },
-                            })
+                            });
                         }
                     },
                     ftd::ftd2021::p2::Kind::String { .. }
@@ -500,7 +542,7 @@ impl Kind {
                             format!("`{}` is {:?}", name, t),
                             doc.name,
                             line_number,
-                        )
+                        );
                     }
                 };
 

--- a/ftd/src/ftd2021/p2/kind.rs
+++ b/ftd/src/ftd2021/p2/kind.rs
@@ -132,74 +132,33 @@ impl Kind {
         doc_id: &str,
     ) -> ftd::ftd2021::p1::Result<ftd::Value> {
         Ok(match self {
-            ftd::ftd2021::p2::Kind::String {
-                default: Some(d), ..
-            } => ftd::Value::String {
-                text: d.to_string(),
-                source: ftd::TextSource::Default,
-            },
-            ftd::ftd2021::p2::Kind::Integer {
-                default: Some(d), ..
-            } => ftd::Value::Integer {
-                value: match d.parse::<i64>() {
+            ftd::ftd2021::p2::Kind::String { default: Some(d), .. } => ftd::Value::String {text: d.to_string(), source: ftd::TextSource::Default} ,
+            ftd::ftd2021::p2::Kind::Integer { default: Some(d), .. } => ftd::Value::Integer { value: match d.parse::<i64>() {
                     Ok(v) => v,
-                    Err(_) => {
-                        return ftd::ftd2021::p2::utils::e2(
-                            format!("{} is not an integer", d),
-                            doc_id,
-                            line_number,
-                        );
-                    }
+                    Err(_) => return ftd::ftd2021::p2::utils::e2(format!("{} is not an integer", d), doc_id, line_number),
                 },
             },
-            ftd::ftd2021::p2::Kind::Decimal {
-                default: Some(d), ..
-            } => ftd::Value::Decimal {
-                value: d
-                    .parse::<f64>()
-                    .map_err(|e| ftd::ftd2021::p1::Error::ParseError {
-                        message: e.to_string(),
-                        doc_id: doc_id.to_string(),
-                        line_number,
-                    })?,
-            },
-            ftd::ftd2021::p2::Kind::Boolean {
-                default: Some(d), ..
-            } => ftd::Value::Boolean {
-                value: d
-                    .parse::<bool>()
-                    .map_err(|e| ftd::ftd2021::p1::Error::ParseError {
-                        message: e.to_string(),
-                        doc_id: doc_id.to_string(),
-                        line_number,
-                    })?,
-            },
-            ftd::ftd2021::p2::Kind::Optional { kind, .. } => {
-                match kind.to_value(line_number, doc_id) {
-                    Ok(f) => ftd::Value::Optional {
-                        data: Box::new(Some(f)),
-                        kind: kind.as_ref().to_owned(),
-                    },
-                    _ => ftd::Value::Optional {
-                        data: Box::new(None),
-                        kind: kind.as_ref().to_owned(),
-                    },
-                }
-            }
-            ftd::ftd2021::p2::Kind::List { kind, .. } => ftd::Value::List {
-                data: vec![],
-                kind: kind.as_ref().to_owned(),
-            },
-            _ => {
-                return ftd::ftd2021::p2::utils::e2(
-                    format!(
-                        "2 Kind supported for default value are string, integer, decimal and boolean with default value, found: kind `{:?}`",
-                        &self
-                    ),
-                    doc_id,
+            ftd::ftd2021::p2::Kind::Decimal { default: Some(d), .. } => ftd::Value::Decimal { value: d.parse::<f64>().map_err(|e| ftd::ftd2021::p1::Error::ParseError {
+                    message: e.to_string(),
+                    doc_id: doc_id.to_string(),
                     line_number,
-                );
-            }
+                })?,
+            },
+            ftd::ftd2021::p2::Kind::Boolean { default: Some(d), .. } => ftd::Value::Boolean { value: d.parse::<bool>().map_err(|e| ftd::ftd2021::p1::Error::ParseError {
+                    message: e.to_string(),
+                    doc_id: doc_id.to_string(),
+                    line_number,
+                })?,
+            },
+            ftd::ftd2021::p2::Kind::Optional {kind, ..} => if let Ok(f) = kind.to_value(line_number, doc_id) {
+                ftd::Value::Optional {data: Box::new(Some(f)), kind: kind.as_ref().to_owned()}
+            } else {
+                ftd::Value::Optional {data: Box::new(None), kind: kind.as_ref().to_owned()}
+            },
+            ftd::ftd2021::p2::Kind::List { kind, .. } => ftd::Value::List { data: vec![], kind: kind.as_ref().to_owned() },
+            _ => return ftd::ftd2021::p2::utils::e2(
+                format!("2 Kind supported for default value are string, integer, decimal and boolean with default value, found: kind `{:?}`", &self),
+                doc_id,  line_number),
         })
     }
 
@@ -529,7 +488,7 @@ impl Kind {
                                 value: ftd::Value::None {
                                     kind: *kind.clone(),
                                 },
-                            });
+                            })
                         }
                     },
                     ftd::ftd2021::p2::Kind::String { .. }
@@ -541,7 +500,7 @@ impl Kind {
                             format!("`{}` is {:?}", name, t),
                             doc.name,
                             line_number,
-                        );
+                        )
                     }
                 };
 

--- a/ftd/src/ftd2021/p2/library.rs
+++ b/ftd/src/ftd2021/p2/library.rs
@@ -37,52 +37,52 @@ fn read_package(
             line_number: section.line_number,
         }
     })?;
-    match var.value.resolve(section.line_number, doc) {
-        Ok(ftd::Value::List {
-            kind:
-                ftd::ftd2021::p2::Kind::String {
-                    caption,
-                    body,
-                    default,
-                    is_reference,
-                },
-            ..
-        }) => {
-            let mut data = vec![];
-            for line in get.split('\n') {
-                if line.is_empty() {
-                    break;
-                }
-                if line.contains('=') {
-                    let mut part = line.splitn(2, '=');
-                    let _part_1 = part.next().unwrap().trim();
-                    let part_2 = part.next().unwrap().trim();
-                    data.push(ftd::PropertyValue::Value {
-                        value: ftd::Value::String {
-                            text: part_2.to_string(),
-                            source: ftd::TextSource::Header,
-                        },
-                    });
-                }
+    if let Ok(ftd::Value::List {
+        kind:
+            ftd::ftd2021::p2::Kind::String {
+                caption,
+                body,
+                default,
+                is_reference,
+            },
+        ..
+    }) = var.value.resolve(section.line_number, doc)
+    {
+        let mut data = vec![];
+        for line in get.split('\n') {
+            if line.is_empty() {
+                break;
             }
-            Ok(ftd::Value::List {
-                data,
-                kind: ftd::ftd2021::p2::Kind::String {
-                    caption,
-                    body,
-                    default,
-                    is_reference,
-                },
-            })
+            if line.contains('=') {
+                let mut part = line.splitn(2, '=');
+                let _part_1 = part.next().unwrap().trim();
+                let part_2 = part.next().unwrap().trim();
+                data.push(ftd::PropertyValue::Value {
+                    value: ftd::Value::String {
+                        text: part_2.to_string(),
+                        source: ftd::TextSource::Header,
+                    },
+                });
+            }
         }
-        _ => ftd::ftd2021::p2::utils::unknown_processor_error(
+        Ok(ftd::Value::List {
+            data,
+            kind: ftd::ftd2021::p2::Kind::String {
+                caption,
+                body,
+                default,
+                is_reference,
+            },
+        })
+    } else {
+        ftd::ftd2021::p2::utils::unknown_processor_error(
             format!(
                 "list should have 'string' kind, found {:?}",
                 var.value.kind()
             ),
             doc.name.to_string(),
             section.line_number,
-        ),
+        )
     }
 }
 
@@ -118,65 +118,64 @@ fn read_records(
             line_number: section.line_number,
         }
     })?;
-    match var.value.resolve(section.line_number, doc) {
-        Ok(ftd::Value::List {
-            kind:
-                ftd::ftd2021::p2::Kind::Record {
-                    name, is_reference, ..
-                },
-            ..
-        }) => {
-            let rec = doc.get_record(section.line_number, name.as_str())?;
-            let mut data = vec![];
-            for line in get.split('\n') {
-                if line.is_empty() {
-                    break;
-                }
-                if line.contains('=') {
-                    let mut fields: ftd::Map<ftd::PropertyValue> = Default::default();
-                    let mut parts = line.splitn(2, '=');
-                    for (k, v) in &rec.fields {
-                        let part = parts.next().unwrap().trim();
-                        match v {
-                            ftd::ftd2021::p2::Kind::String { .. } => {
-                                fields.insert(
-                                    k.to_string(),
-                                    ftd::PropertyValue::Value {
-                                        value: ftd::ftd2021::variable::Value::String {
-                                            text: part.to_string(),
-                                            source: ftd::TextSource::Header,
-                                        },
-                                    },
-                                );
-                            }
-                            _ => unimplemented!(),
-                        }
-                    }
-                    data.push(ftd::PropertyValue::Value {
-                        value: ftd::Value::Record {
-                            name: rec.name.clone(),
-                            fields,
-                        },
-                    });
-                }
+    if let Ok(ftd::Value::List {
+        kind: ftd::ftd2021::p2::Kind::Record {
+            name, is_reference, ..
+        },
+        ..
+    }) = var.value.resolve(section.line_number, doc)
+    {
+        let rec = doc.get_record(section.line_number, name.as_str())?;
+        let mut data = vec![];
+        for line in get.split('\n') {
+            if line.is_empty() {
+                break;
             }
-            Ok(ftd::Value::List {
-                data,
-                kind: ftd::ftd2021::p2::Kind::Record {
-                    name,
-                    default: None,
-                    is_reference,
-                },
-            })
+            if line.contains('=') {
+                let mut fields: ftd::Map<ftd::PropertyValue> = Default::default();
+                let mut parts = line.splitn(2, '=');
+                for (k, v) in &rec.fields {
+                    let part = parts.next().unwrap().trim();
+                    match v {
+                        ftd::ftd2021::p2::Kind::String { .. } => {
+                            fields.insert(
+                                k.to_string(),
+                                ftd::PropertyValue::Value {
+                                    value: ftd::ftd2021::variable::Value::String {
+                                        text: part.to_string(),
+                                        source: ftd::TextSource::Header,
+                                    },
+                                },
+                            );
+                        }
+                        _ => unimplemented!(),
+                    }
+                }
+                data.push(ftd::PropertyValue::Value {
+                    value: ftd::Value::Record {
+                        name: rec.name.clone(),
+                        fields,
+                    },
+                });
+            }
         }
-        _ => ftd::ftd2021::p2::utils::unknown_processor_error(
+        Ok(ftd::Value::List {
+            data,
+            kind: ftd::ftd2021::p2::Kind::Record {
+                name,
+                default: None,
+                is_reference,
+            },
+        })
+    } else {
+        ftd::ftd2021::p2::utils::unknown_processor_error(
             format!(
                 "list should have 'string' kind, found {:?}",
                 var.value.kind()
             ),
             doc.name.to_string(),
             section.line_number,
-        ),
+        )
     }
 }
 

--- a/ftd/src/ftd2021/p2/tdoc.rs
+++ b/ftd/src/ftd2021/p2/tdoc.rs
@@ -102,20 +102,17 @@ impl TDoc<'_> {
                     arguments,
                     None,
                 )?
+            } else if let Ok(value) = arg.to_value(0, self.name) {
+                ftd::PropertyValue::Value { value }
             } else {
-                match arg.to_value(0, self.name) {
-                    Ok(value) => ftd::PropertyValue::Value { value },
-                    _ => {
-                        return ftd::ftd2021::p2::utils::e2(
-                            format!(
-                                "expected default value for local variable 2 {}: {:?} in {}",
-                                k, arg, root
-                            ),
-                            self.name,
-                            0,
-                        );
-                    }
-                }
+                return ftd::ftd2021::p2::utils::e2(
+                    format!(
+                        "expected default value for local variable 2 {}: {:?} in {}",
+                        k, arg, root
+                    ),
+                    self.name,
+                    0,
+                );
             };
             if let ftd::PropertyValue::Variable { ref mut name, .. } = default {
                 if !self.local_variables.contains_key(name) && !self.bag.contains_key(name) {
@@ -1095,9 +1092,12 @@ impl TDoc<'_> {
                 v.value.resolve(line_number, self)?,
                 v.conditions
                     .into_iter()
-                    .flat_map(|(b, v)| match v.resolve(line_number, self) {
-                        Ok(v) => Some((b, v)),
-                        _ => None,
+                    .flat_map(|(b, v)| {
+                        if let Ok(v) = v.resolve(line_number, self) {
+                            Some((b, v))
+                        } else {
+                            None
+                        }
                     })
                     .collect(),
             )),

--- a/ftd/src/ftd2021/p2/utils.rs
+++ b/ftd/src/ftd2021/p2/utils.rs
@@ -1809,7 +1809,7 @@ pub fn convert_to_document_id(doc_name: &str) -> String {
 #[cfg(test)]
 mod test {
     macro_rules! p {
-        ($s:expr, $id: expr_2021, $alias: expr_2021) => {
+        ($s:expr, $id: expr, $alias: expr) => {
             assert_eq!(
                 super::parse_import(&Some($s.to_string()), $id, 0)
                     .unwrap_or_else(|e| panic!("{}", e)),

--- a/ftd/src/ftd2021/test.rs
+++ b/ftd/src/ftd2021/test.rs
@@ -3676,11 +3676,7 @@ mod interpreter {
                     vec![
                         (s("about"), {
                             let s = ftd::ftd2021::p2::Kind::body();
-                            if about_optional {
-                                s.into_optional()
-                            } else {
-                                s
-                            }
+                            if about_optional { s.into_optional() } else { s }
                         }),
                         (s("src"), {
                             let s = ftd::ftd2021::p2::Kind::Record {
@@ -3688,11 +3684,7 @@ mod interpreter {
                                 default: None,
                                 is_reference: false,
                             };
-                            if about_optional {
-                                s.into_optional()
-                            } else {
-                                s
-                            }
+                            if about_optional { s.into_optional() } else { s }
                         }),
                         (s("title"), ftd::ftd2021::p2::Kind::caption()),
                     ],
@@ -12207,17 +12199,19 @@ mod interpreter {
                     },
                 }),
                 kernel: false,
-                invocations: vec![std::iter::IntoIterator::into_iter([
-                    (
-                        s("name"),
-                        ftd::Value::String {
-                            text: s("Hello"),
-                            source: ftd::TextSource::Caption,
-                        },
-                    ),
-                    (s("open"), ftd::Value::Boolean { value: true }),
-                ])
-                .collect()],
+                invocations: vec![
+                    std::iter::IntoIterator::into_iter([
+                        (
+                            s("name"),
+                            ftd::Value::String {
+                                text: s("Hello"),
+                                source: ftd::TextSource::Caption,
+                            },
+                        ),
+                        (s("open"), ftd::Value::Boolean { value: true }),
+                    ])
+                    .collect(),
+                ],
                 line_number: 1,
                 ..Default::default()
             }),
@@ -17804,7 +17798,7 @@ mod component {
     fn caption_body_conflicts() {
         // Caption and Header Value conflict
         intf!(
-             "-- ftd.row A: 
+            "-- ftd.row A: 
             caption message: Default message
             
             -- A: Im the message here 
@@ -17815,7 +17809,7 @@ mod component {
 
         // Caption and Body conflict
         intf!(
-             "-- ftd.row A: 
+            "-- ftd.row A: 
             caption or body msg: 
             
             -- A: Caption will say hello

--- a/ftd/src/ftd2021/test.rs
+++ b/ftd/src/ftd2021/test.rs
@@ -77,10 +77,10 @@ pub fn interpret(
 }
 
 macro_rules! p {
-    ($s:expr, $t: expr_2021,) => {
+    ($s:expr, $t: expr,) => {
         p!($s, $t)
     };
-    ($s:expr, $t: expr_2021) => {
+    ($s:expr, $t: expr) => {
         let (ebag, ecol): (ftd::Map<ftd::ftd2021::p2::Thing>, _) = $t;
         let (mut bag, col) = ftd::ftd2021::test::interpret(
             "foo/bar",
@@ -110,10 +110,10 @@ macro_rules! p {
 }
 
 macro_rules! intf {
-    ($s:expr, $m: expr_2021,) => {
+    ($s:expr, $m: expr,) => {
         intf!($s, $m)
     };
-    ($s:expr, $m: expr_2021) => {
+    ($s:expr, $m: expr) => {
         match ftd::ftd2021::test::interpret(
             "foo",
             indoc::indoc!($s),
@@ -3676,7 +3676,11 @@ mod interpreter {
                     vec![
                         (s("about"), {
                             let s = ftd::ftd2021::p2::Kind::body();
-                            if about_optional { s.into_optional() } else { s }
+                            if about_optional {
+                                s.into_optional()
+                            } else {
+                                s
+                            }
                         }),
                         (s("src"), {
                             let s = ftd::ftd2021::p2::Kind::Record {
@@ -3684,7 +3688,11 @@ mod interpreter {
                                 default: None,
                                 is_reference: false,
                             };
-                            if about_optional { s.into_optional() } else { s }
+                            if about_optional {
+                                s.into_optional()
+                            } else {
+                                s
+                            }
                         }),
                         (s("title"), ftd::ftd2021::p2::Kind::caption()),
                     ],
@@ -12199,19 +12207,17 @@ mod interpreter {
                     },
                 }),
                 kernel: false,
-                invocations: vec![
-                    std::iter::IntoIterator::into_iter([
-                        (
-                            s("name"),
-                            ftd::Value::String {
-                                text: s("Hello"),
-                                source: ftd::TextSource::Caption,
-                            },
-                        ),
-                        (s("open"), ftd::Value::Boolean { value: true }),
-                    ])
-                    .collect(),
-                ],
+                invocations: vec![std::iter::IntoIterator::into_iter([
+                    (
+                        s("name"),
+                        ftd::Value::String {
+                            text: s("Hello"),
+                            source: ftd::TextSource::Caption,
+                        },
+                    ),
+                    (s("open"), ftd::Value::Boolean { value: true }),
+                ])
+                .collect()],
                 line_number: 1,
                 ..Default::default()
             }),
@@ -17687,10 +17693,10 @@ mod component {
     use ftd::ftd2021::test::*;
 
     macro_rules! p2 {
-        ($s:expr, $doc: expr_2021, $t: expr_2021,) => {
+        ($s:expr, $doc: expr, $t: expr,) => {
             p2!($s, $doc, $t)
         };
-        ($s:expr, $doc: expr_2021, $t: expr_2021) => {
+        ($s:expr, $doc: expr, $t: expr) => {
             let p1 = ftd::ftd2021::p1::parse(indoc::indoc!($s), $doc.name).unwrap();
             pretty_assertions::assert_eq!(ftd::Component::from_p1(&p1[0], &$doc).unwrap(), $t)
         };
@@ -17798,7 +17804,7 @@ mod component {
     fn caption_body_conflicts() {
         // Caption and Header Value conflict
         intf!(
-            "-- ftd.row A: 
+             "-- ftd.row A: 
             caption message: Default message
             
             -- A: Im the message here 
@@ -17809,7 +17815,7 @@ mod component {
 
         // Caption and Body conflict
         intf!(
-            "-- ftd.row A: 
+             "-- ftd.row A: 
             caption or body msg: 
             
             -- A: Caption will say hello
@@ -18748,10 +18754,10 @@ mod variable {
     use ftd::ftd2021::test::*;
 
     macro_rules! p2 {
-        ($s:expr, $n: expr_2021, $v: expr_2021, $c: expr_2021,) => {
+        ($s:expr, $n: expr, $v: expr, $c: expr,) => {
             p2!($s, $n, $v, $c)
         };
-        ($s:expr, $n: expr_2021, $v: expr_2021, $c: expr_2021) => {
+        ($s:expr, $n: expr, $v: expr, $c: expr) => {
             let p1 = ftd::ftd2021::p1::parse(indoc::indoc!($s), "foo").unwrap();
             let mut bag = ftd::Map::new();
             let aliases = ftd::Map::new();

--- a/ftd/src/ftd2021/ui.rs
+++ b/ftd/src/ftd2021/ui.rs
@@ -1497,7 +1497,7 @@ impl Element {
                 _ => continue,
             };
             for (condition, value) in conditions {
-                let condition = match condition.to_condition(
+                let condition = if let Ok(condition) = condition.to_condition(
                     0,
                     &ftd::ftd2021::p2::TDoc {
                         name: document.name.as_str(),
@@ -1507,10 +1507,9 @@ impl Element {
                         referenced_local_variables: &mut Default::default(),
                     },
                 ) {
-                    Ok(condition) => condition,
-                    _ => {
-                        continue;
-                    }
+                    condition
+                } else {
+                    continue;
                 };
                 let value = match value.resolve(0, &doc) {
                     Ok(value) => match value.to_serde_value() {

--- a/ftd/src/html/fastn_type_functions.rs
+++ b/ftd/src/html/fastn_type_functions.rs
@@ -138,17 +138,14 @@ impl ValueExt for fastn_resolved::Value {
             fastn_resolved::Value::List { data, .. } => {
                 let mut values = vec![];
                 for value in data {
-                    let v = match value.clone().resolve(doc, line_number)?.to_html_string(
-                        doc,
-                        value.line_number(),
-                        None,
-                        id,
-                        true,
-                    )? {
-                        Some(v) => v,
-                        _ => {
-                            continue;
-                        }
+                    let v = if let Some(v) = value
+                        .clone()
+                        .resolve(doc, line_number)?
+                        .to_html_string(doc, value.line_number(), None, id, true)?
+                    {
+                        v
+                    } else {
+                        continue;
                     };
                     values.push(v);
                 }
@@ -177,31 +174,29 @@ impl ValueExt for fastn_resolved::Value {
                 let value = value.to_html_string(doc, field, id, string_needs_no_quotes)?;
                 match value {
                     Some(value) if name.eq(ftd::interpreter::FTD_LENGTH) => {
-                        match ftd::executor::Length::set_pattern_from_variant_str(
+                        if let Ok(pattern) = ftd::executor::Length::set_pattern_from_variant_str(
                             variant,
                             doc.name,
                             line_number,
                         ) {
-                            Ok(pattern) => {
-                                Some(format!("`{}`.format(JSON.stringify({}))", pattern, value))
-                            }
-                            _ => Some(value),
+                            Some(format!("`{}`.format(JSON.stringify({}))", pattern, value))
+                        } else {
+                            Some(value)
                         }
                     }
                     Some(value)
                         if name.eq(ftd::interpreter::FTD_RESIZING)
                             && variant.ne(ftd::interpreter::FTD_RESIZING_FIXED) =>
                     {
-                        match ftd::executor::Resizing::set_pattern_from_variant_str(
+                        if let Ok(pattern) = ftd::executor::Resizing::set_pattern_from_variant_str(
                             variant,
                             full_variant,
                             doc.name,
                             line_number,
                         ) {
-                            Ok(pattern) => {
-                                Some(format!("`{}`.format(JSON.stringify({}))", pattern, value))
-                            }
-                            _ => Some(value),
+                            Some(format!("`{}`.format(JSON.stringify({}))", pattern, value))
+                        } else {
+                            Some(value)
                         }
                     }
                     Some(value) => Some(value),
@@ -211,11 +206,13 @@ impl ValueExt for fastn_resolved::Value {
             fastn_resolved::Value::Record { fields, .. } => {
                 let mut values = vec![];
                 for (k, v) in fields {
-                    let value =
-                        match v.to_html_string(doc, field.clone(), id, string_needs_no_quotes)? {
-                            Some(v) => v,
-                            _ => "null".to_string(),
-                        };
+                    let value = if let Some(v) =
+                        v.to_html_string(doc, field.clone(), id, string_needs_no_quotes)?
+                    {
+                        v
+                    } else {
+                        "null".to_string()
+                    };
                     values.push(format!("\"{}\": {}", k, value));
                 }
 

--- a/ftd/src/html/utils.rs
+++ b/ftd/src/html/utils.rs
@@ -80,13 +80,13 @@ pub(crate) fn get_formatted_dep_string_from_property_value(
         None => None,
     };*/
 
-    let value_string =
-        match property_value.to_html_string(doc, field, id, string_needs_no_quotes)? {
-            Some(value_string) => value_string,
-            _ => {
-                return Ok(None);
-            }
-        };
+    let value_string = if let Some(value_string) =
+        property_value.to_html_string(doc, field, id, string_needs_no_quotes)?
+    {
+        value_string
+    } else {
+        return Ok(None);
+    };
 
     Ok(Some(match pattern_with_eval {
         Some((p, eval)) => {
@@ -295,20 +295,18 @@ fn dependencies_from_length_property_value(
         let value = property_value
             .value(doc.name, property_value.line_number())
             .unwrap();
-        match value.get_or_type(doc.name, property_value.line_number()) {
-            Ok(property_value) => dependencies_from_property_value(property_value.2, doc),
-            _ => match value.record_fields(doc.name, property_value.line_number()) {
-                Ok(property_value) => {
-                    let mut values = vec![];
-                    for field in property_value.values() {
-                        values.extend(dependencies_from_property_value(field, doc));
-                    }
-                    values
-                }
-                _ => {
-                    vec![]
-                }
-            },
+        if let Ok(property_value) = value.get_or_type(doc.name, property_value.line_number()) {
+            dependencies_from_property_value(property_value.2, doc)
+        } else if let Ok(property_value) =
+            value.record_fields(doc.name, property_value.line_number())
+        {
+            let mut values = vec![];
+            for field in property_value.values() {
+                values.extend(dependencies_from_property_value(field, doc));
+            }
+            values
+        } else {
+            vec![]
         }
     } else {
         vec![]

--- a/ftd/src/interpreter/things/component.rs
+++ b/ftd/src/interpreter/things/component.rs
@@ -346,7 +346,7 @@ fn get_module_name_and_thing(
                             format!("Expected module, found: {:?}", t),
                             doc.name,
                             module_property.line_number,
-                        )
+                        );
                     }
                 }
             }

--- a/ftd/src/interpreter/things/component.rs
+++ b/ftd/src/interpreter/things/component.rs
@@ -346,7 +346,7 @@ fn get_module_name_and_thing(
                             format!("Expected module, found: {:?}", t),
                             doc.name,
                             module_property.line_number,
-                        );
+                        )
                     }
                 }
             }
@@ -1368,20 +1368,21 @@ impl ComponentExt for fastn_resolved::ComponentInvocation {
                 .resolve_name(definition_name_with_arguments.as_ref().unwrap().0)
                 .ne(&name)
         {
-            let mut var_name =
-                match ftd::interpreter::utils::get_argument_for_reference_and_remaining(
+            let mut var_name = if let Some(value) =
+                ftd::interpreter::utils::get_argument_for_reference_and_remaining(
                     name.as_str(),
                     doc,
                     definition_name_with_arguments,
                     loop_object_name_and_kind,
                     line_number,
                 )? {
-                    Some(value) => Some((
-                        value.2.get_reference_name(name.as_str(), doc),
-                        Some(value.0),
-                    )),
-                    _ => None,
-                };
+                Some((
+                    value.2.get_reference_name(name.as_str(), doc),
+                    Some(value.0),
+                ))
+            } else {
+                None
+            };
 
             if var_name.is_none() {
                 if let Ok(variable) = doc.search_variable(name.as_str(), line_number) {

--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -383,7 +383,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        )
+                        );
                     }
                     _ => {}
                 }
@@ -453,7 +453,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        )
+                        );
                     }
                     _ => {}
                 }
@@ -514,7 +514,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 is_mutable: mutable,
                                 line_number: value.line_number(),
                             },
-                        )))
+                        )));
                     }
                     Some(ekind)
                         if !ekind.kind.is_same_as(&found_kind.kind)
@@ -543,7 +543,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        )
+                        );
                     }
                     _ => {}
                 }
@@ -804,40 +804,61 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 line_number: value.line_number(),
                             })?;
                         let value = match &variant {
-                            fastn_resolved::OrTypeVariant::Constant(c) => return ftd::interpreter::utils::e2(format!("Cannot pass constant variant as property, variant: `{}`. Help: Pass variant as value instead", c.name), doc.name, c.line_number),
-                            fastn_resolved::OrTypeVariant::AnonymousRecord(record) =>
+                            fastn_resolved::OrTypeVariant::Constant(c) => {
+                                return ftd::interpreter::utils::e2(
+                                    format!(
+                                        "Cannot pass constant variant as property, variant: `{}`. Help: Pass variant as value instead",
+                                        c.name
+                                    ),
+                                    doc.name,
+                                    c.line_number,
+                                );
+                            }
+                            fastn_resolved::OrTypeVariant::AnonymousRecord(record) => {
                                 try_ok_state!(fastn_resolved::PropertyValue::from_record(
-                        record,
-                        value,
-                        doc,
-                        is_mutable,
-                        expected_kind,
-                        definition_name_with_arguments,
-                        loop_object_name_and_kind,
-                    )?),
+                                    record,
+                                    value,
+                                    doc,
+                                    is_mutable,
+                                    expected_kind,
+                                    definition_name_with_arguments,
+                                    loop_object_name_and_kind,
+                                )?)
+                            }
                             fastn_resolved::OrTypeVariant::Regular(regular) => {
-                                let mut variant_name = variant_name.trim_start_matches(format!("{}.", variant.name()).as_str()).trim().to_string();
+                                let mut variant_name = variant_name
+                                    .trim_start_matches(format!("{}.", variant.name()).as_str())
+                                    .trim()
+                                    .to_string();
                                 if variant_name.eq(&variant.name()) {
                                     variant_name = "".to_string();
                                 }
-                                let kind = if regular.kind.kind.ref_inner().is_or_type() && !variant_name.is_empty() {
-                                    let (name, variant, _full_variant) = regular.kind.kind.get_or_type().unwrap();
+                                let kind = if regular.kind.kind.ref_inner().is_or_type()
+                                    && !variant_name.is_empty()
+                                {
+                                    let (name, variant, _full_variant) =
+                                        regular.kind.kind.get_or_type().unwrap();
                                     let variant_name = format!("{}.{}", name, variant_name);
-                                    fastn_resolved::Kind::or_type_with_variant(name.as_str(), variant.unwrap_or_else(|| variant_name.clone()).as_str(), variant_name.as_str()).into_kind_data()
+                                    fastn_resolved::Kind::or_type_with_variant(
+                                        name.as_str(),
+                                        variant.unwrap_or_else(|| variant_name.clone()).as_str(),
+                                        variant_name.as_str(),
+                                    )
+                                    .into_kind_data()
                                 } else {
                                     regular.kind.to_owned()
                                 };
 
                                 try_ok_state!(
-                            fastn_resolved::PropertyValue::from_ast_value_with_argument(
-                                value,
-                                doc,
-                                is_mutable,
-                                Some(&kind),
-                                definition_name_with_arguments,
-                                loop_object_name_and_kind
-                            )?
-                        )
+                                    fastn_resolved::PropertyValue::from_ast_value_with_argument(
+                                        value,
+                                        doc,
+                                        is_mutable,
+                                        Some(&kind),
+                                        definition_name_with_arguments,
+                                        loop_object_name_and_kind
+                                    )?
+                                )
                             }
                         };
                         ftd::interpreter::StateWithThing::new_thing(
@@ -851,8 +872,8 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                         )
                     } else {
                         let value_str = format!("{}.{}", name, value.string(doc.name)?);
-                        let (found_or_type_name, or_type_variant) = try_ok_state!(doc
-                            .search_or_type_with_variant(
+                        let (found_or_type_name, or_type_variant) =
+                            try_ok_state!(doc.search_or_type_with_variant(
                                 value_str.as_str(),
                                 value.line_number()
                             )?);
@@ -1853,7 +1874,7 @@ impl ValueExt for fastn_resolved::Value {
                     format!("Expected kind: `{:?}`, found: `{:?}`", expected_kind, t),
                     doc_name,
                     line_number,
-                )
+                );
             }
         })
     }

--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -383,7 +383,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        );
+                        )
                     }
                     _ => {}
                 }
@@ -453,7 +453,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        );
+                        )
                     }
                     _ => {}
                 }
@@ -514,7 +514,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 is_mutable: mutable,
                                 line_number: value.line_number(),
                             },
-                        )));
+                        )))
                     }
                     Some(ekind)
                         if !ekind.kind.is_same_as(&found_kind.kind)
@@ -543,7 +543,7 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 .as_str(),
                             doc.name,
                             value.line_number(),
-                        );
+                        )
                     }
                     _ => {}
                 }
@@ -804,61 +804,40 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                                 line_number: value.line_number(),
                             })?;
                         let value = match &variant {
-                            fastn_resolved::OrTypeVariant::Constant(c) => {
-                                return ftd::interpreter::utils::e2(
-                                    format!(
-                                        "Cannot pass constant variant as property, variant: `{}`. Help: Pass variant as value instead",
-                                        c.name
-                                    ),
-                                    doc.name,
-                                    c.line_number,
-                                );
-                            }
-                            fastn_resolved::OrTypeVariant::AnonymousRecord(record) => {
+                            fastn_resolved::OrTypeVariant::Constant(c) => return ftd::interpreter::utils::e2(format!("Cannot pass constant variant as property, variant: `{}`. Help: Pass variant as value instead", c.name), doc.name, c.line_number),
+                            fastn_resolved::OrTypeVariant::AnonymousRecord(record) =>
                                 try_ok_state!(fastn_resolved::PropertyValue::from_record(
-                                    record,
-                                    value,
-                                    doc,
-                                    is_mutable,
-                                    expected_kind,
-                                    definition_name_with_arguments,
-                                    loop_object_name_and_kind,
-                                )?)
-                            }
+                        record,
+                        value,
+                        doc,
+                        is_mutable,
+                        expected_kind,
+                        definition_name_with_arguments,
+                        loop_object_name_and_kind,
+                    )?),
                             fastn_resolved::OrTypeVariant::Regular(regular) => {
-                                let mut variant_name = variant_name
-                                    .trim_start_matches(format!("{}.", variant.name()).as_str())
-                                    .trim()
-                                    .to_string();
+                                let mut variant_name = variant_name.trim_start_matches(format!("{}.", variant.name()).as_str()).trim().to_string();
                                 if variant_name.eq(&variant.name()) {
                                     variant_name = "".to_string();
                                 }
-                                let kind = if regular.kind.kind.ref_inner().is_or_type()
-                                    && !variant_name.is_empty()
-                                {
-                                    let (name, variant, _full_variant) =
-                                        regular.kind.kind.get_or_type().unwrap();
+                                let kind = if regular.kind.kind.ref_inner().is_or_type() && !variant_name.is_empty() {
+                                    let (name, variant, _full_variant) = regular.kind.kind.get_or_type().unwrap();
                                     let variant_name = format!("{}.{}", name, variant_name);
-                                    fastn_resolved::Kind::or_type_with_variant(
-                                        name.as_str(),
-                                        variant.unwrap_or_else(|| variant_name.clone()).as_str(),
-                                        variant_name.as_str(),
-                                    )
-                                    .into_kind_data()
+                                    fastn_resolved::Kind::or_type_with_variant(name.as_str(), variant.unwrap_or_else(|| variant_name.clone()).as_str(), variant_name.as_str()).into_kind_data()
                                 } else {
                                     regular.kind.to_owned()
                                 };
 
                                 try_ok_state!(
-                                    fastn_resolved::PropertyValue::from_ast_value_with_argument(
-                                        value,
-                                        doc,
-                                        is_mutable,
-                                        Some(&kind),
-                                        definition_name_with_arguments,
-                                        loop_object_name_and_kind
-                                    )?
-                                )
+                            fastn_resolved::PropertyValue::from_ast_value_with_argument(
+                                value,
+                                doc,
+                                is_mutable,
+                                Some(&kind),
+                                definition_name_with_arguments,
+                                loop_object_name_and_kind
+                            )?
+                        )
                             }
                         };
                         ftd::interpreter::StateWithThing::new_thing(
@@ -872,8 +851,8 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                         )
                     } else {
                         let value_str = format!("{}.{}", name, value.string(doc.name)?);
-                        let (found_or_type_name, or_type_variant) =
-                            try_ok_state!(doc.search_or_type_with_variant(
+                        let (found_or_type_name, or_type_variant) = try_ok_state!(doc
+                            .search_or_type_with_variant(
                                 value_str.as_str(),
                                 value.line_number()
                             )?);
@@ -1764,13 +1743,10 @@ impl ValueExt for fastn_resolved::Value {
                 value.resolve(doc, line_number)?.into_evalexpr_value(doc)
             }
             fastn_resolved::Value::Record { .. } => {
-                match ftd::interpreter::utils::get_value(doc, &self) {
-                    Ok(Some(value)) => {
-                        Ok(fastn_resolved::evalexpr::Value::String(value.to_string()))
-                    }
-                    _ => {
-                        unimplemented!("{:?}", self)
-                    }
+                if let Ok(Some(value)) = ftd::interpreter::utils::get_value(doc, &self) {
+                    Ok(fastn_resolved::evalexpr::Value::String(value.to_string()))
+                } else {
+                    unimplemented!("{:?}", self)
                 }
             }
             fastn_resolved::Value::List { data, .. } => {
@@ -1877,7 +1853,7 @@ impl ValueExt for fastn_resolved::Value {
                     format!("Expected kind: `{:?}`, found: `{:?}`", expected_kind, t),
                     doc_name,
                     line_number,
-                );
+                )
             }
         })
     }

--- a/ftd/src/interpreter/utils.rs
+++ b/ftd/src/interpreter/utils.rs
@@ -120,7 +120,7 @@ pub(crate) fn get_function_name_and_properties(
                 format!("{} is not a function", s),
                 doc_id,
                 line_number,
-            )
+            );
         }
     };
     let function_name = s[..si].to_string();
@@ -440,9 +440,14 @@ pub fn validate_record_value(
     ) -> ftd::interpreter::Result<()> {
         for value in fields.iter() {
             if let Some(reference_name) = value.reference_name() {
-                return ftd::interpreter::utils::e2(format!(
-                    "Currently, reference `{}` to record field  is not supported. Use clone (*) instead", reference_name
-                ), doc.name, value.line_number());
+                return ftd::interpreter::utils::e2(
+                    format!(
+                        "Currently, reference `{}` to record field  is not supported. Use clone (*) instead",
+                        reference_name
+                    ),
+                    doc.name,
+                    value.line_number(),
+                );
             }
 
             if let fastn_resolved::PropertyValue::Value { value, .. } = value {
@@ -840,7 +845,7 @@ pub(crate) fn validate_properties_and_set_default(
                         format!("Expected module, found: {:?}", t),
                         doc_id,
                         line_number,
-                    )
+                    );
                 }
             };
 

--- a/ftd/src/interpreter/utils.rs
+++ b/ftd/src/interpreter/utils.rs
@@ -120,7 +120,7 @@ pub(crate) fn get_function_name_and_properties(
                 format!("{} is not a function", s),
                 doc_id,
                 line_number,
-            );
+            )
         }
     };
     let function_name = s[..si].to_string();
@@ -440,14 +440,9 @@ pub fn validate_record_value(
     ) -> ftd::interpreter::Result<()> {
         for value in fields.iter() {
             if let Some(reference_name) = value.reference_name() {
-                return ftd::interpreter::utils::e2(
-                    format!(
-                        "Currently, reference `{}` to record field  is not supported. Use clone (*) instead",
-                        reference_name
-                    ),
-                    doc.name,
-                    value.line_number(),
-                );
+                return ftd::interpreter::utils::e2(format!(
+                    "Currently, reference `{}` to record field  is not supported. Use clone (*) instead", reference_name
+                ), doc.name, value.line_number());
             }
 
             if let fastn_resolved::PropertyValue::Value { value, .. } = value {
@@ -569,40 +564,43 @@ pub(crate) fn get_value(
             let value = get_value(doc, &value.clone().resolve(doc, value.line_number())?)?;
             match value {
                 Some(value) if name.eq(ftd::interpreter::FTD_LENGTH) => {
-                    match ftd::executor::Length::set_value_from_variant(
+                    if let Ok(pattern) = ftd::executor::Length::set_value_from_variant(
                         variant.as_str(),
                         value.to_string().as_str(),
                         doc.name,
                         0,
                     ) {
-                        Ok(pattern) => serde_json::to_value(pattern).ok(),
-                        _ => Some(value),
+                        serde_json::to_value(pattern).ok()
+                    } else {
+                        Some(value)
                     }
                 }
                 Some(value) if name.eq(ftd::interpreter::FTD_FONT_SIZE) => {
-                    match ftd::executor::FontSize::set_value_from_variant(
+                    if let Ok(pattern) = ftd::executor::FontSize::set_value_from_variant(
                         variant.as_str(),
                         value.to_string().as_str(),
                         doc.name,
                         0,
                     ) {
-                        Ok(pattern) => serde_json::to_value(pattern).ok(),
-                        _ => Some(value),
+                        serde_json::to_value(pattern).ok()
+                    } else {
+                        Some(value)
                     }
                 }
                 Some(value)
                     if name.eq(ftd::interpreter::FTD_RESIZING_FIXED)
                         && variant.ne(ftd::interpreter::FTD_RESIZING_FIXED) =>
                 {
-                    match ftd::executor::Resizing::set_value_from_variant(
+                    if let Ok(pattern) = ftd::executor::Resizing::set_value_from_variant(
                         variant.as_str(),
                         full_variant.as_str(),
                         doc.name,
                         value.to_string().as_str(),
                         0,
                     ) {
-                        Ok(pattern) => serde_json::to_value(pattern).ok(),
-                        _ => Some(value),
+                        serde_json::to_value(pattern).ok()
+                    } else {
+                        Some(value)
                     }
                 }
                 Some(value) => Some(value),
@@ -737,33 +735,28 @@ pub(crate) fn insert_module_thing(
             reference.strip_prefix(&format!("{}.{}.", component_name, arg.name))
         {
             let module_component_name = format!("{}#{}", module_name, reference);
-            match doc.get_function(module_component_name.as_str(), line_number) {
-                Ok(function_definition) => {
-                    let function_module_thing = fastn_resolved::ModuleThing::function(
-                        reference.to_string(),
-                        function_definition.return_kind.clone(),
-                    );
-                    things.insert(reference.to_string(), function_module_thing);
-                }
-                _ => match doc.get_component(module_component_name.as_str(), 0) {
-                    Ok(module_component_definition) => {
-                        let component_module_thing = fastn_resolved::ModuleThing::component(
-                            reference.to_string(),
-                            fastn_resolved::Kind::ui_with_name(reference_full_name)
-                                .into_kind_data(),
-                            module_component_definition.arguments,
-                        );
+            if let Ok(function_definition) =
+                doc.get_function(module_component_name.as_str(), line_number)
+            {
+                let function_module_thing = fastn_resolved::ModuleThing::function(
+                    reference.to_string(),
+                    function_definition.return_kind.clone(),
+                );
+                things.insert(reference.to_string(), function_module_thing);
+            } else if let Ok(module_component_definition) =
+                doc.get_component(module_component_name.as_str(), 0)
+            {
+                let component_module_thing = fastn_resolved::ModuleThing::component(
+                    reference.to_string(),
+                    fastn_resolved::Kind::ui_with_name(reference_full_name).into_kind_data(),
+                    module_component_definition.arguments,
+                );
 
-                        things.insert(reference.to_string(), component_module_thing);
-                    }
-                    _ => {
-                        let variable_module_thing = fastn_resolved::ModuleThing::variable(
-                            reference.to_string(),
-                            kind.clone(),
-                        );
-                        things.insert(reference.to_string(), variable_module_thing);
-                    }
-                },
+                things.insert(reference.to_string(), component_module_thing);
+            } else {
+                let variable_module_thing =
+                    fastn_resolved::ModuleThing::variable(reference.to_string(), kind.clone());
+                things.insert(reference.to_string(), variable_module_thing);
             }
         }
     }
@@ -847,7 +840,7 @@ pub(crate) fn validate_properties_and_set_default(
                         format!("Expected module, found: {:?}", t),
                         doc_id,
                         line_number,
-                    );
+                    )
                 }
             };
 

--- a/ftd/src/lib.rs
+++ b/ftd/src/lib.rs
@@ -7,7 +7,7 @@ pub use ftd2021::component::{ChildComponent, Component, Instruction};
 pub use ftd2021::condition::Condition;
 pub use ftd2021::constants::{identifier, regex};
 pub use ftd2021::event::{Action, Event};
-pub use ftd2021::html::{anchor, color, length, overflow, Collector, Node, StyleSpec};
+pub use ftd2021::html::{Collector, Node, StyleSpec, anchor, color, length, overflow};
 pub use ftd2021::ui::{
     Anchor, AttributeType, Code, Color, ColorValue, Column, Common, ConditionalAttribute,
     ConditionalValue, Container, Element, FontDisplay, GradientDirection, Grid, IFrame, IText,

--- a/ftd/src/lib.rs
+++ b/ftd/src/lib.rs
@@ -7,7 +7,7 @@ pub use ftd2021::component::{ChildComponent, Component, Instruction};
 pub use ftd2021::condition::Condition;
 pub use ftd2021::constants::{identifier, regex};
 pub use ftd2021::event::{Action, Event};
-pub use ftd2021::html::{Collector, Node, StyleSpec, anchor, color, length, overflow};
+pub use ftd2021::html::{anchor, color, length, overflow, Collector, Node, StyleSpec};
 pub use ftd2021::ui::{
     Anchor, AttributeType, Code, Color, ColorValue, Column, Common, ConditionalAttribute,
     ConditionalValue, Container, Element, FontDisplay, GradientDirection, Grid, IFrame, IText,
@@ -117,37 +117,28 @@ impl<T: std::cmp::PartialEq> VecMap<T> {
     }
 
     pub fn insert(&mut self, key: String, value: T) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                v.push(value);
-            }
-            _ => {
-                self.value.insert(key, vec![value]);
-            }
+        if let Some(v) = self.value.get_mut(&key) {
+            v.push(value);
+        } else {
+            self.value.insert(key, vec![value]);
         }
     }
 
     pub fn unique_insert(&mut self, key: String, value: T) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                if !v.contains(&value) {
-                    v.push(value);
-                }
+        if let Some(v) = self.value.get_mut(&key) {
+            if !v.contains(&value) {
+                v.push(value);
             }
-            _ => {
-                self.value.insert(key, vec![value]);
-            }
+        } else {
+            self.value.insert(key, vec![value]);
         }
     }
 
     pub fn extend(&mut self, key: String, value: Vec<T>) {
-        match self.value.get_mut(&key) {
-            Some(v) => {
-                v.extend(value);
-            }
-            _ => {
-                self.value.insert(key, value);
-            }
+        if let Some(v) = self.value.get_mut(&key) {
+            v.extend(value);
+        } else {
+            self.value.insert(key, value);
         }
     }
 

--- a/v0.5/fastn-compiler/src/compiler.rs
+++ b/v0.5/fastn-compiler/src/compiler.rs
@@ -125,21 +125,20 @@ impl Compiler {
         let mut new_content = vec![];
 
         for mut ci in content {
-            let resolved = match ci {
-                fastn_unresolved::UR::UnResolved(ref mut c) => {
-                    let mut needed = Default::default();
-                    let resolved = c.resolve(
-                        &self.definitions,
-                        &mut self.arena,
-                        &mut needed,
-                        &self.main_package,
-                    );
-                    stuck_on_symbols.extend(needed.stuck_on);
-                    self.document
-                        .merge(needed.errors, needed.warnings, needed.comments);
-                    resolved
-                }
-                _ => false,
+            let resolved = if let fastn_unresolved::UR::UnResolved(ref mut c) = ci {
+                let mut needed = Default::default();
+                let resolved = c.resolve(
+                    &self.definitions,
+                    &mut self.arena,
+                    &mut needed,
+                    &self.main_package,
+                );
+                stuck_on_symbols.extend(needed.stuck_on);
+                self.document
+                    .merge(needed.errors, needed.warnings, needed.comments);
+                resolved
+            } else {
+                false
             };
             if resolved {
                 ci.resolve_it(&self.arena)

--- a/v0.5/fastn-compiler/src/utils.rs
+++ b/v0.5/fastn-compiler/src/utils.rs
@@ -14,17 +14,12 @@ pub(crate) fn used_definitions(
     // go through self.symbols_used and get the resolved definitions
     let def_map = indexmap::IndexMap::new();
     for definition in definitions_used.iter() {
-        match definitions.get(definition.str(&arena)) {
-            Some(_definition) => {
-                // definitions.insert(symbol.clone(), definition);
-                todo!()
-            }
-            _ => {
-                if let Some(_definition) = fastn_builtins::builtins().get(definition.str(&arena)) {
-                    // definitions.insert(symbol.clone(), definition);
-                    todo!()
-                }
-            }
+        if let Some(_definition) = definitions.get(definition.str(&arena)) {
+            // definitions.insert(symbol.clone(), definition);
+            todo!()
+        } else if let Some(_definition) = fastn_builtins::builtins().get(definition.str(&arena)) {
+            // definitions.insert(symbol.clone(), definition);
+            todo!()
         }
     }
     def_map

--- a/v0.5/fastn-wasm/src/sqlite/batch_execute.rs
+++ b/v0.5/fastn-wasm/src/sqlite/batch_execute.rs
@@ -13,14 +13,13 @@ impl<STORE: fastn_wasm::StoreExt> fastn_wasm::Store<STORE> {
         &mut self,
         q: String,
     ) -> wasmtime::Result<Result<(), ft_sys_shared::DbError>> {
-        let conn = match self.sqlite {
-            Some(ref mut conn) => conn,
-            _ => {
-                eprintln!("sqlite connection not found");
-                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(
-                    "no db connection".to_string(),
-                )));
-            }
+        let conn = if let Some(ref mut conn) = self.sqlite {
+            conn
+        } else {
+            eprintln!("sqlite connection not found");
+            return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(
+                "no db connection".to_string(),
+            )));
         };
 
         let conn = conn.lock().await;
@@ -35,7 +34,7 @@ impl<STORE: fastn_wasm::StoreExt> fastn_wasm::Store<STORE> {
                 return Ok(Err(e));
             }
             Err(fastn_wasm::SQLError::InvalidQuery(e)) => {
-                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(e)));
+                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(e)))
             } // Todo: Handle error message
         })
     }

--- a/v0.5/fastn-wasm/src/sqlite/batch_execute.rs
+++ b/v0.5/fastn-wasm/src/sqlite/batch_execute.rs
@@ -34,7 +34,7 @@ impl<STORE: fastn_wasm::StoreExt> fastn_wasm::Store<STORE> {
                 return Ok(Err(e));
             }
             Err(fastn_wasm::SQLError::InvalidQuery(e)) => {
-                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(e)))
+                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(e)));
             } // Todo: Handle error message
         })
     }

--- a/v0.5/fastn-wasm/src/sqlite/execute.rs
+++ b/v0.5/fastn-wasm/src/sqlite/execute.rs
@@ -13,14 +13,13 @@ impl<STORE: fastn_wasm::StoreExt> fastn_wasm::Store<STORE> {
         &mut self,
         q: fastn_wasm::sqlite::Query,
     ) -> wasmtime::Result<Result<usize, ft_sys_shared::DbError>> {
-        let conn = match self.sqlite {
-            Some(ref mut conn) => conn,
-            _ => {
-                eprintln!("sqlite connection not found");
-                return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(
-                    "connection not found".to_string(),
-                )));
-            }
+        let conn = if let Some(ref mut conn) = self.sqlite {
+            conn
+        } else {
+            eprintln!("sqlite connection not found");
+            return Ok(Err(ft_sys_shared::DbError::UnableToSendCommand(
+                "connection not found".to_string(),
+            )));
         };
 
         let conn = conn.lock().await;


### PR DESCRIPTION
This PR reverts the changes introduced by `cargo fix --edition`, specifically where `if let` was replaced with `match`. The automatic fix led to deeper nesting, reducing readability.

## Reverted commits:

- https://github.com/fastn-stack/fastn/commit/21d3bfb74f5bb229f7dbdf6ce464ff299b81606e
- https://github.com/fastn-stack/fastn/commit/7e4cabdddcde15d5afe0b0ccfb4e3b8371a4f7f8

## Example:

### Example 1:
Consider `fastn-core/src/http.rs`:
#### Before (`if let` for better readability):
```rs
if let (Ok(v), Ok(k)) = (
    value.to_str().unwrap_or("").parse::<http::HeaderValue>(),
    http::HeaderName::from_bytes(key.as_str().as_bytes()),
) {
    headers.insert(k, v.clone());
} else {
    tracing::warn!("failed to parse header: {key:?} {value:?}");
}
```
#### After (`match` causing unnecessary nesting):
```rs
match (
    value.to_str().unwrap_or("").parse::<http::HeaderValue>(),
    http::HeaderName::from_bytes(key.as_str().as_bytes()),
) {
    (Ok(v), Ok(k)) => {
        headers.insert(k, v.clone());
    }
    _ => {
        tracing::warn!("failed to parse header: {key:?} {value:?}");
    }
}
```
### Example 2:

Consider `ftd/src/interpreter/utils.rs`:
#### Before (`if let` for better readability):
```rs
if let Ok(function_definition) =
      doc.get_function(module_component_name.as_str(), line_number)
  {
      let function_module_thing = fastn_resolved::ModuleThing::function(
          reference.to_string(),
          function_definition.return_kind.clone(),
      );
      things.insert(reference.to_string(), function_module_thing);
  } else if let Ok(module_component_definition) =
      doc.get_component(module_component_name.as_str(), 0)
  {
      let component_module_thing = fastn_resolved::ModuleThing::component(
          reference.to_string(),
          fastn_resolved::Kind::ui_with_name(reference_full_name).into_kind_data(),
          module_component_definition.arguments,
      );

      things.insert(reference.to_string(), component_module_thing);
  } else {
      let variable_module_thing =
          fastn_resolved::ModuleThing::variable(reference.to_string(), kind.clone());
      things.insert(reference.to_string(), variable_module_thing);
  }
}
```

#### After (`match` causing unnecessary nesting):
```rs
 match doc.get_function(module_component_name.as_str(), line_number) {
    Ok(function_definition) => {
        let function_module_thing = fastn_resolved::ModuleThing::function(
            reference.to_string(),
            function_definition.return_kind.clone(),
        );
        things.insert(reference.to_string(), function_module_thing);
    }
    _ => match doc.get_component(module_component_name.as_str(), 0) {
        Ok(module_component_definition) => {
            let component_module_thing = fastn_resolved::ModuleThing::component(
                reference.to_string(),
                fastn_resolved::Kind::ui_with_name(reference_full_name)
                    .into_kind_data(),
                module_component_definition.arguments,
            );

            things.insert(reference.to_string(), component_module_thing);
        }
        _ => {
            let variable_module_thing = fastn_resolved::ModuleThing::variable(
                reference.to_string(),
                kind.clone(),
            );
            things.insert(reference.to_string(), variable_module_thing);
        }
    },
}
```

## Why This Change?
- Reduces nesting → `if let` results in a flatter, more readable structure.
- Maintains clarity → The revert ensures intent is immediately clear without unnecessary branching.