### PR TITLE
Fix Incorrect cycle error

### DIFF
--- a/ftd/src/interpreter/things/value.rs
+++ b/ftd/src/interpreter/things/value.rs
@@ -531,7 +531,26 @@ impl PropertyValueExt for fastn_resolved::PropertyValue {
                         if ekind.kind.is_list()
                             && ekind.kind.ref_inner_list().is_same_as(&found_kind.kind) =>
                     {
-                        return Ok(ftd::interpreter::StateWithThing::new_thing(None));
+                        let reference_full_name =
+                            source.get_reference_name(reference.as_str(), doc);
+                        let kind = get_kind(expected_kind, &found_kind);
+
+                        return Ok(ftd::interpreter::StateWithThing::new_thing(Some(
+                            fastn_resolved::PropertyValue::Value {
+                                value: fastn_resolved::Value::List {
+                                    data: vec![fastn_resolved::PropertyValue::Reference {
+                                        name: reference_full_name,
+                                        kind,
+                                        source,
+                                        is_mutable: mutable,
+                                        line_number: value.line_number(),
+                                    }],
+                                    kind: ekind.kind.clone().inner_list().into_kind_data(),
+                                },
+                                is_mutable: false,
+                                line_number: 0,
+                            },
+                        )));
                     }
                     Some(ekind) if !ekind.kind.is_same_as(&found_kind.kind) => {
                         return ftd::interpreter::utils::e2(


### PR DESCRIPTION
This fixes #2169

Avoids infinite loop for the following code snippet:

```ftd
-- test:
a: Hello

-- component test:
string a:

-- ftd.text: Test
classes: $test.a

-- end: test
```

`classes` of `ftd.text` component takes a list of string but ftd has a feature that turns `T` -> `List<T>` if expected kind is `List<T>` and found kind is `T`.

This works for single literals, like:

```
-- ftd.text: something
classes: one
```

The string literal `one` is converted to `List<String>` because `classes` expects that.

This, for some reason, does not work when we use a variable reference instead of literals. This change fixes this case.

NOTE: This change does not support mixing of two styles, you **can't** do:

```ftd
-- test:
a: two

-- component test:
string a:

-- ftd.text: Test
classes: one, $test.a ;; SEE THIS!

-- end: test
```

This still results in a Cycle Detection error:

```
failed to parse FoundCycle { message: \"test#test:4 => test#test:4 => test#test:4\", line_number: 4 }
```

Simply removing this match branch and failing with a "expected_kind and found_kind mismatch" error is not an option here as it'll break so many existing packages in the world.