### PR TITLE
fix: Escape more chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.111"
+version = "0.4.112"
 dependencies = [
  "actix-web",
  "camino",

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## 20 August 2025
 
+### fastn: 0.4.112
+
+- fix: Escape more chars while constructing a string for js output. See PR #2180.
+
 ### fastn: 0.4.111
 
 - dce62c437 - Add support for simple function calls in `url` header of the `http` processor. See PR #2179.

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -218,7 +218,7 @@ impl Value {
         match self {
             Value::String(s) => {
                 // unescape an already escaped seq. See PR #2044
-                let s = s.replace(r#"\""#, "\""); 
+                let s = s.replace(r#"\""#, "\"");
                 let s = fastn_js::utils::escape_string(s);
                 format!("\"{s}\"")
             }

--- a/fastn-js/src/property.rs
+++ b/fastn-js/src/property.rs
@@ -217,10 +217,9 @@ impl Value {
         use itertools::Itertools;
         match self {
             Value::String(s) => {
-                let s = s
-                    .replace('\n', "\\n") // escape new line character
-                    .replace(r#"\""#, "\"") // unescape an already escaped seq
-                    .replace('\"', "\\\""); // escape " (quote)
+                // unescape an already escaped seq. See PR #2044
+                let s = s.replace(r#"\""#, "\""); 
+                let s = fastn_js::utils::escape_string(s);
                 format!("\"{s}\"")
             }
             Value::Integer(i) => i.to_string(),

--- a/fastn-js/src/utils.rs
+++ b/fastn-js/src/utils.rs
@@ -144,8 +144,7 @@ pub(crate) fn is_asset_path(name: &str) -> bool {
 }
 
 pub(crate) fn escape_string(s: String) -> String {
-    s.replace('\\', "\\\\")
-        .replace('\"', "\\\"")
+    s.replace('\"', "\\\"")
         .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('\t', "\\t")

--- a/fastn-js/src/utils.rs
+++ b/fastn-js/src/utils.rs
@@ -142,3 +142,12 @@ pub(crate) fn ends_with_exact_suffix(name: &str, separator: &str, suffix: &str) 
 pub(crate) fn is_asset_path(name: &str) -> bool {
     ends_with_exact_suffix(name, "/", "assets#files")
 }
+
+pub(crate) fn escape_string(s: String) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+        .replace('\0', "\\0")
+}

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.111"
+version = "0.4.112"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
While making a string during the process outputting js code, we only
escape newline and " (quote) chars. The js output is malformed when
there are \r.

We fix this by escaping some known chars including \r and \t (tab)
