### PR TITLE
fix: Actually working system packages!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.103"
+version = "0.4.104"
 dependencies = [
  "actix-web",
  "camino",
@@ -1822,7 +1822,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2603,7 +2603,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -3174,9 +3174,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
@@ -3187,11 +3187,8 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4221,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -4323,12 +4320,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.233.0"
+version = "0.234.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
+checksum = "170a0157eef517a179f2d20ed7c68df9c3f7f6c1c047782d488bf5a464174684"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.233.0",
+ "wasmparser 0.234.0",
 ]
 
 [[package]]
@@ -4346,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.233.0"
+version = "0.234.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
+checksum = "be22e5a8f600afce671dd53c8d2dd26b4b7aa810fd18ae27dfc49737f3e02fc5"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap",
@@ -4622,22 +4619,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "233.0.0"
+version = "234.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
+checksum = "f5fc6bea84cc3007ad3e68c6223f52095e6093eec4d7ebdff355f2c952fd9007"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.1",
- "wasm-encoder 0.233.0",
+ "wasm-encoder 0.234.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.233.0"
+version = "1.234.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9bc80f5e4b25ea086ef41b91ccd244adde45d931c384d94a8ff64ab8bd7d87"
+checksum = "1a4807d67cf6885965d2f118744fd0ad20ffb9082c875de532af37b499e65aa6"
 dependencies = [
  "wast",
 ]
@@ -4875,9 +4872,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # `fastn` Change Log
 
+## 11 June 2025
+
+### fastn: 0.4.104
+
+- 348030b8a: Fix correctly reflect overriden components for system packages. See issue #2139.
+- a42da86f6: Handle package local relative urls in http processor. See PR #2144.
+- 7551fc8f4: Handle wasm modules in mountpoint of app dependencies when called through http processor. See PR #2144.
+
 ## 10 June 2025
 
 ### fastn: 0.4.103

--- a/fastn-core/src/lib.rs
+++ b/fastn-core/src/lib.rs
@@ -90,7 +90,7 @@ async fn original_package_status(
     } else {
         let body_prefix = config
             .package
-            .generate_prefix_string(false)
+            .generate_prefix_string(&config.package, false)
             .unwrap_or_default();
         format!(
             "{}\n\n-- import: {}/original-status as pi\n\n-- pi.original-status-page:",
@@ -116,7 +116,7 @@ async fn translation_package_status(
     } else {
         let body_prefix = config
             .package
-            .generate_prefix_string(false)
+            .generate_prefix_string(&config.package, false)
             .unwrap_or_default();
         format!(
             "{}\n\n-- import: {}/translation-status as pi\n\n-- pi.translation-status-page:",

--- a/fastn-core/src/package/package_doc.rs
+++ b/fastn-core/src/package/package_doc.rs
@@ -427,8 +427,12 @@ pub(crate) async fn read_ftd_2022(
     config.base_url = base_url.to_string();
 
     // Get Prefix Body => [AutoImports + Actual Doc content]
-    let mut doc_content =
-        current_package.get_prefixed_body(main.content.as_str(), main.id.as_str(), true);
+    let mut doc_content = current_package.get_prefixed_body(
+        &config.config.package,
+        main.content.as_str(),
+        main.id.as_str(),
+        true,
+    );
     // Fix aliased imports to full path (if any)
     doc_content = current_package.fix_imports_in_body(doc_content.as_str(), main.id.as_str())?;
 
@@ -510,8 +514,12 @@ pub(crate) async fn read_ftd_2023(
     config.base_url = base_url.to_string();
 
     // Get Prefix Body => [AutoImports + Actual Doc content]
-    let mut doc_content =
-        current_package.get_prefixed_body(main.content.as_str(), main.id.as_str(), true);
+    let mut doc_content = current_package.get_prefixed_body(
+        &config.config.package,
+        main.content.as_str(),
+        main.id.as_str(),
+        true,
+    );
     // Fix aliased imports to full path (if any)
     doc_content = current_package.fix_imports_in_body(doc_content.as_str(), main.id.as_str())?;
 

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.103"
+version = "0.4.104"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is fixed by prefixing the auto-import with `inherited-` if:

The auto-import is for the dependency that has a `provided-via`
attribute which has the value of the path to a local ftd file that
overrides the contents of this dependency.

After the prefix is added. We check for this prefix while resolving
imports, if the imported module starts with `inherited-` we instead read
it's `provided-via` file path and load its contents instead. This way
even the third party dependencies end up importing this `imported-`
module by sourcing the `provided-via` path.

The users don't have to know about this `inherited-` prefixing as it is
done by the framework to the auto imports only.

Explicitly importing the `provided-via` package by its name works as
usual and will import the un-overriden original variant of the
dependency. This is useful in case where you want to override a few
components in your `provided-via` file but re-export original symbols by
importing the original dependency.

fixes: #2139
