### PR TITLE
Do not overrid http request target url with current_request properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "fastn"
-version = "0.4.112"
+version = "0.4.113"
 dependencies = [
  "actix-web",
  "camino",

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # `fastn` Change Log
 
+## 17 September 2025
+
+### fastn: 0.4.113
+
+- fix: Do not override query params of http processor's target url. PR #2209.
+
 ## 20 August 2025
 
 ### fastn: 0.4.112

--- a/fastn-core/src/library2022/processor/http.rs
+++ b/fastn-core/src/library2022/processor/http.rs
@@ -112,17 +112,14 @@ pub async fn process(
         req_config.config.package.clone()
     };
 
-    let (mut url, mountpoint, mut conf) = {
-        let (mut url, mountpoint, conf) =
-            fastn_core::config::utils::get_clean_url(&package, req_config, url.as_str())
-                .await
-                .map_err(|e| ftd::interpreter::Error::ParseError {
-                    message: format!("invalid url: {e:?}"),
-                    doc_id: doc.name.to_string(),
-                    line_number,
-                })?;
-        (url, mountpoint, conf)
-    };
+    let (mut url, mountpoint, mut conf) =
+        fastn_core::config::utils::get_clean_url(&package, req_config, url.as_str())
+            .await
+            .map_err(|e| ftd::interpreter::Error::ParseError {
+                message: format!("invalid url: {e:?}"),
+                doc_id: doc.name.to_string(),
+                line_number,
+            })?;
 
     tracing::info!(?url);
 

--- a/fastn-core/src/library2022/processor/http.rs
+++ b/fastn-core/src/library2022/processor/http.rs
@@ -121,11 +121,10 @@ pub async fn process(
                     doc_id: doc.name.to_string(),
                     line_number,
                 })?;
-        if !req_config.request.query_string().is_empty() {
-            url.set_query(Some(req_config.request.query_string()));
-        }
         (url, mountpoint, conf)
     };
+
+    tracing::info!(?url);
 
     let mut body = serde_json::Map::new();
     for header in headers.0 {

--- a/fastn/Cargo.toml
+++ b/fastn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastn"
-version = "0.4.112"
+version = "0.4.113"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -20,10 +20,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
-        "path": "/nix/store/zi50l9z7jjfv92nr6m12czq5qcrrmqdr-source",
-        "type": "path"
+        "lastModified": 1757746433,
+        "narHash": "sha256-fEvTiU4s9lWgW7mYEU/1QUPirgkn+odUBTaindgiziY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6d7ec06d6868ac6d94c371458fc2391ded9ff13d",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
@@ -44,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750991972,
-        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
+        "lastModified": 1757903816,
+        "narHash": "sha256-bVi6V/HZtUedmLPM5OP/tYhwi6G7FIyFH6+/EFb7qGo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
+        "rev": "11a559c0baf1019bde7bbf0363a22db978be4363",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
             openssl.dev
             diesel-cli
             rust-analyzer-unwrapped
-          ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Foundation ];
+            git
+          ] ++ lib.optionals stdenv.isDarwin [  ];
 
           shellHook = ''
             export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
The http processor `url` should not be manipulated by `current_request`
properties. If the user code wants to inherit something from current
request then they should explicitly add that property to the `url` (or
custom headers) while using the `http` processor.

This is an immediate fix for the following situation:

An .ftd file for url /experts/?payment=true has a call to http processor
like this:

```ftd
-- expert-detail-response res:
$processor$: pr.http
method: GET
url: /experts/?id=120
```

The http processor overrides the `id` query param with the current
request query params (payment=true), which is clearly wrong! The right
thing is to not manipulate the user provided `url` at all. If the user
want to append `payment=true` then they will have to change their ftd
code so that the `url` becomes "/experts/?id=120&payment=true".