### PR TITLE
Fix: Consider sitemap items when resolving imports 

### DIFF
--- a/fastn-core/fbt-tests/17-sitemap/input/guide/install.ftd
+++ b/fastn-core/fbt-tests/17-sitemap/input/guide/install.ftd
@@ -1,2 +1,4 @@
--- ftd.text: How to install `fastn` on your system
+-- string title: How to install `fastn` on your system
+
+-- ftd.text: $title
 link: https://fastn.com/install

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -138,7 +138,8 @@ pub async fn interpret_helper(
 }
 
 // source, foreign_variable, foreign_function
-#[tracing::instrument(skip_all)]
+#[allow(clippy::type_complexity)]
+#[tracing::instrument(skip(lib, _state))]
 pub async fn resolve_import_2022(
     lib: &mut fastn_core::Library2022,
     _state: &mut ftd::interpreter::InterpreterState,

--- a/fastn-core/src/doc.rs
+++ b/fastn-core/src/doc.rs
@@ -58,6 +58,7 @@ pub async fn interpret_helper(
     loop {
         match s {
             ftd::interpreter::Interpreter::Done { document: doc } => {
+                tracing::info!("done");
                 document = doc;
                 break;
             }
@@ -66,6 +67,7 @@ pub async fn interpret_helper(
                 state: mut st,
                 caller_module,
             } => {
+                tracing::info!("stuck on import: {module}");
                 let (source, path, foreign_variable, foreign_function, ignore_line_numbers) =
                     resolve_import_2022(
                         lib,
@@ -92,6 +94,7 @@ pub async fn interpret_helper(
                 processor,
                 ..
             } => {
+                tracing::info!("stuck on processor: {processor}");
                 let doc = state.get_current_processing_module().ok_or(
                     ftd::interpreter::Error::ValueNotFound {
                         doc_id: module,
@@ -116,6 +119,7 @@ pub async fn interpret_helper(
                 variable,
                 caller_module,
             } => {
+                tracing::info!("stuck on foreign variable: {variable}");
                 let value = resolve_foreign_variable2022(
                     variable.as_str(),
                     module.as_str(),
@@ -134,6 +138,7 @@ pub async fn interpret_helper(
 }
 
 // source, foreign_variable, foreign_function
+#[tracing::instrument(skip_all)]
 pub async fn resolve_import_2022(
     lib: &mut fastn_core::Library2022,
     _state: &mut ftd::interpreter::InterpreterState,

--- a/fastn-core/src/http.rs
+++ b/fastn-core/src/http.rs
@@ -372,6 +372,7 @@ impl Request {
         self.host.to_string()
     }
 
+    #[tracing::instrument]
     pub fn is_bot(&self) -> bool {
         match self.user_agent() {
             Some(user_agent) => is_bot(&user_agent),

--- a/fastn-core/src/library2022/mod.rs
+++ b/fastn-core/src/library2022/mod.rs
@@ -201,10 +201,26 @@ impl Library2022 {
             if !name.starts_with(format!("{}/", package.name.as_str()).as_str()) {
                 return Ok(None);
             }
-            let new_name = name.replacen(package.name.as_str(), "", 1);
+
+            let id = name.replacen(package.name.as_str(), "", 1);
+
+            tracing::info!("checking sitemap for {id}");
+
+            let resolved_id = package
+                .sitemap
+                .as_ref()
+                .and_then(|sitemap| {
+                    sitemap
+                        .resolve_document(&id)
+                        .map(|(sitemap_id, _)| sitemap_id)
+                })
+                .unwrap_or(id);
+
+            tracing::info!("found id in sitemap: {resolved_id}");
+
             let (file_path, data) = package
                 .resolve_by_id(
-                    new_name.as_str(),
+                    resolved_id.as_str(),
                     None,
                     lib.config.package.name.as_str(),
                     &lib.config.ds,

--- a/fastn-core/src/library2022/mod.rs
+++ b/fastn-core/src/library2022/mod.rs
@@ -17,6 +17,7 @@ impl KeyValueData {
 pub type Library2022 = fastn_core::RequestConfig;
 
 impl Library2022 {
+    #[tracing::instrument(skip(self))]
     pub async fn get_with_result(
         &mut self,
         name: &str,
@@ -54,6 +55,7 @@ impl Library2022 {
             })
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn get(
         &mut self,
         name: &str,
@@ -84,6 +86,7 @@ impl Library2022 {
         )
         .await;
 
+        #[tracing::instrument(skip(lib, session_id))]
         async fn get_for_package(
             name: &str,
             lib: &mut fastn_core::Library2022,
@@ -139,6 +142,7 @@ impl Library2022 {
             fastn_core::usage_error(format!("library not found 1: {}: {package:?}", name))
         }
 
+        #[tracing::instrument(skip(lib, package))]
         async fn get_for_package_(
             name: &str,
             lib: &mut fastn_core::Library2022,
@@ -180,6 +184,7 @@ impl Library2022 {
 
         // TODO: This function is too long. Break it down.
         #[allow(clippy::await_holding_refcell_ref)]
+        #[tracing::instrument(skip(lib, package))]
         async fn get_data_from_package(
             name: &str,
             package: &fastn_core::Package,

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743042789,
-        "narHash": "sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18=",
+        "lastModified": 1745980514,
+        "narHash": "sha256-CITAeiuXGjDvT5iZBXr6vKVWQwsUQLJUMFO91bfJFC4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b4d2dee9d16e7725b71969f28862ded3a94a7934",
+        "rev": "7fbdae44b0f40ea432e46fd152ad8be0f8f41ad6",
         "type": "github"
       },
       "original": {

--- a/ftd/src/interpreter/main.rs
+++ b/ftd/src/interpreter/main.rs
@@ -943,6 +943,7 @@ impl InterpreterState {
         Ok(ftd::interpreter::StateWithThing::new_continue())
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn continue_after_import(
         mut self,
         module: &str,


### PR DESCRIPTION
```ftd
;; guide/install.ftd
-- string test: some val
-- ftd.text: $test
```

```ftd
;; FASTN.ftd
...

-- fastn.sitemap:

\# Installation: /install/
  document: guide/install.ftd
```

This will fail to build, reason:

fastn is trying to resolve `$test` in `guide/install.ftd` and in doing
so, it's resolving the current module with id: `/install/` but this
fails as the id translates to a `install.ftd` (or `/install/index.ftd`)
in project dir. The correct id should be `guide/install/` (document
attributed in sitemap definition).

This is fixed by looking into sitemp entries if available and changing
the id before trying to do `package.resolve_by_id`.

NOTE: The build fails only with `fastn build`. `fastn serve` works fine without this change.