### PR TITLE
Add support for simple function calls in `url` header of the `http` processor

### DIFF
--- a/fastn-resolved/src/evalexpr/operator/mod.rs
+++ b/fastn-resolved/src/evalexpr/operator/mod.rs
@@ -217,6 +217,20 @@ impl Operator {
                 } else if let (Ok(a), Ok(b)) = (arguments[0].as_number(), arguments[1].as_number())
                 {
                     Ok(Value::Float(a + b))
+                } else if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_number())
+                {
+                    let b = format!("{}", b);
+                    let mut result = String::with_capacity(a.len() + b.len());
+                    result.push_str(&a);
+                    result.push_str(&b);
+                    Ok(Value::String(result))
+                } else if let (Ok(a), Ok(b)) = (arguments[0].as_number(), arguments[1].as_string())
+                {
+                    let a = format!("{}", a);
+                    let mut result = String::with_capacity(a.len() + b.len());
+                    result.push_str(&a);
+                    result.push_str(&b);
+                    Ok(Value::String(result))
                 } else {
                     Err(EvalexprError::wrong_type_combination(
                         self.clone(),


### PR DESCRIPTION
functions can now be used at `url` header of the http processor. This
allows the following code snippet to work:

```ftd
-- import: fastn/processors

;; this could come from request-data processor for example
;; or some other reference, like:
;; -- string v: $some-other-reference
-- string v: foo

-- string x:
$processor$: processors.http
url: $some-func(v = $v)

-- string some-func(v):
string v:

"/api/" + v + "/"
```

** Known issues

- The function can't be a js function (a function definition with js:
  header) since we don't execute js on the server.

- Typecheck between function params and args is not correct. While
  constructing the function call, we use the param's type for the arg's
  type. The right thing here is to resolve the reference and use the
  resolved type so that type check happens correctly. There's a TODO
  comment for this.

- The function body supports simple expressions only and has been only
  tested with the + operator expression. To learn more about the full
  supported constructs, see the evalexpr crate.