### PR TITLE
Build static fastn for x86_64-linux-gnu

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -3,12 +3,8 @@
 Checkout fastn installation step: https://fastn.com/install/.
 
 Note: `fastn_linux_musl_x86_64` is not built with `musl` libc, it is built with
-`glibc` and is not a static binary. The name is kept for consistency with older
+`glibc` and is a static binary. The name is kept for consistency with older
 releases.
-
-## Linux (x64)
-
-Minimum glibc version to run these releases is 2.35.
 
 GitHub Sha: GITHUB_SHA  
 Date: DATE  

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,7 +15,7 @@ jobs:
     # using the oldest available ubuntu on github CI to provide maximum compatibility with glibc versions
     # update RELEASE_TEMPLATE with the glibc version
     # on ubuntu-22.04, glibc version is 2.35
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -30,20 +30,24 @@ jobs:
             ftd/target
             fifthtry_content/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install static glibc
+        run: |
+          sudo apt update && sudo apt install -y libc6-dev
       - name: print rustc version
         run: rustc --version
       - name: cargo build (linux)
-        run: cargo build --release
+        run: |
+          RUSTFLAGS="-C target-feature=+crt-static" cargo build --target x86_64-unknown-linux-gnu --bin fastn --release
       - name: print fastn version
-        run: ./target/release/fastn --version
+        run: ./target/x86_64-unknown-linux-gnu/release/fastn --version
       - name: print file info
         run: |
-          file ./target/release/fastn
-          ldd ./target/release/fastn
+          file ./target/x86_64-unknown-linux-gnu/release/fastn
+          ldd ./target/x86_64-unknown-linux-gnu/release/fastn
       - uses: actions/upload-artifact@v4
         with:
           name: linux_x86_64
-          path: target/release/fastn
+          path: target/x86_64-unknown-linux-gnu/release/fastn
   build-windows:
     name: Build for Windows
     runs-on: windows-2019

--- a/flake.lock
+++ b/flake.lock
@@ -20,10 +20,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
-        "path": "/nix/store/zi50l9z7jjfv92nr6m12czq5qcrrmqdr-source",
-        "type": "path"
+        "lastModified": 1738958807,
+        "narHash": "sha256-h0WKgHTLkjwjRNTkqByQquS7N/15SqIFMQ356Ww8uCA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e8d0b02af0958823c955aaab3c82b03f54411d91",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
@@ -44,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745980514,
-        "narHash": "sha256-CITAeiuXGjDvT5iZBXr6vKVWQwsUQLJUMFO91bfJFC4=",
+        "lastModified": 1748140821,
+        "narHash": "sha256-GZcjWLQtDifSYMd1ueLDmuVTcQQdD5mONIBTqABooOk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7fbdae44b0f40ea432e46fd152ad8be0f8f41ad6",
+        "rev": "476b2ba7dc99ddbf70b1f45357dbbdbdbdfb4422",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The CI is setup to build static `fastn` binary. This is done by statically linking with the glibc on linux.

This is tested on NixOS with the `pkgs.glibc.static` package. From stackoverflow[1], it's equivalent on ubuntu is `libc6-dev` so this should work on github CI too.

An attempt to compile using `musl-gcc` was also made but it did not work because crates `rusqlite` (because libsqlite-sys) and `quickjs` failed to link with musl's libc.